### PR TITLE
Updated project URLs in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,11 @@ classifiers = [
 ]
 
 [project.urls]
-homepage = "https://github.com/neuroinformatics-unit/movement"
-bug_tracker = "https://github.com/neuroinformatics-unit/movement/issues"
-documentation = "https://github.com/neuroinformatics-unit/movement"
-source_code = "https://github.com/neuroinformatics-unit/movement"
-user_support = "https://github.com/neuroinformatics-unit/movement/issues"
+"Homepage" = "https://github.com/neuroinformatics-unit/movement"
+"Bug Tracker" = "https://github.com/neuroinformatics-unit/movement/issues"
+"Documentation" = "https://movement.neuroinformatics.dev/"
+"Source Code" = "https://github.com/neuroinformatics-unit/movement"
+"User Support" = "https://neuroinformatics.zulipchat.com/#narrow/stream/406001-Movement"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
This affects the URLs appearing on PyPI.

I changed the documentation URL to https://movement.neuroinformatics.dev and the user support URL to the appropriate [zulip stream](https://neuroinformatics.zulipchat.com/#narrow/stream/406001-Movement).

I also fixed the formatting of the names of those URLs, e.g. "Bug Tracker" instead of "bug_tracker", which should improve their readability on PyPI.