### PR TITLE
Deprecate support for python 3.8

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         # Run all supported Python versions on linux
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         os: [ubuntu-latest]
         # Include one windows and macOS run
         include:

--- a/movement/datasets.py
+++ b/movement/datasets.py
@@ -6,7 +6,6 @@ and are downloaded to the user's local machine the first time they are used.
 """
 
 from pathlib import Path
-from typing import List
 
 import pooch
 
@@ -41,7 +40,7 @@ POSE_DATA = pooch.create(
 )
 
 
-def list_pose_data() -> List[str]:
+def list_pose_data() -> list[str]:
     """Find available sample pose data in the *movement* data repository.
 
     Returns

--- a/movement/io/validators.py
+++ b/movement/io/validators.py
@@ -1,6 +1,7 @@
 import os
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable, List, Literal, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 import h5py
 import numpy as np
@@ -44,7 +45,7 @@ class ValidFile:
     expected_permission: Literal["r", "w", "rw"] = field(
         default="r", validator=validators.in_(["r", "w", "rw"]), kw_only=True
     )
-    expected_suffix: List[str] = field(factory=list, kw_only=True)
+    expected_suffix: list[str] = field(factory=list, kw_only=True)
 
     @path.validator
     def path_is_not_dir(self, attribute, value):
@@ -121,7 +122,7 @@ class ValidHDF5:
     """
 
     path: Path = field(validator=validators.instance_of(Path))
-    expected_datasets: List[str] = field(factory=list, kw_only=True)
+    expected_datasets: list[str] = field(factory=list, kw_only=True)
 
     @path.validator
     def file_is_h5(self, attribute, value):
@@ -192,7 +193,7 @@ class ValidPosesCSV:
                     )
 
 
-def _list_of_str(value: Union[str, Iterable[Any]]) -> List[str]:
+def _list_of_str(value: Union[str, Iterable[Any]]) -> list[str]:
     """Try to coerce the value into a list of strings.
     Otherwise, raise a ValueError."""
     if isinstance(value, str):
@@ -229,7 +230,7 @@ def _set_fps_to_none_if_invalid(fps: Optional[float]) -> Optional[float]:
 
 
 def _validate_list_length(
-    attribute: str, value: Optional[List], expected_length: int
+    attribute: str, value: Optional[list], expected_length: int
 ):
     """Raise a ValueError if the list does not have the expected length."""
     if (value is not None) and (len(value) != expected_length):
@@ -270,11 +271,11 @@ class ValidPoseTracks:
     # Define class attributes
     tracks_array: np.ndarray = field()
     scores_array: Optional[np.ndarray] = field(default=None)
-    individual_names: Optional[List[str]] = field(
+    individual_names: Optional[list[str]] = field(
         default=None,
         converter=converters.optional(_list_of_str),
     )
-    keypoint_names: Optional[List[str]] = field(
+    keypoint_names: Optional[list[str]] = field(
         default=None,
         converter=converters.optional(_list_of_str),
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "Analysis of body movement"
 readme = "README.md"
-requires-python = ">=3.8.0"
+requires-python = ">=3.9.0"
 dynamic = ["version"]
 
 license = {text = "BSD-3-Clause"}
@@ -26,7 +26,6 @@ classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -77,7 +76,7 @@ exclude = ["tests", "docs*"]
 addopts = "--cov=movement"
 
 [tool.black]
-target-version = ['py38', 'py39', 'py310', 'py311']
+target-version = ['py39', 'py310', 'py311']
 skip-string-normalization = false
 line-length = 79
 
@@ -123,7 +122,6 @@ isolated_build = True
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ select = ["I", "E", "F"]
 fix = true
 
 [tool.cibuildwheel]
-build = "cp38-* cp39-* cp310-* cp311-*"
+build = "cp39-* cp310-* cp311-*"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]
@@ -117,7 +117,7 @@ archs = ["x86_64", "arm64"]
 legacy_tox_ini = """
 [tox]
 requires = tox-conda
-envlist = py{38,39,310,311}
+envlist = py{39,310,311}
 isolated_build = True
 
 [gh-actions]


### PR DESCRIPTION
[Python 3.9](https://docs.python.org/3/whatsnew/3.9.html) introduced type hinting generics in standard collections via [PEP 585](https://peps.python.org/pep-0585/).

Replaced typing.list to list for datasets.py and validators.py. 
Also changed typing.collections to collections.abc.Iterable for validators.py. 

Did not remove typing.Optional, typing.Union, typing.Any, typing.Literal and typing.ClassVar as these were not mentioned to be deprecated on https://peps.python.org/pep-0585/. 

Removed support for Python 3.8 from the following files:
- pyproject.toml
- .github/workflows/test_and_deploy.yml
