### PR TITLE
Changed documentation website URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,7 @@ The version number is automatically determined from the latest tag on the _main_
 ## Contributing documentation
 
 The documentation is hosted via [GitHub pages](https://pages.github.com/) at
-[neuroinformatics-unit.github.io/movement](https://neuroinformatics-unit.github.io/movement/).
+[movement.neuroinformatics.dev](https://movement.neuroinformatics.dev).
 Its source files are located in the `docs` folder of this repository.
 They are written in either [reStructuredText](https://docutils.sourceforge.io/rst.html) or
 [markdown](https://myst-parser.readthedocs.io/en/stable/syntax/typography.html).
@@ -185,7 +185,7 @@ my_new_file
 ### Updating the API reference
 If your PR introduces new public-facing functions, classes, or methods,
 make sure to add them to the `docs/source/api_index.rst` page, so that they are
-included in the [API reference](https://neuroinformatics-unit.github.io/movement/api_index.html),
+included in the [API reference](https://movement.neuroinformatics.dev/api_index.html),
 e.g.:
 
 ```rst
@@ -204,7 +204,7 @@ that follow the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html
 
 ### Updating the examples
 We use [sphinx-gallery](https://sphinx-gallery.github.io/stable/index.html)
-to create the [examples](https://neuroinformatics-unit.github.io/movement/auto_examples/index.html).
+to create the [examples](https://movement.neuroinformatics.dev/auto_examples/index.html).
 To add new examples, you will need to create a new `.py` file in `examples/`.
 The file should be structured as specified in the relevant
 [sphinx-gallery documentation](https://sphinx-gallery.github.io/stable/syntax.html).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Kinematic analysis of animal 🐝 🦀 🐀 🐒 body movements for neuroscience and ethology research 🔬.
 
-- Read the [documentation](https://neuroinformatics-unit.github.io/movement/) for more information.
+- Read the [documentation](https://movement.neuroinformatics.dev) for more information.
 - If you wish to contribute, please read the [contributing guide](./CONTRIBUTING.md).
 - Join us on [zulip](https://neuroinformatics.zulipchat.com/#narrow/stream/406001-Movement/topic/Welcome!) to chat with the team. We welcome your questions and suggestions.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -125,7 +125,7 @@ html_theme_options = {
 # The default is the URL of the GitHub pages
 # https://www.sphinx-doc.org/en/master/usage/extensions/githubpages.html
 github_user = "neuroinformatics-unit"
-html_baseurl = "https://neuroinformatics-unit.github.io/movement/"
+html_baseurl = "https://movement.neuroinformatics.dev"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -36,7 +36,7 @@ pip install --upgrade movement
 
 :::{tab-item} Developers
 To get the latest development version, clone the
-[GitHub repository](https://neuroinformatics-unit.github.io/movement/)
+[GitHub repository](https://github.com/neuroinformatics-unit/movement/)
 and then run from inside the repository:
 
 ```sh


### PR DESCRIPTION
@adamltyson I think it's time to switch the docs website from the default gh-pages URL to movement.neuroinformatics.dev
Any easy way to have the [old link](https://neuroinformatics-unit.github.io/movement/) redirect to the new one (if it's complicated, nevermind)?