### PR TITLE
SLEAP read user labels

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -139,6 +139,7 @@ html_baseurl = "https://movement.neuroinformatics.dev"
 linkcheck_anchors_ignore_for_url = [
     "https://gin.g-node.org/G-Node/Info/wiki/",
     "https://neuroinformatics.zulipchat.com/",
+    "https://github.com/talmolab/sleap/blob/v1.3.3/sleap/info/write_tracking_h5.py",
 ]
 
 myst_url_schemes = {

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -111,15 +111,19 @@ def from_sleap_file(
 
     You can also directly load the ".slp" file. However, if the file contains
     multiple videos, only the pose tracks from the first video will be loaded.
+    If the file contains a mix of user-labelled and predicted instances, user
+    labels are prioritised over predicted instances to mirror SLEAP's approach
+    when exporting ".h5" analysis files [2]_.
 
     *movement* expects the tracks to be assigned and proofread before loading
     them, meaning each track is interpreted as a single individual/animal.
-    Follow the SLEAP guide for tracking and proofreading [2]_.
+    Follow the SLEAP guide for tracking and proofreading [3]_.
 
     References
     ----------
     .. [1] https://sleap.ai/tutorials/analysis.html
-    .. [2] https://sleap.ai/guides/proofreading.html
+    .. [2] https://github.com/talmolab/sleap/blob/v1.3.3/sleap/info/write_tracking_h5.py#L129-L150
+    .. [3] https://sleap.ai/guides/proofreading.html
 
     Examples
     --------

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -389,13 +389,13 @@ def _sleap_user_labels_to_numpy(labels: Labels) -> np.ndarray:
 def _parse_dlc_csv_to_df(file_path: Path) -> pd.DataFrame:
     """If poses are loaded from a DeepLabCut .csv file, the DataFrame
     lacks the multi-index columns that are present in the .h5 file. This
-    function parses the csv file to a pandas DataFrame with multi-index
+    function parses the .csv file to a pandas DataFrame with multi-index
     columns, i.e. the same format as in the .h5 file.
 
     Parameters
     ----------
     file_path : pathlib.Path
-        Path to the DeepLabCut-style CSV file.
+        Path to the DeepLabCut-style .csv file.
 
     Returns
     -------

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -17,7 +17,7 @@ from movement.io.validators import (
     ValidPosesCSV,
     ValidPoseTracks,
 )
-from movement.logging import log_error
+from movement.logging import log_error, log_warning
 
 logger = logging.getLogger(__name__)
 
@@ -255,6 +255,11 @@ def _load_from_sleap_analysis_file(
                 # Assume user-labelled and assign 1.0 as score
                 mask = np.isnan(tracks[:, :, :, 1])
                 scores = np.where(mask, scores, 1.0)
+                log_warning(
+                    f"Could not find confidence scores in {file.path}. "
+                    "Assuming pose tracks are user-labelled and "
+                    "assigning fixed confidence scores of 1.0."
+                )
         return ValidPoseTracks(
             tracks_array=tracks.astype(np.float32),
             scores_array=scores.astype(np.float32),
@@ -290,6 +295,11 @@ def _load_from_sleap_labels_file(
 
     if _sleap_labels_contains_user_labels_only(labels):
         tracks_with_scores = _sleap_user_labels_to_numpy(labels)
+        log_warning(
+            f"Could not find PredictedInstances in {file.path}. "
+            "Assuming pose tracks are user-labelled and "
+            "assigning fixed confidence scores of 1.0."
+        )
     else:
         tracks_with_scores = labels.numpy(
             untracked=False, return_confidence=True

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -110,11 +110,14 @@ def from_sleap_file(
     "Export Analysis HDF5…" from the "File" menu) [1]_. This is the
     preferred format for loading pose tracks from SLEAP into *movement*.
 
-    You can also try directly loading the ".slp" file, but this feature is
-    experimental and does not work in all cases. If the ".slp" file contains
-    both user-labeled and predicted instances, only the predicted ones will be
-    loaded. If there are multiple videos in the file, only the first one will
-    be used.
+    You can also try directly loading the ".slp" file, but this feature
+    does not work in all cases. If the ".slp" file contains only predicted
+    instances, they will be imported alongside their point-wise confidence
+    scores. Alternatively, if it contains only user-labelled instances, they
+    will be loaded and assigned fixed point-wise confidence scores of 1.0.
+    Lastly, if a mix of both user-labelled and predicted instances are present,
+    only the predicted ones will be loaded.
+    If there are multiple videos in the file, only the first one will be used.
 
     *movement* expects the tracks to be assigned and proofread before loading
     them, meaning each track is interpreted as a single individual/animal.
@@ -232,9 +235,9 @@ def _load_from_sleap_analysis_file(
 
     Notes
     -----
-    If the point-level prediction scores (i.e. confidence) in the SLEAP
+    If the point-wise confidence scores in the SLEAP
     analysis file are all NaNs, this function assumes that the pose
-    tracks are user-labeled, and will assign a fixed score of 1.0.
+    tracks are user-labelled, and will assign a fixed score of 1.0.
     """
 
     file = ValidHDF5(file_path, expected_datasets=["tracks"])
@@ -302,7 +305,7 @@ def _load_from_sleap_labels_file(
 
 
 def _sleap_labels_contains_user_labels_only(labels: Labels) -> bool:
-    """Check if a SLEAP `Labels` object contains only user-labeled instances.
+    """Check if a SLEAP `Labels` object contains only user-labelled instances.
 
     Parameters
     ----------
@@ -313,7 +316,7 @@ def _sleap_labels_contains_user_labels_only(labels: Labels) -> bool:
     -------
     bool
         A boolean value indicating whether the labels contain only
-        user-labeled instances.
+        user-labelled instances.
     """
     all_instances = [
         instance for lf in labels.labeled_frames for instance in lf.instances
@@ -326,7 +329,7 @@ def _sleap_labels_contains_user_labels_only(labels: Labels) -> bool:
 
 def _sleap_user_labels_to_numpy(labels: Labels) -> np.ndarray:
     """Convert a SLEAP `Labels` object to a NumPy array containing
-    pose tracks with point scores (i.e. confidence) set as 1.0.
+    pose tracks with point-wise confidence scores set as 1.0.
 
     Parameters
     ----------
@@ -342,15 +345,15 @@ def _sleap_user_labels_to_numpy(labels: Labels) -> np.ndarray:
     -----
     This function only considers SLEAP instances in the first
     video of the SLEAP `Labels` object. It is primarily meant
-    to be used with `Labels` containing only user-labeled instances.
+    to be used with `Labels` containing only user-labelled instances.
     If `Labels` contains predicted instances only, this function
-    will overwrite all point scores to 1.0. If `Labels` contains
-    both user-labeled and predicted instances, the returned NumPy
-    array will contain the last occurrence of each tracked instance
+    will overwrite all point-wise confidence scores to 1.0. If `Labels`
+    contains both user-labelled and predicted instances, the returned
+    NumPy array will contain the last occurrence of each tracked instance
     in each frame.
 
     This function is adapted from `Labels.numpy()` from the
-    `sleap_io` package [1]_ to allow user-labeled instances.
+    `sleap_io` package [1]_ to allow user-labelled instances.
 
     References
     ----------

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -340,17 +340,17 @@ def _sleap_user_labels_to_numpy(labels: Labels) -> np.ndarray:
 
     Notes
     -----
-        This function only considers SLEAP instances in the first
-        video of the SLEAP `Labels` object. It is primarily meant
-        to be used with `Labels` containing only user-labeled instances.
-        If `Labels` contains predicted instances only, this function
-        will overwrite all point scores to 1.0. If `Labels` contains
-        both user-labeled and predicted instances, the returned NumPy
-        array will contain the last occurrence of each tracked instance
-        in each frame.
+    This function only considers SLEAP instances in the first
+    video of the SLEAP `Labels` object. It is primarily meant
+    to be used with `Labels` containing only user-labeled instances.
+    If `Labels` contains predicted instances only, this function
+    will overwrite all point scores to 1.0. If `Labels` contains
+    both user-labeled and predicted instances, the returned NumPy
+    array will contain the last occurrence of each tracked instance
+    in each frame.
 
-        This function is adapted from `Labels.numpy()` from the
-        `sleap_io` package [1]_ to allow user-labeled instances.
+    This function is adapted from `Labels.numpy()` from the
+    `sleap_io` package [1]_ to allow user-labeled instances.
 
     References
     ----------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ def setup_logging(tmp_path):
 @pytest.fixture
 def unreadable_file(tmp_path):
     """Return a dictionary containing the file path and
-    expected permission for an unreadable h5 file."""
+    expected permission for an unreadable .h5 file."""
     file_path = tmp_path / "unreadable.h5"
     with open(file_path, "w") as f:
         f.write("unreadable data")
@@ -61,7 +61,7 @@ def unreadable_file(tmp_path):
 @pytest.fixture
 def unwriteable_file(tmp_path):
     """Return a dictionary containing the file path and
-    expected permission for an unwriteable h5 file."""
+    expected permission for an unwriteable .h5 file."""
     unwriteable_dir = tmp_path / "no_write"
     unwriteable_dir.mkdir()
     os.chmod(unwriteable_dir, not stat.S_IWUSR)
@@ -115,7 +115,7 @@ def directory(tmp_path):
 @pytest.fixture
 def h5_file_no_dataframe(tmp_path):
     """Return a dictionary containing the file path and
-    expected datasets for an h5 file with no dataframe."""
+    expected datasets for a .h5 file with no dataframe."""
     file_path = tmp_path / "no_dataframe.h5"
     with h5py.File(file_path, "w") as f:
         f.create_dataset("data_in_list", data=[1, 2, 3])
@@ -143,7 +143,7 @@ def fake_h5_file(tmp_path):
 
 @pytest.fixture
 def invalid_single_animal_csv_file(tmp_path):
-    """Return the file path for a fake single-animal csv file."""
+    """Return the file path for a fake single-animal .csv file."""
     file_path = tmp_path / "fake_single_animal.csv"
     with open(file_path, "w") as f:
         f.write("scorer,columns\nsome,columns\ncoords,columns\n")
@@ -153,7 +153,7 @@ def invalid_single_animal_csv_file(tmp_path):
 
 @pytest.fixture
 def invalid_multi_animal_csv_file(tmp_path):
-    """Return the file path for a fake multi-animal csv file."""
+    """Return the file path for a fake multi-animal .csv file."""
     file_path = tmp_path / "fake_multi_animal.csv"
     with open(file_path, "w") as f:
         f.write(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,7 +101,7 @@ def nonexistent_file(tmp_path):
 
 
 @pytest.fixture
-def directory(tmp_path):  # used in save_poses, validators
+def directory(tmp_path):
     """Return a dictionary containing the file path and
     expected permission for a directory."""
     file_path = tmp_path / "directory"
@@ -126,7 +126,7 @@ def h5_file_no_dataframe(tmp_path):
 
 
 @pytest.fixture
-def fake_h5_file(tmp_path):  # used in save_poses, validators
+def fake_h5_file(tmp_path):
     """Return a dictionary containing the file path,
     expected exception, and expected datasets for
     a file with .h5 extension that is not in HDF5 format.
@@ -186,7 +186,7 @@ def sleap_file(request):
 
 @pytest.fixture
 def valid_tracks_array():
-    """Return a function that generate different kinds
+    """Return a function that generates different kinds
     of valid tracks array."""
 
     def _valid_tracks_array(array_type):

--- a/tests/test_integration/test_io.py
+++ b/tests/test_integration/test_io.py
@@ -1,25 +1,12 @@
 import numpy as np
 import pytest
 import xarray as xr
-from pytest import POSE_DATA
 
 from movement.io import load_poses, save_poses
 
 
 class TestPosesIO:
     """Test the IO functionalities of the PoseTracks class."""
-
-    @pytest.fixture(
-        params=[
-            "SLEAP_single-mouse_EPM.analysis.h5",
-            "SLEAP_single-mouse_EPM.predictions.slp",
-            "SLEAP_three-mice_Aeon_proofread.analysis.h5",
-            "SLEAP_three-mice_Aeon_proofread.predictions.slp",
-        ]
-    )
-    def sleap_file(self, request):
-        """Return the file path for a SLEAP .h5 or .slp file."""
-        return POSE_DATA.get(request.param)
 
     @pytest.fixture(params=["dlc.h5", "dlc.csv"])
     def dlc_output_file(self, request, tmp_path):

--- a/tests/test_integration/test_io.py
+++ b/tests/test_integration/test_io.py
@@ -19,7 +19,7 @@ class TestPosesIO:
     )
     def sleap_file(self, request):
         """Return the file path for a SLEAP .h5 or .slp file."""
-        return request.param
+        return POSE_DATA.get(request.param)
 
     @pytest.fixture(params=["dlc.h5", "dlc.csv"])
     def dlc_output_file(self, request, tmp_path):
@@ -44,7 +44,7 @@ class TestPosesIO:
         """Test that pose tracks loaded from SLEAP .slp and .h5 files,
         when converted to DLC .h5 and .csv files and re-loaded return
         the same Datasets."""
-        sleap_ds = load_poses.from_sleap_file(POSE_DATA.get(sleap_file))
+        sleap_ds = load_poses.from_sleap_file(sleap_file)
         save_poses.to_dlc_file(sleap_ds, dlc_output_file)
         dlc_ds = load_poses.from_dlc_file(dlc_output_file)
         xr.testing.assert_allclose(sleap_ds, dlc_ds)

--- a/tests/test_integration/test_io.py
+++ b/tests/test_integration/test_io.py
@@ -1,12 +1,30 @@
 import numpy as np
 import pytest
 import xarray as xr
+from pytest import POSE_DATA
 
 from movement.io import load_poses, save_poses
 
 
 class TestPosesIO:
     """Test the IO functionalities of the PoseTracks class."""
+
+    @pytest.fixture(
+        params=[
+            "SLEAP_single-mouse_EPM.analysis.h5",
+            "SLEAP_single-mouse_EPM.predictions.slp",
+            "SLEAP_three-mice_Aeon_proofread.analysis.h5",
+            "SLEAP_three-mice_Aeon_proofread.predictions.slp",
+        ]
+    )
+    def sleap_file(self, request):
+        """Return the file path for a SLEAP .h5 or .slp file."""
+        return request.param
+
+    @pytest.fixture(params=["dlc.h5", "dlc.csv"])
+    def dlc_output_file(self, request, tmp_path):
+        """Return the output file path for a DLC .h5 or .csv file."""
+        return tmp_path / request.param
 
     def test_load_and_save_to_dlc_df(self, dlc_style_df):
         """Test that loading pose tracks from a DLC-style DataFrame and
@@ -15,12 +33,18 @@ class TestPosesIO:
         df = save_poses.to_dlc_df(ds)
         np.testing.assert_allclose(df.values, dlc_style_df.values)
 
-    @pytest.mark.parametrize("file_name", ["dlc.h5", "dlc.csv"])
-    def test_save_and_load_dlc_file(
-        self, file_name, valid_pose_dataset, tmp_path
-    ):
+    def test_save_and_load_dlc_file(self, dlc_output_file, valid_pose_dataset):
         """Test that saving pose tracks to DLC .h5 and .csv files and then
         loading them back in returns the same Dataset."""
-        save_poses.to_dlc_file(valid_pose_dataset, tmp_path / file_name)
-        ds = load_poses.from_dlc_file(tmp_path / file_name)
+        save_poses.to_dlc_file(valid_pose_dataset, dlc_output_file)
+        ds = load_poses.from_dlc_file(dlc_output_file)
         xr.testing.assert_allclose(ds, valid_pose_dataset)
+
+    def test_convert_sleap_to_dlc_file(self, sleap_file, dlc_output_file):
+        """Test that pose tracks loaded from SLEAP .slp and .h5 files,
+        when converted to DLC .h5 and .csv files and re-loaded return
+        the same Datasets."""
+        sleap_ds = load_poses.from_sleap_file(POSE_DATA.get(sleap_file))
+        save_poses.to_dlc_file(sleap_ds, dlc_output_file)
+        dlc_ds = load_poses.from_dlc_file(dlc_output_file)
+        xr.testing.assert_allclose(sleap_ds, dlc_ds)

--- a/tests/test_unit/test_load_poses.py
+++ b/tests/test_unit/test_load_poses.py
@@ -2,31 +2,12 @@ import numpy as np
 import pytest
 import xarray as xr
 from pytest import POSE_DATA
-from sleap_io.io.slp import read_labels
 
 from movement.io import PosesAccessor, load_poses
 
 
 class TestLoadPoses:
     """Test suite for the load_poses module."""
-
-    @pytest.fixture(scope="module")
-    def sleap_user_labels(self):
-        """Return a SLEAP `Labels` object containing only
-        user-labelled instances.
-        """
-        slp_file = POSE_DATA.get(
-            "SLEAP_three-mice_Aeon_proofread.predictions.slp"
-        )
-        return read_labels(slp_file)
-
-    @pytest.fixture(scope="module")
-    def sleap_predicted_labels(self):
-        """Return a SLEAP `Labels` object containing only
-        predicted instances.
-        """
-        slp_file = POSE_DATA.get("SLEAP_single-mouse_EPM.predictions.slp")
-        return read_labels(slp_file)
 
     def assert_dataset(
         self, dataset, file_path=None, expected_source_software=None
@@ -78,6 +59,10 @@ class TestLoadPoses:
                 "SLEAP_three-mice_Aeon_proofread.analysis.h5",
                 "SLEAP_three-mice_Aeon_proofread.predictions.slp",
             ),
+            (
+                "SLEAP_three-mice_Aeon_mixed-labels.analysis.h5",
+                "SLEAP_three-mice_Aeon_mixed-labels.predictions.slp",
+            ),
         ],
     )
     def test_load_from_sleap_slp_file_or_h5_file_returns_same(
@@ -90,37 +75,6 @@ class TestLoadPoses:
         ds_from_slp = load_poses.from_sleap_file(slp_file_path)
         ds_from_h5 = load_poses.from_sleap_file(h5_file_path)
         xr.testing.assert_allclose(ds_from_h5, ds_from_slp)
-
-    @pytest.mark.parametrize(
-        "sleap_labels, expected",
-        [
-            ("sleap_user_labels", True),
-            ("sleap_predicted_labels", False),
-        ],
-    )
-    def test_sleap_labels_contains_user_labels_only(
-        self, sleap_labels, expected, request
-    ):
-        labels = request.getfixturevalue(sleap_labels)
-        assert (
-            load_poses._sleap_labels_contains_user_labels_only(labels)
-            == expected
-        )
-
-    @pytest.mark.parametrize(
-        "sleap_labels",
-        [
-            "sleap_user_labels",
-            "sleap_predicted_labels",
-        ],
-    )
-    def test_sleap_user_labels_to_numpy_confidence_equals_one(
-        self, sleap_labels, request
-    ):
-        labels = request.getfixturevalue(sleap_labels)
-        confidence = load_poses._sleap_user_labels_to_numpy(labels)[:, :, :, 2]
-        mask = np.isnan(confidence)
-        assert np.all(confidence[~mask] == 1)
 
     @pytest.mark.parametrize(
         "file_name",

--- a/tests/test_unit/test_load_poses.py
+++ b/tests/test_unit/test_load_poses.py
@@ -13,7 +13,7 @@ class TestLoadPoses:
     @pytest.fixture(scope="module")
     def sleap_user_labels(self):
         """Return a SLEAP `Labels` object containing only
-        user-labeled instances.
+        user-labelled instances.
         """
         slp_file = POSE_DATA.get(
             "SLEAP_three-mice_Aeon_proofread.predictions.slp"

--- a/tests/test_unit/test_save_poses.py
+++ b/tests/test_unit/test_save_poses.py
@@ -34,12 +34,12 @@ class TestSavePoses:
 
     @pytest.fixture
     def new_dlc_h5_file(self, tmp_path):
-        """Return the file path for a new DeepLabCut H5 file."""
+        """Return the file path for a new DeepLabCut .h5 file."""
         return tmp_path / "new_dlc_file.h5"
 
     @pytest.fixture
     def new_dlc_csv_file(self, tmp_path):
-        """Return the file path for a new DeepLabCut csv file."""
+        """Return the file path for a new DeepLabCut .csv file."""
         return tmp_path / "new_dlc_file.csv"
 
     @pytest.fixture

--- a/tests/test_unit/test_save_poses.py
+++ b/tests/test_unit/test_save_poses.py
@@ -63,6 +63,20 @@ class TestSavePoses:
                 ),
                 does_not_raise(),
             ),  # valid dataset
+            (
+                load_poses.from_sleap_file(
+                    POSE_DATA.get("SLEAP_single-mouse_EPM.analysis.h5")
+                ),
+                does_not_raise(),
+            ),  # valid dataset
+            (
+                load_poses.from_sleap_file(
+                    POSE_DATA.get(
+                        "SLEAP_three-mice_Aeon_proofread.predictions.slp"
+                    )
+                ),
+                does_not_raise(),
+            ),  # valid dataset
         ],
     )
     def test_to_dlc_df(self, ds, expected_exception):


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
This PR enables `load_poses._load_from_sleap_labels_file` to load pose tracks from a SLEAP .slp file consisting of either:
- user-labelled instances only,
- predicted instances only, or
- a mix of user-labelled and predicted instances

**What does this PR do?**
This PR adds:
- `load_poses._sleap_labels_to_numpy`, a function that converts SLEAP `Labels` to a NumPy array, adapted from [`Labels.numpy()`](https://github.com/talmolab/sleap-io/blob/9a04f7feac0397d7d7bed9fb79f205678cccf9f8/sleap_io/model/labels.py#L92-L178) from the [`sleap_io`](https://github.com/talmolab/sleap-io) package, but prioritises user-labelled instances over predicted instances when the .slp file consists of a mix of user-labelled and predicted instances. This behaviour mirrors [SLEAP's approach when exporting ".h5" analysis files](https://github.com/talmolab/sleap/blob/v1.3.3/sleap/info/write_tracking_h5.py#L129-L150), so that the loading a .slp file in _movement_ returns the same dataset as the corresponding SLEAP analysis .h5 file (i.e., exported from the same .slp file). 
- new test cases for 
  - checking that loading pairs of .h5 and .slp files returns the same dataset, regardless of whether the .slp file consists of user-labelled instances only, predicted instances only, or a mix of both
  - converting SLEAP datasets to DeepLabCut-style pandas DataFrames
  - converting SLEAP datasets to DeepLabCut file formats 

## References
This PR addresses #84 

## How has this PR been tested?
Tests have been written and run for the new functions added.

## Does this PR require an update to the documentation?
Docstrings have been updated accordingly.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
