### PR TITLE
Added function to load poses from LightningPose

### DIFF
--- a/tests/test_unit/test_load_poses.py
+++ b/tests/test_unit/test_load_poses.py
@@ -205,3 +205,17 @@ class TestLoadPoses:
                 ds.coords["time"].data,
                 np.arange(ds.dims["time"], dtype=int) / ds.attrs["fps"],
             )
+
+    @pytest.mark.parametrize(
+        "file_name",
+        [
+            "LP_mouse-face_AIND.predictions.csv",
+            "LP_mouse-twoview_AIND.predictions.csv",
+        ],
+    )
+    def test_load_from_LP_file(self, file_name):
+        """Test that loading pose tracks from valid DLC files
+        returns a proper Dataset."""
+        file_path = POSE_DATA.get(file_name)
+        ds = load_poses.from_lp_file(file_path)
+        self.assert_dataset(ds, file_path, "LightningPose")


### PR DESCRIPTION
## Description

Created a function called from_lp_file to load poses from LightningPose. Used previous code from from_dlc_file to create _from_lp_or_dlc_file which is used for both from_lp_file and from_dlc_file. 

This method was chosen as there was quite a lot of information in the docstrings and users may prefer from_lp_file() rather than from_file(source_software='LightningPose'). _from_lp_or_dlc_file was created to avoid repetition, an optional parameter was not added directly to from_dlc_file to reuse for from_lp_file as then users can also use the parameter with from_dlc_file and would now have two methods to load lp files which may be confusing. 

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

## References

closes #74 

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
