### PR TITLE
Refactor configure_logging

### DIFF
--- a/movement/logging.py
+++ b/movement/logging.py
@@ -31,34 +31,36 @@ def configure_logging(
 
     # Set the log directory and file path
     log_directory.mkdir(parents=True, exist_ok=True)
-    log_file = log_directory / f"{logger_name}.log"
+    log_file = (log_directory / f"{logger_name}.log").as_posix()
 
-    # If a logger with the given name is already configured
-    if logger_name in logging.root.manager.loggerDict:
-        logger = logging.getLogger(logger_name)
-        handlers = logger.handlers[:]
-        # If the log file path has changed
-        if log_file.as_posix() != handlers[0].baseFilename:  # type: ignore
-            # remove the handlers to allow for reconfiguration
-            for handler in handlers:
-                logger.removeHandler(handler)
-        else:
-            # otherwise, do nothing
-            return
+    # Check if logger with the given name is already configured
+    logger_configured = logger_name in logging.root.manager.loggerDict
 
     logger = logging.getLogger(logger_name)
-    logger.setLevel(log_level)
 
-    # Create a rotating file handler
-    max_log_size = 5 * 1024 * 1024  # 5 MB
-    handler = RotatingFileHandler(log_file, maxBytes=max_log_size)
+    # Logger needs to be (re)configured if unconfigured or
+    # if configured but the log file path has changed
+    configure_logger = not logger_configured or (
+        logger_configured
+        and log_file != logger.handlers[0].baseFilename  # type: ignore
+    )
+    if configure_logger:
+        if logger_configured:
+            # remove the handlers to allow for reconfiguration
+            logger.handlers.clear()
 
-    # Create a formatter and set it to the handler
-    formatter = logging.Formatter(FORMAT)
-    handler.setFormatter(formatter)
+        logger.setLevel(log_level)
 
-    # Add the handler to the logger
-    logger.addHandler(handler)
+        # Create a rotating file handler
+        max_log_size = 5 * 1024 * 1024  # 5 MB
+        handler = RotatingFileHandler(log_file, maxBytes=max_log_size)
+
+        # Create a formatter and set it to the handler
+        formatter = logging.Formatter(FORMAT)
+        handler.setFormatter(formatter)
+
+        # Add the handler to the logger
+        logger.addHandler(handler)
 
 
 def log_error(error, message: str, logger_name: str = "movement"):

--- a/movement/logging.py
+++ b/movement/logging.py
@@ -40,10 +40,11 @@ def configure_logging(
 
     # Logger needs to be (re)configured if unconfigured or
     # if configured but the log file path has changed
-    configure_logger = not logger_configured or (
-        logger_configured
-        and log_file != logger.handlers[0].baseFilename  # type: ignore
+    configure_logger = (
+        not logger_configured
+        or log_file != logger.handlers[0].baseFilename  # type: ignore
     )
+
     if configure_logger:
         if logger_configured:
             # remove the handlers to allow for reconfiguration


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**What does this PR do?**
There are 3 possible cases in ``logging.configure_logging()``:
  - logger with the given name is not configured
  - logger with the given name is configured but path has not changed
  - logger  with the given name is configured and path has changed

We only want to (re)configure logging in the first and third cases.
This PR removes the need for [ ``else: return``](https://github.com/neuroinformatics-unit/movement/blob/7dec1532a415b8d9b3885a5c862cfc3b86823e0f/movement/logging.py#L45-L47) for the second case, while taking into account all three cases. It also avoids[ mutating ``handlers`` while iterating through it](https://github.com/neuroinformatics-unit/movement/blob/7dec1532a415b8d9b3885a5c862cfc3b86823e0f/movement/logging.py#L43-L44), by calling ``.clear()`` 

## How has this PR been tested?
Code tested locally

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
