### PR TITLE
Remove pytables as a conda dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,15 +9,12 @@ or [mamba](mamba:) to create a
 development environment for movement. In the following we assume you have
 `conda` installed, but the same commands will also work with `mamba`/`micromamba`.
 
-First, create and activate a `conda` environment with some pre-requisites:
+First, create and activate a `conda` environment:
 
 ```sh
-conda create -n movement-dev -c conda-forge python=3.10 pytables
+conda create -n movement-dev python=3.10
 conda activate movement-dev
 ```
-
-The above method ensures that you will get packages that often can't be
-installed via `pip`, including [hdf5](https://www.hdfgroup.org/solutions/hdf5/).
 
 To install movement for development, clone the GitHub repository,
 and then run from inside the repository:

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -2,8 +2,10 @@
 
 ## Installation
 
+:::{admonition} Use a conda environment
+:class: note
 We recommend you install movement inside a [conda](conda:)
-or [mamba](mamba:) environment.
+or [mamba](mamba:) environment, to avoid dependency conflicts with other packages.
 In the following we assume you have `conda` installed,
 but the same commands will also work with `mamba`/`micromamba`.
 
@@ -12,11 +14,12 @@ First, create and activate an environment.
 You can call your environment whatever you like, we've used "movement-env".
 
 ```sh
-conda create -n movement-env -c conda-forge python=3.10 pytables
+conda create -n movement-env python=3.10
 conda activate movement-env
 ```
 
-Next install the `movement` package:
+Then install the `movement` package as described below.
+:::
 
 ::::{tab-set}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = {text = "BSD-3-Clause"}
 
 dependencies = [
     "numpy",
-    "pandas",
+    "pandas[hdf5]",
     "h5py",
     "attrs",
     "pooch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,6 @@ archs = ["x86_64", "arm64"]
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-requires = tox-conda
 envlist = py{39,310,311}
 isolated_build = True
 
@@ -130,10 +129,6 @@ python =
     3.11: py311
 
 [testenv]
-conda_deps =
-    pytables
-conda_channels =
-    conda-forge
 extras =
     dev
 commands =


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Currently, we have a two-step installation process:

1. Create a conda environment, with `pytables` installed:
```sh
conda create -n movement-env -c conda-forge python=3.10 pytables
conda activate movement-env
```
2. Install movement itself.
```sh
pip install movement
```

We would like to simplify it to a single step, so users can simply `pip install movement`. That can be preceded by `conda create -n movement-env python=3.10`, if they want to install it in a fresh environment (which we still recommend).

**What does this PR do?**

As per @willGraham01's suggestion, we now require `pandas[hdf5]` instead of vanilla pandas. See #91 for more details on this.

## References

Closes #91 

## How has this PR been tested?

Tested locally on an M2 Mac and on CI across platforms.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

The installation instructions have been updated accordingly. We still recommend using a conda environment (albeit without `pytables`), and after that it's simply `pip install movement`.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (installation already covered in CI)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
