### PR TITLE
Added LightningPose data to pooch dataset registry

### DIFF
--- a/movement/datasets.py
+++ b/movement/datasets.py
@@ -29,7 +29,9 @@ POSE_DATA = pooch.create(
         "DLC_single-wasp.predictions.h5": "931dddb6ef5e08db6054d3757a441ee31dd0d9ff5a10802ad8405d6c4e7e274e",  # noqa: E501
         "DLC_single-wasp.predictions.csv": "9b194cc930c2e2e0d33c816320d029f889b306d53ff2fe95ff408e99c9cdea23",  # noqa: E501
         "DLC_single-mouse_EPM.predictions.h5": "0ddc2b08c9401435929783b22ea31b3673ceb80c3a02c5f3531bb1cfd78deea5",  # noqa: E501
-        "DLC_two-mice.predictions.csv": "6f152cf7ce1ea2a3099384fa1655abde8963f5153a02f0ca643e3e8e97f63cbf",  # noqa: E501
+        "DLC_two-mice.predictions.csv": "6e891ab4e14a3ad74451ed0899f770b47aa3eb959d9824d3782827297d7c75e0",  # noqa: E501
+        "LP_mouse-face_AIND.predictions.csv": "13620f20a3fbb20c9ef0ad6fd8898944d2cfe3e83c5fe18946b7592e0a718da2",  # noqa: E501
+        "LP_mouse-twoview_AIND.predictions.csv": "22cded593ff77226dffab3c10f87874e597d86d70d62a81e5c4c690a96fd1e49",  # noqa: E501
         "SLEAP_single-mouse_EPM.analysis.h5": "0df0a09c2493a1d9964ba98cbf751eda62743f1d688ae82b6df7b0f77169ed47",  # noqa: E501
         "SLEAP_single-mouse_EPM.predictions.slp": "ca620db6123635761ddf69947f72f653d14a59137b355bd2d8f7c2f1be67e474",  # noqa: E501
         "SLEAP_two-mice_social-interaction.analysis.h5": "f7f1e59d4b2c34712089f8aaf2390272291d93e6991c1abe32d9ce798a6234f9",  # noqa: E501


### PR DESCRIPTION
I've updated the [test datasets on GIN](https://gin.g-node.org/neuroinformatics/movement-test-data), specifically:
- I've added two sample output .csv files from LightningPoses (prefixed with 'LP')
- I've reduced the 'DLC_two-mice.predictions.csv` file in size, specifically I've extracted the first 10 minutes from it (previously this file was > 110 MB)

The `poses_files_metadata.yaml` and `poses_registry.txt` files have been updated accordingly and now contain the updated sha256 hashes.

This PR adds the new files and hashes to the dataset registry in `datasets.py`.

This is a pre-requisite for un-blocking #74. After this one gets merged, you can get started on that issue @DhruvSkyy

@b-peri tagging you as a reviewer so you're aware of these changes. After we merge this, you'll probably have to rebase your branch on this one, before you continue with #86 