### PR TITLE
Cache test data in gh actions workflow

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -37,7 +37,13 @@ jobs:
           python-version: "3.10"
 
     steps:
-      # Run tests
+      - name: Cache Test Data
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.movement/*
+          key: cached-test-data
+          enableCrossOsArchive: true
       - uses: neuroinformatics-unit/actions/test@v2
         with:
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
The tests currently take a somewhat long time to run on CI. It's partly due to the test data being downloaded from GIN every time the tests start. This is not an issue for local tests because `pooch` caches the data locally.

This PR adds caching of the test data during GitHub actions, which allows its reuse across the test matrix (avoiding repeated downloads). I expect this to speed up CI.

The action is copied from brainglobe: https://github.com/brainglobe/brainglobe-napari/blob/8598161e49f995ebd0e765de3ef4c65f001dfe8f/.github/workflows/test_and_deploy.yml#L57-L63