### PR TITLE
Ability to save multi-animal pose tracks to single-animal files

### DIFF
--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -78,7 +78,7 @@ def _save_dlc_df(filepath: Path, df: pd.DataFrame) -> None:
 
 
 def to_dlc_df(
-    ds: xr.Dataset, split_individuals: bool = True
+    ds: xr.Dataset, split_individuals: bool = False
 ) -> Union[pd.DataFrame, dict[str, pd.DataFrame]]:
     """Convert an xarray dataset containing pose tracks into a single
     DeepLabCut-style pandas DataFrame or a dictionary of DataFrames
@@ -92,7 +92,7 @@ def to_dlc_df(
         If True, return a dictionary of pandas DataFrames per individual,
         with individual names as keys and DataFrames as values.
         If False, return a single pandas DataFrame for all individuals.
-        Default is True.
+        Default is False.
 
     Returns
     -------

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -12,16 +12,20 @@ from movement.logging import log_error
 logger = logging.getLogger(__name__)
 
 
-def _xarry_to_dlc_df(ds: xr.Dataset, columns: pd.MultiIndex) -> pd.DataFrame:
+def _xarray_to_dlc_df(ds: xr.Dataset, columns: pd.MultiIndex) -> pd.DataFrame:
     """Takes an xarray dataset and DLC-style multi-index columns and outputs
     a pandas dataframe.
 
     Parameters
     ----------
-    ds : xarray Dataset
+    ds : xarray.Dataset
         Dataset containing pose tracks, confidence scores, and metadata.
-    columns : pd.MultiIndex
+    columns : pandas.MultiIndex
         DLC-style multi-index columns
+
+    Returns
+    -------
+    pandas.DataFrame
     """
 
     # Concatenate the pose tracks and confidence scores into one array
@@ -44,37 +48,30 @@ def _xarry_to_dlc_df(ds: xr.Dataset, columns: pd.MultiIndex) -> pd.DataFrame:
     return df
 
 
-def _auto_split_individuals(ds: xr.Dataset):
+def _auto_split_individuals(ds: xr.Dataset) -> bool:
     """Returns True if there is only one individual in the dataset,
-    else returns False.
-
-    Parameters
-    ----------
-    ds : xarray Dataset
-        Dataset containing pose tracks, confidence scores, and metadata.
-    """
+    else returns False."""
 
     individuals = ds.coords["individuals"].data.tolist()
     return True if len(individuals) == 1 else False
 
 
-def _save_dlc_df(filepath: Path, dataframe: pd.DataFrame):
+def _save_dlc_df(filepath: Path, df: pd.DataFrame) -> None:
     """Given a filepath, will save the dataframe as either a .h5 or .csv.
 
     Parameters
     ----------
-    suffix : os.PathLike
-        Suffix of path provided.
-    filepath : os.PathLike
-        Path of where to save data.
-    suffix : pd.DataFrame
-        Pandas Dataframe to save to .csv or .h5.
+    filepath : pathlib.Path
+        Path of the file to save the dataframe to. The file extension
+        must be either .h5 (recommended) or .csv.
+    df : pandas.DataFrame
+        Pandas Dataframe to save
     """
 
     if filepath.suffix == ".csv":
-        dataframe.to_csv(filepath, sep=",")
+        df.to_csv(filepath, sep=",")
     elif filepath.suffix == ".h5":
-        dataframe.to_hdf(filepath, key="df_with_missing")
+        df.to_hdf(filepath, key="df_with_missing")
     # for invalid suffix
     else:
         raise log_error(ValueError, "Expected filepath to end in .csv or .h5.")
@@ -83,24 +80,23 @@ def _save_dlc_df(filepath: Path, dataframe: pd.DataFrame):
 def to_dlc_df(
     ds: xr.Dataset, split_individuals: bool = True
 ) -> Union[pd.DataFrame, dict[str, pd.DataFrame]]:
-    """Convert an xarray dataset containing pose tracks into a DeepLabCut-style
-    pandas DataFrame with multi-index columns for each individual or a
-    dictionary of DataFrames for each individual based on the
-    'split_individuals' argument.
+    """Convert an xarray dataset containing pose tracks into a single
+    DeepLabCut-style pandas DataFrame or a dictionary of DataFrames
+    per individual, depending on the 'split_individuals' argument.
 
     Parameters
     ----------
-    ds : xarray Dataset
+    ds : xarray.Dataset
         Dataset containing pose tracks, confidence scores, and metadata.
     split_individuals : bool, optional
-        If True, return a dictionary of pandas DataFrames, for each individual.
-        If False, return a single pandas DataFrame with multi-index columns
-        for all individuals.
+        If True, return a dictionary of pandas DataFrames per individual,
+        with individual names as keys and DataFrames as values.
+        If False, return a single pandas DataFrame for all individuals.
         Default is True.
 
     Returns
     -------
-    pandas DataFrame or dict
+    pandas.DataFrame or dict
         DeepLabCut-style pandas DataFrame or dictionary of DataFrames.
 
     Notes
@@ -109,6 +105,7 @@ def to_dlc_df(
     "scorer", "bodyparts", "coords" (if split_individuals is True),
     or "scorer", "individuals", "bodyparts", "coords"
     (if split_individuals is False).
+
     Regardless of the provenance of the points-wise confidence scores,
     they will be referred to as "likelihood", and stored in
     the "coords" level (as DeepLabCut expects).
@@ -116,7 +113,7 @@ def to_dlc_df(
     See Also
     --------
     to_dlc_file : Save the xarray dataset containing pose tracks directly
-        to a DeepLabCut-style ".h5" or ".csv" file.
+        to a DeepLabCut-style .h5 or .csv file.
     """
     if not isinstance(ds, xr.Dataset):
         raise log_error(
@@ -131,41 +128,34 @@ def to_dlc_df(
     individuals = ds.coords["individuals"].data.tolist()
 
     if split_individuals:
-        result = {}
+        df_dict = {}
 
         for individual in individuals:
-            # Select data for the current individual
             individual_data = ds.sel(individuals=individual)
 
-            # Create the DLC-style multi-index columns
             index_levels = ["scorer", "bodyparts", "coords"]
             columns = pd.MultiIndex.from_product(
                 [scorer, bodyparts, coords], names=index_levels
             )
 
-            # Uses the columns and data to make a df
-            df = _xarry_to_dlc_df(individual_data, columns)
-
-            """ Add the DataFrame to the result
-            dictionary with individual's name as key """
-            result[individual] = df
+            df = _xarray_to_dlc_df(individual_data, columns)
+            df_dict[individual] = df
 
         logger.info(
-            """Converted PoseTracks dataset to
-            DLC-style DataFrames for each individual."""
+            "Converted PoseTracks dataset to DeepLabCut-style DataFrames "
+            "per individual."
         )
-        return result
+        return df_dict
     else:
-        # Create the DLC-style multi-index columns
         index_levels = ["scorer", "individuals", "bodyparts", "coords"]
         columns = pd.MultiIndex.from_product(
             [scorer, individuals, bodyparts, coords], names=index_levels
         )
 
-        df = _xarry_to_dlc_df(ds, columns)
+        df_all = _xarray_to_dlc_df(ds, columns)
 
         logger.info("Converted PoseTracks dataset to DLC-style DataFrame.")
-        return df
+        return df_all
 
 
 def to_dlc_file(
@@ -174,34 +164,34 @@ def to_dlc_file(
     split_individuals: Union[bool, Literal["auto"]] = "auto",
 ) -> None:
     """Save the xarray dataset containing pose tracks to a
-    DeepLabCut-style ".h5" or ".csv" file.
+    DeepLabCut-style .h5 or .csv file.
 
     Parameters
     ----------
-    ds : xarray Dataset
+    ds : xarray.Dataset
         Dataset containing pose tracks, confidence scores, and metadata.
-    file_path : pathlib Path or str
+    file_path : pathlib.Path or str
         Path to the file to save the DLC poses to. The file extension
-        must be either ".h5" (recommended) or ".csv".
+        must be either .h5 (recommended) or .csv.
     split_individuals : bool, optional
-        If True, the file will be formatted as in a single-animal
-        DeepLabCut project: no "individuals" level, and each individual will be
-        saved in a separate file. The individual's name will be appended to the
-        file path, just before the file extension, i.e.
+        If True, each individual will be saved to a separate file,
+        formatted as in a single-animal DeepLabCut project - i.e. without
+        the "individuals" column level. The individual's name will be appended
+        to the file path, just before the file extension, i.e.
         "/path/to/filename_individual1.h5".
-        If False, the file will be formatted as in a multi-animal
-        DeepLabCut project: the columns will include the
-        "individuals" level and all individuals will be saved to the same file.
-        If "auto" the format will be determined based on the number of
+        If False, all individuals will be saved to the same file,
+        formatted as in a multi-animal DeepLabCut project - i.e. the columns
+        will include the "individuals" level. The file path will not be
+        modified.
+        If "auto" the argument's value be determined based on the number of
         individuals in the dataset: True if there is only one, and
         False if there are more than one. This is the default.
 
     See Also
     --------
-    to_dlc_df : Convert an xarray dataset containing pose tracks into a
-        DeepLabCut-style pandas DataFrame with multi-index columns
-        for each individual or a dictionary of DataFrames for each individual
-        based on the 'split_individuals' argument.
+    to_dlc_df : Convert an xarray dataset containing pose tracks into a single
+        DeepLabCut-style pandas DataFrame or a dictionary of DataFrames
+        per individual.
 
     Examples
     --------
@@ -227,29 +217,25 @@ def to_dlc_file(
     elif not isinstance(split_individuals, bool):
         raise log_error(
             ValueError,
-            f"Expected 'split_individuals' to be a boolean or 'auto', but got "
+            "Expected 'split_individuals' to be a boolean or 'auto', but got "
             f"{type(split_individuals)}.",
         )
 
     if split_individuals:
-        """If split_individuals is True then it will split the file into a
-        dictionary of pandas dataframes for each individual."""
-
+        # split the dataset into a dictionary of dataframes per individual
         df_dict = to_dlc_df(ds, split_individuals=True)
 
         for key, df in df_dict.items():
-            """Iterates over dictionary, the key is the name of the
-            individual and the value is the corresponding df."""
+            # the key is the individual's name
             filepath = f"{file.path.with_suffix('')}_{key}{file.path.suffix}"
-
             if isinstance(df, pd.DataFrame):
                 _save_dlc_df(Path(filepath), df)
-
-            logger.info(f"Saved PoseTracks dataset to {file.path}.")
+            logger.info(
+                f"Saved PoseTracks data for individual {key} to {file.path}."
+            )
     else:
-        """If split_individuals is False then it will save the file as
-        a dataframe with multi-index columns for each individual."""
-        dataframe = to_dlc_df(ds, split_individuals=False)
-        if isinstance(dataframe, pd.DataFrame):
-            _save_dlc_df(file.path, dataframe)
+        # convert the dataset to a single dataframe for all individuals
+        df_all = to_dlc_df(ds, split_individuals=False)
+        if isinstance(df_all, pd.DataFrame):
+            _save_dlc_df(file.path, df_all)
         logger.info(f"Saved PoseTracks dataset to {file.path}.")

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -77,7 +77,7 @@ def _save_dlc_df(filepath: Path, dataframe: pd.DataFrame):
         dataframe.to_hdf(filepath, key="df_with_missing")
     # for invalid suffix
     else:
-        log_error(ValueError, "Expected filepath to end in .csv or .h5.")
+        raise log_error(ValueError, "Expected filepath to end in .csv or .h5.")
 
 
 def to_dlc_df(
@@ -119,7 +119,7 @@ def to_dlc_df(
         to a DeepLabCut-style ".h5" or ".csv" file.
     """
     if not isinstance(ds, xr.Dataset):
-        log_error(
+        raise log_error(
             ValueError, f"Expected an xarray Dataset, but got {type(ds)}."
         )
 

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -7,11 +7,12 @@ import pandas as pd
 import xarray as xr
 
 from movement.io.validators import ValidFile
+from movement.logging import log_error
 
 logger = logging.getLogger(__name__)
 
 
-def _xarraytodf(ds: xr.Dataset, columns: pd.MultiIndex) -> pd.DataFrame:
+def _xarry_to_dlc_df(ds: xr.Dataset, columns: pd.MultiIndex) -> pd.DataFrame:
     """Takes an xarray dataset and DLC-style multi-index columns and outputs
     a pandas dataframe.
 
@@ -45,7 +46,7 @@ def _xarraytodf(ds: xr.Dataset, columns: pd.MultiIndex) -> pd.DataFrame:
 
 def _auto_split_individuals(ds: xr.Dataset):
     """Returns True if there is only one individual in the dataset,
-        else returns False.
+    else returns False.
 
     Parameters
     ----------
@@ -57,9 +58,8 @@ def _auto_split_individuals(ds: xr.Dataset):
     return True if len(individuals) == 1 else False
 
 
-def _savedataframe(suffix: str, filepath: Path, dataframe: pd.DataFrame):
-    """Given the suffix and filepath, will save the dataframe
-    as either a .h5 or .csv.
+def _save_dlc_df(filepath: Path, dataframe: pd.DataFrame):
+    """Given a filepath, will save the dataframe as either a .h5 or .csv.
 
     Parameters
     ----------
@@ -71,15 +71,13 @@ def _savedataframe(suffix: str, filepath: Path, dataframe: pd.DataFrame):
         Pandas Dataframe to save to .csv or .h5.
     """
 
-    if suffix == ".csv":
+    if filepath.suffix == ".csv":
         dataframe.to_csv(filepath, sep=",")
-    elif suffix == ".h5":
+    elif filepath.suffix == ".h5":
         dataframe.to_hdf(filepath, key="df_with_missing")
     # for invalid suffix
     else:
-        error_msg = "Expected filepath to end in .csv or .h5."
-        logger.error(error_msg)
-        raise ValueError(error_msg)
+        log_error(ValueError, "Expected filepath to end in .csv or .h5.")
 
 
 def to_dlc_df(
@@ -121,18 +119,18 @@ def to_dlc_df(
         to a DeepLabCut-style ".h5" or ".csv" file.
     """
     if not isinstance(ds, xr.Dataset):
-        error_msg = f"Expected an xarray Dataset, but got {type(ds)}. "
-        logger.error(error_msg)
-        raise ValueError(error_msg)
+        log_error(
+            ValueError, f"Expected an xarray Dataset, but got {type(ds)}."
+        )
 
     ds.poses.validate()  # validate the dataset
 
     scorer = ["movement"]
     bodyparts = ds.coords["keypoints"].data.tolist()
     coords = ds.coords["space"].data.tolist() + ["likelihood"]
+    individuals = ds.coords["individuals"].data.tolist()
 
     if split_individuals:
-        individuals = ds.coords["individuals"].data.tolist()
         result = {}
 
         for individual in individuals:
@@ -146,7 +144,7 @@ def to_dlc_df(
             )
 
             # Uses the columns and data to make a df
-            df = _xarraytodf(individual_data, columns)
+            df = _xarry_to_dlc_df(individual_data, columns)
 
             """ Add the DataFrame to the result
             dictionary with individual's name as key """
@@ -160,12 +158,11 @@ def to_dlc_df(
     else:
         # Create the DLC-style multi-index columns
         index_levels = ["scorer", "individuals", "bodyparts", "coords"]
-        individuals = ds.coords["individuals"].data.tolist()
         columns = pd.MultiIndex.from_product(
             [scorer, individuals, bodyparts, coords], names=index_levels
         )
 
-        df = _xarraytodf(ds, columns)
+        df = _xarry_to_dlc_df(ds, columns)
 
         logger.info("Converted PoseTracks dataset to DLC-style DataFrame.")
         return df
@@ -187,25 +184,24 @@ def to_dlc_file(
         Path to the file to save the DLC poses to. The file extension
         must be either ".h5" (recommended) or ".csv".
     split_individuals : bool, optional
-        Format of the DeepLabcut output file.
-        - If True, the file will be formatted as in a single-animal
+        If True, the file will be formatted as in a single-animal
         DeepLabCut project: no "individuals" level, and each individual will be
         saved in a separate file. The individual's name will be appended to the
         file path, just before the file extension, i.e.
         "/path/to/filename_individual1.h5".
-        - If False, the file will be formatted as in a multi-animal
+        If False, the file will be formatted as in a multi-animal
         DeepLabCut project: the columns will include the
         "individuals" level and all individuals will be saved to the same file.
-        - If "auto" the format will be determined based on the number of
+        If "auto" the format will be determined based on the number of
         individuals in the dataset: True if there is only one, and
         False if there are more than one. This is the default.
 
     See Also
     --------
     to_dlc_df : Convert an xarray dataset containing pose tracks into a
-    DeepLabCut-style pandas DataFrame with multi-index columns
-    for each individual or a dictionary of DataFrames for each individual
-    based on the 'split_individuals' argument.
+        DeepLabCut-style pandas DataFrame with multi-index columns
+        for each individual or a dictionary of DataFrames for each individual
+        based on the 'split_individuals' argument.
 
     Examples
     --------
@@ -229,33 +225,31 @@ def to_dlc_file(
         split_individuals = _auto_split_individuals(ds)
 
     elif not isinstance(split_individuals, bool):
-        error_msg = (
+        raise log_error(
+            ValueError,
             f"Expected 'split_individuals' to be a boolean or 'auto', but got "
-            f"{type(split_individuals)}."
+            f"{type(split_individuals)}.",
         )
-        logger.error(error_msg)
-        raise ValueError(error_msg)
 
-    """If split_individuals is True then it will split the file into a
-    dictionary of pandas dataframes for each individual."""
     if split_individuals:
+        """If split_individuals is True then it will split the file into a
+        dictionary of pandas dataframes for each individual."""
+
         df_dict = to_dlc_df(ds, split_individuals=True)
 
         for key, df in df_dict.items():
             """Iterates over dictionary, the key is the name of the
             individual and the value is the corresponding df."""
             filepath = f"{file.path.with_suffix('')}_{key}{file.path.suffix}"
-            filepath_posix = Path(filepath)
 
             if isinstance(df, pd.DataFrame):
-                _savedataframe(file.path.suffix, filepath_posix, df)
+                _save_dlc_df(Path(filepath), df)
 
-        logger.info(f"Saved PoseTracks dataset to {file.path}.")
-
-    """If split_individuals is False then it will save the file as a dataframe
-    with multi-index columns for each individual."""
-    if not split_individuals:
+            logger.info(f"Saved PoseTracks dataset to {file.path}.")
+    else:
+        """If split_individuals is False then it will save the file as
+        a dataframe with multi-index columns for each individual."""
         dataframe = to_dlc_df(ds, split_individuals=False)
         if isinstance(dataframe, pd.DataFrame):
-            _savedataframe(file.path.suffix, file.path, dataframe)
+            _save_dlc_df(file.path, dataframe)
         logger.info(f"Saved PoseTracks dataset to {file.path}.")

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -70,11 +70,8 @@ def _save_dlc_df(filepath: Path, df: pd.DataFrame) -> None:
 
     if filepath.suffix == ".csv":
         df.to_csv(filepath, sep=",")
-    elif filepath.suffix == ".h5":
+    else:  # at this point it can only be .h5 (because of validation)
         df.to_hdf(filepath, key="df_with_missing")
-    # for invalid suffix
-    else:
-        raise log_error(ValueError, "Expected filepath to end in .csv or .h5.")
 
 
 def to_dlc_df(

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Union
+from typing import Literal, Union
 
 import numpy as np
 import pandas as pd
@@ -11,39 +11,17 @@ from movement.io.validators import ValidFile
 logger = logging.getLogger(__name__)
 
 
-def to_dlc_df(ds: xr.Dataset) -> pd.DataFrame:
-    """Convert an xarray dataset containing pose tracks into a
-    DeepLabCut-style pandas DataFrame with multi-index columns.
+def _xarraytodf(ds: xr.Dataset, columns: pd.MultiIndex) -> pd.DataFrame:
+    """Takes an xarray dataset and DLC-style multi-index columns and outputs
+    a pandas dataframe.
 
     Parameters
     ----------
     ds : xarray Dataset
         Dataset containing pose tracks, confidence scores, and metadata.
-
-    Returns
-    -------
-    pandas DataFrame
-
-    Notes
-    -----
-    The DataFrame will have a multi-index column with the following levels:
-    "scorer", "individuals", "bodyparts", "coords" (even if there is only
-    one individual present). Regardless of the provenance of the
-    points-wise confidence scores, they will be referred to as
-    "likelihood", and stored in the "coords" level (as DeepLabCut expects).
-
-    See Also
-    --------
-    to_dlc_file : Save the xarray dataset containing pose tracks directly
-        to a DeepLabCut-style ".h5" or ".csv" file.
+    columns : pd.MultiIndex
+        DLC-style multi-index columns
     """
-
-    if not isinstance(ds, xr.Dataset):
-        error_msg = f"Expected an xarray Dataset, but got {type(ds)}. "
-        logger.error(error_msg)
-        raise ValueError(error_msg)
-
-    ds.poses.validate()  # validate the dataset
 
     # Concatenate the pose tracks and confidence scores into one array
     tracks_with_scores = np.concatenate(
@@ -54,29 +32,150 @@ def to_dlc_df(ds: xr.Dataset) -> pd.DataFrame:
         axis=-1,
     )
 
-    # Create the DLC-style multi-index columns
-    # Use the DLC terminology: scorer, individuals, bodyparts, coords
-    scorer = ["movement"]
-    individuals = ds.coords["individuals"].data.tolist()
-    bodyparts = ds.coords["keypoints"].data.tolist()
-    # The confidence scores in DLC are referred to as "likelihood"
-    coords = ds.coords["space"].data.tolist() + ["likelihood"]
-
-    index_levels = ["scorer", "individuals", "bodyparts", "coords"]
-    columns = pd.MultiIndex.from_product(
-        [scorer, individuals, bodyparts, coords], names=index_levels
-    )
+    # Create DataFrame with multi-index columns
     df = pd.DataFrame(
         data=tracks_with_scores.reshape(ds.dims["time"], -1),
         index=np.arange(ds.dims["time"], dtype=int),
         columns=columns,
         dtype=float,
     )
-    logger.info("Converted PoseTracks dataset to DLC-style DataFrame.")
+
     return df
 
 
-def to_dlc_file(ds: xr.Dataset, file_path: Union[str, Path]) -> None:
+def _auto_split_individuals(ds: xr.Dataset):
+    """Returns True if there is only one individual in the dataset,
+        else returns False.
+
+    Parameters
+    ----------
+    ds : xarray Dataset
+        Dataset containing pose tracks, confidence scores, and metadata.
+    """
+
+    individuals = ds.coords["individuals"].data.tolist()
+    return True if len(individuals) == 1 else False
+
+
+def _savedataframe(suffix: str, filepath: Path, dataframe: pd.DataFrame):
+    """Given the suffix and filepath, will save the dataframe
+    as either a .h5 or .csv.
+
+    Parameters
+    ----------
+    suffix : os.PathLike
+        Suffix of path provided.
+    filepath : os.PathLike
+        Path of where to save data.
+    suffix : pd.DataFrame
+        Pandas Dataframe to save to .csv or .h5.
+    """
+
+    if suffix == ".csv":
+        dataframe.to_csv(filepath, sep=",")
+    elif suffix == ".h5":
+        dataframe.to_hdf(filepath, key="df_with_missing")
+    # for invalid suffix
+    else:
+        error_msg = "Expected filepath to end in .csv or .h5."
+        logger.error(error_msg)
+        raise ValueError(error_msg)
+
+
+def to_dlc_df(
+    ds: xr.Dataset, split_individuals: bool = True
+) -> Union[pd.DataFrame, dict[str, pd.DataFrame]]:
+    """Convert an xarray dataset containing pose tracks into a DeepLabCut-style
+    pandas DataFrame with multi-index columns for each individual or a
+    dictionary of DataFrames for each individual based on the
+    'split_individuals' argument.
+
+    Parameters
+    ----------
+    ds : xarray Dataset
+        Dataset containing pose tracks, confidence scores, and metadata.
+    split_individuals : bool, optional
+        If True, return a dictionary of pandas DataFrames, for each individual.
+        If False, return a single pandas DataFrame with multi-index columns
+        for all individuals.
+        Default is True.
+
+    Returns
+    -------
+    pandas DataFrame or dict
+        DeepLabCut-style pandas DataFrame or dictionary of DataFrames.
+
+    Notes
+    -----
+    The DataFrame(s) will have a multi-index column with the following levels:
+    "scorer", "bodyparts", "coords" (if split_individuals is True),
+    or "scorer", "individuals", "bodyparts", "coords"
+    (if split_individuals is False).
+    Regardless of the provenance of the points-wise confidence scores,
+    they will be referred to as "likelihood", and stored in
+    the "coords" level (as DeepLabCut expects).
+
+    See Also
+    --------
+    to_dlc_file : Save the xarray dataset containing pose tracks directly
+        to a DeepLabCut-style ".h5" or ".csv" file.
+    """
+    if not isinstance(ds, xr.Dataset):
+        error_msg = f"Expected an xarray Dataset, but got {type(ds)}. "
+        logger.error(error_msg)
+        raise ValueError(error_msg)
+
+    ds.poses.validate()  # validate the dataset
+
+    scorer = ["movement"]
+    bodyparts = ds.coords["keypoints"].data.tolist()
+    coords = ds.coords["space"].data.tolist() + ["likelihood"]
+
+    if split_individuals:
+        individuals = ds.coords["individuals"].data.tolist()
+        result = {}
+
+        for individual in individuals:
+            # Select data for the current individual
+            individual_data = ds.sel(individuals=individual)
+
+            # Create the DLC-style multi-index columns
+            index_levels = ["scorer", "bodyparts", "coords"]
+            columns = pd.MultiIndex.from_product(
+                [scorer, bodyparts, coords], names=index_levels
+            )
+
+            # Uses the columns and data to make a df
+            df = _xarraytodf(individual_data, columns)
+
+            """ Add the DataFrame to the result
+            dictionary with individual's name as key """
+            result[individual] = df
+
+        logger.info(
+            """Converted PoseTracks dataset to
+            DLC-style DataFrames for each individual."""
+        )
+        return result
+    else:
+        # Create the DLC-style multi-index columns
+        index_levels = ["scorer", "individuals", "bodyparts", "coords"]
+        individuals = ds.coords["individuals"].data.tolist()
+        columns = pd.MultiIndex.from_product(
+            [scorer, individuals, bodyparts, coords], names=index_levels
+        )
+
+        df = _xarraytodf(ds, columns)
+
+        logger.info("Converted PoseTracks dataset to DLC-style DataFrame.")
+        return df
+
+
+def to_dlc_file(
+    ds: xr.Dataset,
+    file_path: Union[str, Path],
+    split_individuals: Union[bool, Literal["auto"]] = "auto",
+) -> None:
     """Save the xarray dataset containing pose tracks to a
     DeepLabCut-style ".h5" or ".csv" file.
 
@@ -87,11 +186,32 @@ def to_dlc_file(ds: xr.Dataset, file_path: Union[str, Path]) -> None:
     file_path : pathlib Path or str
         Path to the file to save the DLC poses to. The file extension
         must be either ".h5" (recommended) or ".csv".
+    split_individuals : bool, optional
+        Format of the DeepLabcut output file.
+        - If True, the file will be formatted as in a single-animal
+        DeepLabCut project: no "individuals" level, and each individual will be
+        saved in a separate file. The individual's name will be appended to the
+        file path, just before the file extension, i.e.
+        "/path/to/filename_individual1.h5".
+        - If False, the file will be formatted as in a multi-animal
+        DeepLabCut project: the columns will include the
+        "individuals" level and all individuals will be saved to the same file.
+        - If "auto" the format will be determined based on the number of
+        individuals in the dataset: True if there is only one, and
+        False if there are more than one. This is the default.
 
     See Also
     --------
     to_dlc_df : Convert an xarray dataset containing pose tracks into a
-        DeepLabCut-style pandas DataFrame with multi-index columns.
+    DeepLabCut-style pandas DataFrame with multi-index columns
+    for each individual or a dictionary of DataFrames for each individual
+    based on the 'split_individuals' argument.
+
+    Examples
+    --------
+    >>> from movement.io import save_poses, load_poses
+    >>> ds = load_poses.from_sleap("/path/to/file_sleap.analysis.h5")
+    >>> save_poses.to_dlc_file(ds, "/path/to/file_dlc.h5")
     """
 
     try:
@@ -104,9 +224,38 @@ def to_dlc_file(ds: xr.Dataset, file_path: Union[str, Path]) -> None:
         logger.error(error)
         raise error
 
-    df = to_dlc_df(ds)  # convert to pandas DataFrame
-    if file.path.suffix == ".csv":
-        df.to_csv(file.path, sep=",")
-    else:  # file.path.suffix == ".h5"
-        df.to_hdf(file.path, key="df_with_missing")
-    logger.info(f"Saved PoseTracks dataset to {file.path}.")
+    # Sets default behaviour for the function
+    if split_individuals == "auto":
+        split_individuals = _auto_split_individuals(ds)
+
+    elif not isinstance(split_individuals, bool):
+        error_msg = (
+            f"Expected 'split_individuals' to be a boolean or 'auto', but got "
+            f"{type(split_individuals)}."
+        )
+        logger.error(error_msg)
+        raise ValueError(error_msg)
+
+    """If split_individuals is True then it will split the file into a
+    dictionary of pandas dataframes for each individual."""
+    if split_individuals:
+        df_dict = to_dlc_df(ds, split_individuals=True)
+
+        for key, df in df_dict.items():
+            """Iterates over dictionary, the key is the name of the
+            individual and the value is the corresponding df."""
+            filepath = f"{file.path.with_suffix('')}_{key}{file.path.suffix}"
+            filepath_posix = Path(filepath)
+
+            if isinstance(df, pd.DataFrame):
+                _savedataframe(file.path.suffix, filepath_posix, df)
+
+        logger.info(f"Saved PoseTracks dataset to {file.path}.")
+
+    """If split_individuals is False then it will save the file as a dataframe
+    with multi-index columns for each individual."""
+    if not split_individuals:
+        dataframe = to_dlc_df(ds, split_individuals=False)
+        if isinstance(dataframe, pd.DataFrame):
+            _savedataframe(file.path.suffix, file.path, dataframe)
+        logger.info(f"Saved PoseTracks dataset to {file.path}.")

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -52,8 +52,8 @@ def _auto_split_individuals(ds: xr.Dataset) -> bool:
     """Returns True if there is only one individual in the dataset,
     else returns False."""
 
-    individuals = ds.coords["individuals"].data.tolist()
-    return True if len(individuals) == 1 else False
+    n_individuals = ds.sizes["individuals"]
+    return True if n_individuals == 1 else False
 
 
 def _save_dlc_df(filepath: Path, df: pd.DataFrame) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,10 +202,19 @@ def valid_tracks_array():
 
 
 @pytest.fixture
-def valid_pose_dataset(valid_tracks_array):
+def valid_pose_dataset(valid_tracks_array, request):
     """Return a valid pose tracks dataset."""
     dim_names = PosesAccessor.dim_names
-    tracks_array = valid_tracks_array("multi_track_array")
+
+    # create a multi_track_array by default unless overriden via param
+    try:
+        array_format = request.param
+    except AttributeError:
+        array_format = "multi_track_array"
+
+    tracks_array = valid_tracks_array(array_format)
+    n_individuals, n_keypoints = tracks_array.shape[1:3]
+
     return xr.Dataset(
         data_vars={
             "pose_tracks": xr.DataArray(tracks_array, dims=dim_names),
@@ -216,8 +225,8 @@ def valid_pose_dataset(valid_tracks_array):
         },
         coords={
             "time": np.arange(tracks_array.shape[0]),
-            "individuals": ["ind1", "ind2"],
-            "keypoints": ["key1", "key2"],
+            "individuals": [f"ind{i}" for i in range(1, n_individuals + 1)],
+            "keypoints": [f"key{i}" for i in range(1, n_keypoints + 1)],
             "space": ["x", "y"],
         },
         attrs={

--- a/tests/test_integration/test_io.py
+++ b/tests/test_integration/test_io.py
@@ -12,7 +12,7 @@ class TestPosesIO:
         """Test that loading pose tracks from a DLC-style DataFrame and
         converting back to a DataFrame returns the same data values."""
         ds = load_poses.from_dlc_df(dlc_style_df)
-        df = save_poses.to_dlc_df(ds)
+        df = save_poses.to_dlc_df(ds, split_individuals=False)
         np.testing.assert_allclose(df.values, dlc_style_df.values)
 
     @pytest.mark.parametrize("file_name", ["dlc.h5", "dlc.csv"])
@@ -21,6 +21,8 @@ class TestPosesIO:
     ):
         """Test that saving pose tracks to DLC .h5 and .csv files and then
         loading them back in returns the same Dataset."""
-        save_poses.to_dlc_file(valid_pose_dataset, tmp_path / file_name)
+        save_poses.to_dlc_file(
+            valid_pose_dataset, tmp_path / file_name, split_individuals=False
+        )
         ds = load_poses.from_dlc_file(tmp_path / file_name)
         xr.testing.assert_allclose(ds, valid_pose_dataset)

--- a/tests/test_integration/test_io.py
+++ b/tests/test_integration/test_io.py
@@ -26,3 +26,12 @@ class TestPosesIO:
         )
         ds = load_poses.from_dlc_file(tmp_path / file_name)
         xr.testing.assert_allclose(ds, valid_pose_dataset)
+
+    @pytest.mark.parametrize("dlc_file", ["dlc.h5", "dlc.csv"])
+    def test_load_from_sleap_save_to_dlc(self, sleap_file, dlc_file, tmp_path):
+        """Test that loading pose tracks from SLEAP and saving to a DLC-style
+        dataframe works"""
+        ds = load_poses.from_sleap_file(sleap_file)
+        save_poses.to_dlc_file(
+            ds, tmp_path / dlc_file, split_individuals="auto"
+        )

--- a/tests/test_unit/test_save_poses.py
+++ b/tests/test_unit/test_save_poses.py
@@ -69,7 +69,7 @@ class TestSavePoses:
         """Test that converting a valid/invalid xarray dataset to
         a DeepLabCut-style pandas DataFrame returns the expected result."""
         with expected_exception as e:
-            df = save_poses.to_dlc_df(ds)
+            df = save_poses.to_dlc_df(ds, split_individuals=False)
             if e is None:  # valid input
                 assert isinstance(df, pd.DataFrame)
                 assert isinstance(df.columns, pd.MultiIndex)
@@ -127,4 +127,5 @@ class TestSavePoses:
             save_poses.to_dlc_file(
                 request.getfixturevalue(invalid_pose_dataset),
                 tmp_path / "test.h5",
+                split_individuals=False,
             )


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**What does this PR do?**

This PR adds the functionality to save xarrays as a dictionary of individual pandas dataframes for to_dlc_df and as multiple files for each individual for to_dlc_file. This is based on the split_individuals: bool parameter, if True it will split the data for each individual, if false it will save it as a multi-animal file. 

## References

This PR addresses Issue #39. 

## How has this PR been tested?

The PR was tested on a Juypter Notebook against the four scenarios, (credit to @niksirbi):
* The xarray.Dataset has multiple (>1) individuals and the user wants to save it to a multi-animal DeepLabCut dataframe. This currently works with the existing functions.
* The xarray.Dataset has only 1 individual but the user still wants to save it to a multi-animal DeepLabCut dataframe, including the redundant "individuals" level. This also works currently.
* The xarray.Dataset has a single individual and the user wants to save it to single-animal DeepLabCut dataframe (without the "individuals" level). This behaviour needs to be implemented, the output will be a single file.
* The xarray.Dataset has multiple (>1) individuals and the user wants to split them for saving into multiple single-animal files. * This is the trickiest case to implement, as the dataset would have to be split across individuals (behind the scenes) and each part is then saved to a single-animal file as in case 3. The output should be as many files as there are individuals.

## Todo

Need to write tests. 

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
