### PR TITLE
Export SLEAP .h5 analysis files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -264,7 +264,7 @@ stored in the `poses` folder. Each file name starts with either "DLC" or "SLEAP"
 depending on the pose estimation software used to generate the data.
 
 ### Fetching data
-To fetch the data from GIN, we use the [pooch](https://www.fatiando.org/pooch/latest/index.html)
+To fetch the data from GIN, we use the [pooch](https://github.com/fatiando/pooch)
 Python package, which can download data from pre-specified URLs and store them
 locally for all subsequent uses. It also provides some nice utilities,
 like verification of sha256 hashes and decompression of archives.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -264,7 +264,7 @@ stored in the `poses` folder. Each file name starts with either "DLC" or "SLEAP"
 depending on the pose estimation software used to generate the data.
 
 ### Fetching data
-To fetch the data from GIN, we use the [pooch](https://github.com/fatiando/pooch)
+To fetch the data from GIN, we use the [pooch](https://www.fatiando.org/pooch/latest/index.html)
 Python package, which can download data from pre-specified URLs and store them
 locally for all subsequent uses. It also provides some nice utilities,
 like verification of sha256 hashes and decompression of archives.

--- a/docs/source/api_index.rst
+++ b/docs/source/api_index.rst
@@ -20,6 +20,7 @@ Input/Output
 
     to_dlc_file
     to_dlc_df
+    to_sleap_analysis_file
 
 .. currentmodule:: movement.io.validators
 .. autosummary::

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -157,7 +157,7 @@ myst_url_schemes = {
     "myst-parser": "https://myst-parser.readthedocs.io/en/latest/{{path}}#{{fragment}}",
     "napari": "https://napari.org/dev/{{path}}",
     "setuptools-scm": "https://setuptools-scm.readthedocs.io/en/latest/{{path}}#{{fragment}}",
-    "sleap": "https://sleap.ai/",
+    "sleap": "https://sleap.ai/{{path}}#{{fragment}}",
     "sphinx-gallery": "https://sphinx-gallery.github.io/stable/{{path}}",
     "xarray": "https://docs.xarray.dev/en/stable/{{path}}#{{fragment}}",
 }

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -221,7 +221,7 @@ Then, use the `to_dlc_file` or `to_sleap_analysis_file` functions to save the da
 
 ::::{tab-item} SLEAP
 
-Save to SLEAP analysis files (`.h5`):
+Save to SLEAP-style analysis files (`.h5`):
 ```python
 save_poses.to_sleap_analysis_file(ds, "/path/to/file.h5")
 ```

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -228,7 +228,9 @@ save_poses.to_sleap_analysis_file(ds, "/path/to/file.h5")
 
 :::{note}
 When saving to SLEAP-style files, only `track_names`, `node_names`, `tracks`, `track_occupancy`,
-`point_scores`, and `labels_path` are saved. Other attributes and data variables
+and `point_scores` are saved. `labels_path` will only be saved if the source
+file of the dataset is a SLEAP .slp file. Otherwise, it will be an empty string.
+Other attributes and data variables
 (i.e., `instance_scores`, `tracking_scores`, `edge_names`, `edge_inds`, `video_path`,
 `video_ind`, and `provenance`) are not currently supported. To learn more about what
 each attribute and data variable represents, see the

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -207,13 +207,23 @@ example for inspiration.
 
 ## Saving data
 You can save movement datasets to disk in a variety of formats.
-Currently, only saving to DeepLabCut-style files is supported.
+This includes saving to DeepLabCut-style files (.h5 or .csv) and
+SLEAP-style analysis files (.h5). When saving to SLEAP-style files,
+do note that only `track_names`, `node_names`, `tracks`, `track_occupancy`,
+`point_scores`, and `labels_path` are saved. Other attributes and data variables
+(i.e., `instance_scores`, `tracking_scores`, `edge_names`, `edge_inds`, `video_path`,
+`video_ind`, and `provenance`) are not currently supported. To learn more about what
+each attribute and data variable represents, see the [SLEAP documentation](sleap:api/sleap.info.write_tracking_h5.html#module-sleap.info.write_tracking_h5).
 
 ```python
 from movement.io import save_poses
 
-save_poses.to_dlc_file(ds, "/path/to/file.h5")  # preferred
+# save to DeepLabCut-style file
+save_poses.to_dlc_file(ds, "/path/to/file.h5")  # preferred format for DeepLabCut
 save_poses.to_dlc_file(ds, "/path/to/file.csv")
+
+# save to SLEAP-style file
+save_poses.to_sleap_analysis_file(ds, "/path/to/file.h5")
 ```
 
 Instead of saving to file directly, you can also convert the dataset to a

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -206,29 +206,50 @@ to visualise the data. Check out the [Load and explore pose tracks](./examples/l
 example for inspiration.
 
 ## Saving data
-You can save movement datasets to disk in a variety of formats.
-This includes saving to DeepLabCut-style files (.h5 or .csv) and
-SLEAP-style analysis files (.h5). When saving to SLEAP-style files,
-do note that only `track_names`, `node_names`, `tracks`, `track_occupancy`,
-`point_scores`, and `labels_path` are saved. Other attributes and data variables
-(i.e., `instance_scores`, `tracking_scores`, `edge_names`, `edge_inds`, `video_path`,
-`video_ind`, and `provenance`) are not currently supported. To learn more about what
-each attribute and data variable represents, see the [SLEAP documentation](sleap:api/sleap.info.write_tracking_h5.html#module-sleap.info.write_tracking_h5).
+You can save movement datasets to disk in a variety of formats, including
+DeepLabCut-style files (.h5 or .csv) and [SLEAP-style analysis files](sleap:tutorials/analysis) (.h5).
+
+First import the `movement.io.save_poses` module:
 
 ```python
 from movement.io import save_poses
+```
 
-# save to DeepLabCut-style file
-save_poses.to_dlc_file(ds, "/path/to/file.h5")  # preferred format for DeepLabCut
-save_poses.to_dlc_file(ds, "/path/to/file.csv")
+Then, use the `to_dlc_file` or `to_sleap_analysis_file` functions to save the data.
 
-# save to SLEAP-style file
+:::::{tab-set}
+
+::::{tab-item} SLEAP
+
+Save to SLEAP analysis files (`.h5`):
+```python
 save_poses.to_sleap_analysis_file(ds, "/path/to/file.h5")
 ```
 
-Instead of saving to file directly, you can also convert the dataset to a
-DeepLabCut-style `pandas.DataFrame` first:
+:::{note}
+When saving to SLEAP-style files, only `track_names`, `node_names`, `tracks`, `track_occupancy`,
+`point_scores`, and `labels_path` are saved. Other attributes and data variables
+(i.e., `instance_scores`, `tracking_scores`, `edge_names`, `edge_inds`, `video_path`,
+`video_ind`, and `provenance`) are not currently supported. To learn more about what
+each attribute and data variable represents, see the
+[SLEAP documentation](sleap:api/sleap.info.write_tracking_h5.html#module-sleap.info.write_tracking_h5).
+:::
+::::
+
+::::{tab-item} DeepLabCut
+
+Save to DeepLabCut-style files (`.h5` or `.csv`):
+```python
+save_poses.to_dlc_file(ds, "/path/to/file.h5")  # preferred format
+save_poses.to_dlc_file(ds, "/path/to/file.csv")
+```
+
+Alternatively, you can first convert the dataset to a
+DeepLabCut-style `pandas.DataFrame` using the `to_dlc_df` function:
 ```python
 df = save_poses.to_dlc_df(ds)
 ```
 and then save it to file using any `pandas` method, e.g. `to_hdf` or `to_csv`.
+::::
+
+:::::

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -88,8 +88,8 @@ def from_sleap_file(
     Parameters
     ----------
     file_path : pathlib.Path or str
-        Path to the file containing the SLEAP predictions in ".h5"
-        (analysis) format. Alternatively, an ".slp" (labels) file can
+        Path to the file containing the SLEAP predictions in .h5
+        (analysis) format. Alternatively, a .slp (labels) file can
         also be supplied (but this feature is experimental, see Notes).
     fps : float, optional
         The number of frames per second in the video. If None (default),
@@ -102,18 +102,18 @@ def from_sleap_file(
 
     Notes
     -----
-    The SLEAP predictions are normally saved in ".slp" files, e.g.
+    The SLEAP predictions are normally saved in .slp files, e.g.
     "v1.predictions.slp". An analysis file, suffixed with ".h5" can be exported
-    from the ".slp" file, using either the command line tool `sleap-convert`
+    from the .slp file, using either the command line tool `sleap-convert`
     (with the "--format analysis" option enabled) or the SLEAP GUI (Choose
     "Export Analysis HDF5…" from the "File" menu) [1]_. This is the
     preferred format for loading pose tracks from SLEAP into *movement*.
 
-    You can also directly load the ".slp" file. However, if the file contains
+    You can also directly load the .slp file. However, if the file contains
     multiple videos, only the pose tracks from the first video will be loaded.
     If the file contains a mix of user-labelled and predicted instances, user
     labels are prioritised over predicted instances to mirror SLEAP's approach
-    when exporting ".h5" analysis files [2]_.
+    when exporting .h5 analysis files [2]_.
 
     *movement* expects the tracks to be assigned and proofread before loading
     them, meaning each track is interpreted as a single individual/animal. If
@@ -169,8 +169,8 @@ def from_dlc_file(
     Parameters
     ----------
     file_path : pathlib.Path or str
-        Path to the file containing the DLC predicted poses, either in ".h5"
-        or ".csv" format.
+        Path to the file containing the DLC predicted poses, either in .h5
+        or .csv format.
     fps : float, optional
         The number of frames per second in the video. If None (default),
         the `time` coordinates will be in frame numbers.
@@ -320,7 +320,7 @@ def _sleap_labels_to_numpy(labels: Labels) -> np.ndarray:
     This function only considers SLEAP instances in the first
     video of the SLEAP `Labels` object. User-labelled instances are
     prioritised over predicted instances, mirroring SLEAP's approach
-    when exporting ".h5" analysis files [1]_.
+    when exporting .h5 analysis files [1]_.
 
     This function is adapted from `Labels.numpy()` from the
     `sleap_io` package [2]_.

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -246,9 +246,11 @@ def to_sleap_analysis_file(
     "track_names", "node_names", "tracks", "track_occupancy", "point_scores",
     "instance_scores", "tracking_scores", "labels_path", "edge_names",
     "edge_inds", "video_path", "video_ind", "provenance" [1]_.
-    However, only "track_names", "node_names", "tracks", "track_occupancy",
-    "point_scores" and "labels_path" will contain data extracted from the
-    input dataset.
+    However, only "track_names", "node_names", "tracks", "track_occupancy"
+    and "point_scores" will contain data extracted from the input dataset.
+    "labels_path" will contain the path to the input file only if the source
+    file of the dataset is a SLEAP .slp file. Otherwise, it will be an empty
+    string.
     The other attributes and data variables that are not present in the input
     dataset will contain default (empty) values.
 
@@ -293,7 +295,9 @@ def to_sleap_analysis_file(
     point_scores = np.transpose(ds.confidence.data, (1, 2, 0))
     instance_scores = np.full((n_individuals, n_frames), np.nan, dtype=float)
     tracking_scores = np.full((n_individuals, n_frames), np.nan, dtype=float)
-
+    labels_path = (
+        ds.source_file if Path(ds.source_file).suffix == ".slp" else ""
+    )
     data_dict = dict(
         track_names=individual_names,
         node_names=keypoint_names,
@@ -302,7 +306,7 @@ def to_sleap_analysis_file(
         point_scores=point_scores,
         instance_scores=instance_scores,
         tracking_scores=tracking_scores,
-        labels_path=ds.source_file,
+        labels_path=labels_path,
         edge_names=[],
         edge_inds=[],
         video_path="",

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -237,8 +237,24 @@ def to_sleap_analysis_file(
     ds : xarray.Dataset
         Dataset containing pose tracks, confidence scores, and metadata.
     file_path : pathlib.Path or str
-        Path to the file to save the poses to. The file extension
-        must be .h5 (recommended) or .csv.
+        Path to the file to save the poses to. The file extension must be .h5.
+
+    Notes
+    -----
+    The output file will contain the following keys (as in SLEAP .h5 analysis
+    files):
+    "track_names", "node_names", "tracks", "track_occupancy", "point_scores",
+    "instance_scores", "tracking_scores", "labels_path", "edge_names",
+    "edge_inds", "video_path", "video_ind", "provenance" [1]_.
+    However, only "track_names", "node_names", "tracks", "track_occupancy",
+    "point_scores" and "labels_path" will contain data extracted from the
+    input dataset.
+    The other attributes and data variables that are not present in the input
+    dataset will contain default (empty) values.
+
+    References
+    ----------
+    .. [1] https://sleap.ai/api/sleap.info.write_tracking_h5.html
 
     Examples
     --------

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -385,7 +385,7 @@ def _validate_dataset(ds: xr.Dataset) -> None:
 
     Parameters
     ----------
-    ds : xr.Dataset
+    ds : xarray.Dataset
         Dataset to validate.
 
     Raises

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,6 +164,24 @@ def invalid_multi_animal_csv_file(tmp_path):
 
 
 @pytest.fixture
+def new_file_wrong_ext(tmp_path):
+    """Return the file path for a new file with the wrong extension."""
+    return tmp_path / "new_file_wrong_ext.txt"
+
+
+@pytest.fixture
+def new_h5_file(tmp_path):
+    """Return the file path for a new .h5 file."""
+    return tmp_path / "new_file.h5"
+
+
+@pytest.fixture
+def new_csv_file(tmp_path):
+    """Return the file path for a new .csv file."""
+    return tmp_path / "new_file.csv"
+
+
+@pytest.fixture
 def dlc_style_df():
     """Return a valid DLC-style DataFrame."""
     return pd.read_hdf(pytest.POSE_DATA.get("DLC_single-wasp.predictions.h5"))
@@ -236,3 +254,39 @@ def valid_pose_dataset(valid_tracks_array, request):
             "source_file": "test.h5",
         },
     )
+
+
+@pytest.fixture
+def not_a_dataset():
+    """Return an invalid pose tracks dataset."""
+    return [1, 2, 3]
+
+
+@pytest.fixture
+def empty_dataset():
+    """Return an empty pose tracks dataset."""
+    return xr.Dataset()
+
+
+@pytest.fixture
+def missing_var_dataset(valid_pose_dataset):
+    """Return a pose tracks dataset missing a variable."""
+    return valid_pose_dataset.drop_vars("pose_tracks")
+
+
+@pytest.fixture
+def missing_dim_dataset(valid_pose_dataset):
+    """Return a pose tracks dataset missing a dimension."""
+    return valid_pose_dataset.drop_dims("time")
+
+
+@pytest.fixture(
+    params=[
+        "not_a_dataset",
+        "empty_dataset",
+        "missing_var_dataset",
+        "missing_dim_dataset",
+    ]
+)
+def invalid_pose_dataset(request):
+    return request.getfixturevalue(request.param)

--- a/tests/test_integration/test_io.py
+++ b/tests/test_integration/test_io.py
@@ -76,14 +76,9 @@ class TestPosesIO:
         "file",
         [
             "DLC_single-wasp.predictions.h5",
-            "DLC_single-wasp.predictions.csv",
             "DLC_two-mice.predictions.csv",
             "SLEAP_single-mouse_EPM.analysis.h5",
-            "SLEAP_single-mouse_EPM.predictions.slp",
-            "SLEAP_three-mice_Aeon_proofread.analysis.h5",
             "SLEAP_three-mice_Aeon_proofread.predictions.slp",
-            "SLEAP_three-mice_Aeon_mixed-labels.analysis.h5",
-            "SLEAP_three-mice_Aeon_mixed-labels.predictions.slp",
         ],
     )
     def test_to_sleap_analysis_file_source_file(self, file, new_h5_file):

--- a/tests/test_integration/test_io.py
+++ b/tests/test_integration/test_io.py
@@ -1,6 +1,8 @@
+import h5py
 import numpy as np
 import pytest
 import xarray as xr
+from pytest import POSE_DATA
 
 from movement.io import load_poses, save_poses
 
@@ -39,3 +41,64 @@ class TestPosesIO:
         )
         dlc_ds = load_poses.from_dlc_file(dlc_output_file)
         xr.testing.assert_allclose(sleap_ds, dlc_ds)
+
+    @pytest.mark.parametrize(
+        "sleap_h5_file, fps",
+        [
+            ("SLEAP_single-mouse_EPM.analysis.h5", 30),
+            ("SLEAP_three-mice_Aeon_proofread.analysis.h5", None),
+            ("SLEAP_three-mice_Aeon_mixed-labels.analysis.h5", 50),
+        ],
+    )
+    def test_to_sleap_analysis_file_returns_same_h5_file_content(
+        self, sleap_h5_file, fps, new_h5_file
+    ):
+        """Test that saving pose tracks exported from a SLEAP analysis
+        file to a SLEAP-style .h5 analysis file returns the same file
+        contents."""
+        sleap_h5_file_path = POSE_DATA.get(sleap_h5_file)
+        ds = load_poses.from_sleap_file(sleap_h5_file_path, fps=fps)
+        save_poses.to_sleap_analysis_file(ds, new_h5_file)
+
+        with h5py.File(ds.source_file, "r") as file_in, h5py.File(
+            new_h5_file, "r"
+        ) as file_out:
+            assert set(file_in.keys()) == set(file_out.keys())
+            keys = [
+                "track_occupancy",
+                "tracks",
+                "point_scores",
+            ]
+            for key in keys:
+                np.testing.assert_allclose(file_in[key][:], file_out[key][:])
+
+    @pytest.mark.parametrize(
+        "file",
+        [
+            "DLC_single-wasp.predictions.h5",
+            "DLC_single-wasp.predictions.csv",
+            "DLC_two-mice.predictions.csv",
+            "SLEAP_single-mouse_EPM.analysis.h5",
+            "SLEAP_single-mouse_EPM.predictions.slp",
+            "SLEAP_three-mice_Aeon_proofread.analysis.h5",
+            "SLEAP_three-mice_Aeon_proofread.predictions.slp",
+            "SLEAP_three-mice_Aeon_mixed-labels.analysis.h5",
+            "SLEAP_three-mice_Aeon_mixed-labels.predictions.slp",
+        ],
+    )
+    def test_to_sleap_analysis_file_source_file(self, file, new_h5_file):
+        """Test that saving pose tracks exported from a SLEAP file
+        to a SLEAP-style .h5 analysis file returns the same file
+        contents."""
+        file_path = POSE_DATA.get(file)
+        if file.startswith("DLC"):
+            ds = load_poses.from_dlc_file(file_path)
+        else:
+            ds = load_poses.from_sleap_file(file_path)
+        save_poses.to_sleap_analysis_file(ds, new_h5_file)
+
+        with h5py.File(new_h5_file, "r") as f:
+            if file_path.suffix == ".slp":
+                assert file_path.name in f["labels_path"][()].decode()
+            else:
+                assert f["labels_path"][()].decode() == ""

--- a/tests/test_integration/test_io.py
+++ b/tests/test_integration/test_io.py
@@ -53,8 +53,8 @@ class TestPosesIO:
     def test_to_sleap_analysis_file_returns_same_h5_file_content(
         self, sleap_h5_file, fps, new_h5_file
     ):
-        """Test that saving pose tracks exported from a SLEAP analysis
-        file to a SLEAP-style .h5 analysis file returns the same file
+        """Test that saving pose tracks (loaded from a SLEAP analysis
+        file) to a SLEAP-style .h5 analysis file returns the same file
         contents."""
         sleap_h5_file_path = POSE_DATA.get(sleap_h5_file)
         ds = load_poses.from_sleap_file(sleap_h5_file_path, fps=fps)
@@ -87,9 +87,9 @@ class TestPosesIO:
         ],
     )
     def test_to_sleap_analysis_file_source_file(self, file, new_h5_file):
-        """Test that saving pose tracks exported from a SLEAP file
-        to a SLEAP-style .h5 analysis file returns the same file
-        contents."""
+        """Test that saving pose tracks (loaded from valid source files)
+        to a SLEAP-style .h5 analysis file stores the .slp labels path
+        only when the source file is a .slp file."""
         file_path = POSE_DATA.get(file)
         if file.startswith("DLC"):
             ds = load_poses.from_dlc_file(file_path)

--- a/tests/test_unit/test_load_poses.py
+++ b/tests/test_unit/test_load_poses.py
@@ -118,8 +118,8 @@ class TestLoadPoses:
         # the assigned default "individuals_0"
         assert ds_from_trackless.individuals == ["individual_0"]
         xr.testing.assert_allclose(
-            ds_from_trackless.drop("individuals"),
-            ds_from_tracked.drop("individuals"),
+            ds_from_trackless.drop_vars("individuals"),
+            ds_from_tracked.drop_vars("individuals"),
         )
 
     @pytest.mark.parametrize(

--- a/tests/test_unit/test_save_poses.py
+++ b/tests/test_unit/test_save_poses.py
@@ -292,21 +292,21 @@ class TestSavePoses:
             )
 
     @pytest.mark.parametrize(
-        "sleap_h5_file",
+        "sleap_h5_file, fps",
         [
-            "SLEAP_single-mouse_EPM.analysis.h5",
-            "SLEAP_three-mice_Aeon_proofread.analysis.h5",
-            "SLEAP_three-mice_Aeon_mixed-labels.analysis.h5",
+            ("SLEAP_single-mouse_EPM.analysis.h5", 30),
+            ("SLEAP_three-mice_Aeon_proofread.analysis.h5", None),
+            ("SLEAP_three-mice_Aeon_mixed-labels.analysis.h5", 50),
         ],
     )
     def test_to_sleap_analysis_file_returns_same_h5_file_content(
-        self, sleap_h5_file, new_h5_file
+        self, sleap_h5_file, fps, new_h5_file
     ):
         """Test that saving pose tracks from a SLEAP analysis file
         to a SLEAP-style .h5 analysis file returns the same file
         contents."""
         sleap_h5_file_path = POSE_DATA.get(sleap_h5_file)
-        ds = load_poses.from_sleap_file(sleap_h5_file_path)
+        ds = load_poses.from_sleap_file(sleap_h5_file_path, fps=fps)
         save_poses.to_sleap_analysis_file(ds, new_h5_file)
 
         with h5py.File(sleap_h5_file_path, "r") as file_in, h5py.File(

--- a/tests/test_unit/test_save_poses.py
+++ b/tests/test_unit/test_save_poses.py
@@ -1,6 +1,7 @@
 from contextlib import nullcontext as does_not_raise
 from pathlib import Path
 
+import h5py
 import numpy as np
 import pandas as pd
 import pytest
@@ -12,6 +13,47 @@ from movement.io import load_poses, save_poses
 
 class TestSavePoses:
     """Test suite for the save_poses module."""
+
+    output_files = [
+        {
+            "file_fixture": "fake_h5_file",
+            "to_dlc_file_expected_exception": pytest.raises(FileExistsError),
+            "to_sleap_file_expected_exception": pytest.raises(FileExistsError),
+            # invalid file path
+        },
+        {
+            "file_fixture": "directory",
+            "to_dlc_file_expected_exception": pytest.raises(IsADirectoryError),
+            "to_sleap_file_expected_exception": pytest.raises(
+                IsADirectoryError
+            ),
+            # invalid file path
+        },
+        {
+            "file_fixture": "new_file_wrong_ext",
+            "to_dlc_file_expected_exception": pytest.raises(ValueError),
+            "to_sleap_file_expected_exception": pytest.raises(ValueError),
+            # invalid file path
+        },
+        {
+            "file_fixture": "new_csv_file",
+            "to_dlc_file_expected_exception": does_not_raise(),
+            "to_sleap_file_expected_exception": pytest.raises(ValueError),
+            # valid file path for dlc, invalid for sleap
+        },
+        {
+            "file_fixture": "new_h5_file",
+            "to_dlc_file_expected_exception": does_not_raise(),
+            "to_sleap_file_expected_exception": does_not_raise(),
+            # valid file path
+        },
+    ]
+
+    @pytest.fixture(params=output_files)
+    def output_file_params(self, request):
+        """Return a dictionary containing parameters for testing saving
+        valid pose datasets to DeepLabCut- or SLEAP-style files."""
+        return request.param
 
     @pytest.fixture
     def not_a_dataset(self):
@@ -34,19 +76,30 @@ class TestSavePoses:
         return tmp_path / "new_file_wrong_ext.txt"
 
     @pytest.fixture
-    def new_dlc_h5_file(self, tmp_path):
-        """Return the file path for a new DeepLabCut .h5 file."""
-        return tmp_path / "new_dlc_file.h5"
+    def new_h5_file(self, tmp_path):
+        """Return the file path for a new .h5 file."""
+        return tmp_path / "new_file.h5"
 
     @pytest.fixture
-    def new_dlc_csv_file(self, tmp_path):
-        """Return the file path for a new DeepLabCut .csv file."""
-        return tmp_path / "new_dlc_file.csv"
+    def new_csv_file(self, tmp_path):
+        """Return the file path for a new .csv file."""
+        return tmp_path / "new_file.csv"
 
     @pytest.fixture
     def missing_dim_dataset(self, valid_pose_dataset):
         """Return a pose tracks dataset missing a dimension."""
         return valid_pose_dataset.drop_dims("time")
+
+    @pytest.fixture(
+        params=[
+            "not_a_dataset",
+            "empty_dataset",
+            "missing_var_dataset",
+            "missing_dim_dataset",
+        ]
+    )
+    def invalid_pose_dataset(self, request):
+        return request.getfixturevalue(request.param)
 
     @pytest.mark.parametrize(
         "ds, expected_exception",
@@ -95,52 +148,23 @@ class TestSavePoses:
                     "coords",
                 ]
 
-    @pytest.mark.parametrize(
-        "file_fixture, expected_exception",
-        [
-            (
-                "fake_h5_file",
-                pytest.raises(FileExistsError),
-            ),  # invalid file path
-            (
-                "directory",
-                pytest.raises(IsADirectoryError),
-            ),  # invalid file path
-            (
-                "new_file_wrong_ext",
-                pytest.raises(ValueError),
-            ),  # invalid file path
-            ("new_dlc_h5_file", does_not_raise()),  # valid file path
-            ("new_dlc_csv_file", does_not_raise()),  # valid file path
-        ],
-    )
     def test_to_dlc_file_valid_dataset(
-        self, file_fixture, expected_exception, valid_pose_dataset, request
+        self, output_file_params, valid_pose_dataset, request
     ):
         """Test that saving a valid pose dataset to a valid/invalid
         DeepLabCut-style file returns the appropriate errors."""
-        with expected_exception:
+        with output_file_params.get("to_dlc_file_expected_exception"):
+            file_fixture = output_file_params.get("file_fixture")
             val = request.getfixturevalue(file_fixture)
             file_path = val.get("file_path") if isinstance(val, dict) else val
             save_poses.to_dlc_file(valid_pose_dataset, file_path)
 
-    @pytest.mark.parametrize(
-        "invalid_pose_dataset",
-        [
-            "not_a_dataset",
-            "empty_dataset",
-            "missing_var_dataset",
-            "missing_dim_dataset",
-        ],
-    )
-    def test_to_dlc_file_invalid_dataset(
-        self, invalid_pose_dataset, request, tmp_path
-    ):
+    def test_to_dlc_file_invalid_dataset(self, invalid_pose_dataset, tmp_path):
         """Test that saving an invalid pose dataset to a valid
         DeepLabCut-style file returns the appropriate errors."""
         with pytest.raises(ValueError):
             save_poses.to_dlc_file(
-                request.getfixturevalue(invalid_pose_dataset),
+                invalid_pose_dataset,
                 tmp_path / "test.h5",
                 split_individuals=False,
             )
@@ -172,16 +196,13 @@ class TestSavePoses:
         self,
         valid_pose_dataset,
         split_individuals,
-        request,
     ):
         """Test that the 'split_individuals' argument affects the behaviour
         of the 'to_dlc_df` function as expected
         """
         df = save_poses.to_dlc_df(valid_pose_dataset, split_individuals)
         # Get the names of the individuals in the dataset
-        ds = request.getfixturevalue("valid_pose_dataset")
-        ind_names = ds.individuals.values
-
+        ind_names = valid_pose_dataset.individuals.values
         if split_individuals is False:
             # this should produce a single df in multi-animal DLC format
             assert isinstance(df, pd.DataFrame)
@@ -219,33 +240,92 @@ class TestSavePoses:
     def test_to_dlc_file_split_individuals(
         self,
         valid_pose_dataset,
-        new_dlc_h5_file,
+        new_h5_file,
         split_individuals,
         expected_exception,
-        request,
     ):
         """Test that the 'split_individuals' argument affects the behaviour
-        of the 'to_dlc_file` function as expected
+        of the 'to_dlc_file` function as expected.
         """
-
         with expected_exception:
             save_poses.to_dlc_file(
                 valid_pose_dataset,
-                new_dlc_h5_file,
+                new_h5_file,
                 split_individuals,
             )
-            ds = request.getfixturevalue("valid_pose_dataset")
-
+            # Get the names of the individuals in the dataset
+            ind_names = valid_pose_dataset.individuals.values
             # "auto" becomes False, default valid dataset is multi-individual
             if split_individuals in [False, "auto"]:
                 # this should save only one file
-                assert new_dlc_h5_file.is_file()
-                new_dlc_h5_file.unlink()
+                assert new_h5_file.is_file()
+                new_h5_file.unlink()
             elif split_individuals is True:
                 # this should save one file per individual
-                for ind in ds.individuals.values:
+                for ind in ind_names:
                     file_path_ind = Path(
-                        f"{new_dlc_h5_file.with_suffix('')}_{ind}.h5"
+                        f"{new_h5_file.with_suffix('')}_{ind}.h5"
                     )
                     assert file_path_ind.is_file()
                     file_path_ind.unlink()
+
+    def test_to_sleap_analysis_file_valid_dataset(
+        self, output_file_params, valid_pose_dataset, request
+    ):
+        """Test that saving a valid pose dataset to a valid/invalid
+        SLEAP-style file returns the appropriate errors."""
+        with output_file_params.get("to_sleap_file_expected_exception"):
+            file_fixture = output_file_params.get("file_fixture")
+            val = request.getfixturevalue(file_fixture)
+            file_path = val.get("file_path") if isinstance(val, dict) else val
+            save_poses.to_sleap_analysis_file(valid_pose_dataset, file_path)
+
+    def test_to_sleap_analysis_file_invalid_dataset(
+        self, invalid_pose_dataset, new_h5_file
+    ):
+        """Test that saving an invalid pose dataset to a valid
+        SLEAP-style file returns the appropriate errors."""
+        with pytest.raises(ValueError):
+            save_poses.to_sleap_analysis_file(
+                invalid_pose_dataset,
+                new_h5_file,
+            )
+
+    @pytest.mark.parametrize(
+        "sleap_h5_file",
+        [
+            "SLEAP_single-mouse_EPM.analysis.h5",
+            "SLEAP_three-mice_Aeon_proofread.analysis.h5",
+            "SLEAP_three-mice_Aeon_mixed-labels.analysis.h5",
+        ],
+    )
+    def test_to_sleap_analysis_file_returns_same_h5_file_content(
+        self, sleap_h5_file, new_h5_file
+    ):
+        """Test that saving pose tracks from a SLEAP analysis file
+        to a SLEAP-style .h5 analysis file returns the same file
+        contents."""
+        sleap_h5_file_path = POSE_DATA.get(sleap_h5_file)
+        ds = load_poses.from_sleap_file(sleap_h5_file_path)
+        save_poses.to_sleap_analysis_file(ds, new_h5_file)
+
+        with h5py.File(sleap_h5_file_path, "r") as file_in, h5py.File(
+            new_h5_file, "r"
+        ) as file_out:
+            assert set(file_in.keys()) == set(file_out.keys())
+            keys = [
+                "track_occupancy",
+                "tracks",
+                "point_scores",
+            ]
+            for key in keys:
+                np.testing.assert_allclose(file_in[key][:], file_out[key][:])
+
+    def test_remove_unoccupied_tracks(self, valid_pose_dataset):
+        """Test that removing unoccupied tracks from a valid pose dataset
+        returns the expected result."""
+        new_individuals = [f"ind{i}" for i in range(1, 4)]
+        # Add new individual with NaN data
+        ds = valid_pose_dataset.reindex(individuals=new_individuals)
+        ds = save_poses._remove_unoccupied_tracks(ds)
+        xr.testing.assert_equal(ds, valid_pose_dataset)


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
This PR enables _movement_ datasets to be exported as SLEAP-style .h5 files.

**What does this PR do?**
1. Adds:
   - `to_sleap_analysis_file` which converts an xarray pose tracks dataset (cleaned using `_remove_unoccupied_tracks`) to a SLEAP-style .h5 analysis file, and the relevant documentation to the API docs
   - documentation  to "saving data" in "Getting started" 
   - file path and dataset validation functions in `save_poses.py`
   - relevant tests for the new functions, and rewrites reused test parameters as fixtures
2. Replaces the [broken pooch URL](https://www.fatiando.org/pooch/latest/index.html) with their [GitHub repository URL](https://github.com/fatiando/pooch) to pass linkcheck when building docs.
3. Refactors file and file path validation in `save_poses.py` as reusable functions.
4. Reorganises test fixtures by moving related (and potentially reusable) fixtures into `conftest.py` .

## References
This PR resolves #46. 

## How has this PR been tested?
- Added new tests 
- Reran all tests

## Does this PR require an update to the documentation?
- Saving data example in "getting started" has been updated
- Added `to_sleap_analysis_file` to API docs

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
