### PR TITLE
Provide a generic load_poses.from_file() function

### DIFF
--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -56,7 +56,7 @@ def from_file(
         return from_dlc_file(file_path, fps)
     elif source_software == "SLEAP":
         return from_sleap_file(file_path, fps)
-    elif source_software == "SLEAP":
+    elif source_software == "LightningPose":
         return from_lp_file(file_path, fps)
 
 

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -21,6 +21,45 @@ from movement.logging import log_error, log_warning
 logger = logging.getLogger(__name__)
 
 
+def from_file(
+    file_path: Union[Path, str],
+    source_software: Literal["DeepLabCut", "SLEAP", "LightningPose"],
+    fps: Optional[float] = None,
+) -> xr.Dataset:
+    """Load pose tracking data from a DeepLabCut (DLC), LightningPose (LP) or
+    SLEAP output file into an xarray Dataset.
+
+    Parameters
+    ----------
+    file_path : pathlib.Path or str
+        Path to the file containing the DLC predicted poses, either in .h5
+        or .csv format.
+    source_software : "DeepLabCut", "SLEAP" or "LightningPose"
+        The source software of the file.
+    fps : float, optional
+        The number of frames per second in the video. If None (default),
+        the `time` coordinates will be in frame numbers.
+
+    Returns
+    -------
+    xarray.Dataset
+        Dataset containing the pose tracks, confidence scores, and metadata.
+
+    Notes
+    -----
+    Identical to calling any of the functions from_dlc_file(),
+    from_sleap_file() or from_lp_file().
+
+    """
+
+    if source_software == "DeepLabCut":
+        return from_dlc_file(file_path, fps)
+    elif source_software == "SLEAP":
+        return from_sleap_file(file_path, fps)
+    elif source_software == "SLEAP":
+        return from_lp_file(file_path, fps)
+
+
 def from_dlc_df(df: pd.DataFrame, fps: Optional[float] = None) -> xr.Dataset:
     """Create an xarray.Dataset from a DeepLabCut-style pandas DataFrame.
 


### PR DESCRIPTION
## Description

**What is this PR**

Creates a generic function from_file() which is identical to: 
- from_dlc_file()
- from_sleap_file()
- from_lp_file()

Can be called by specifying source software, 

```python
def from_file(
    file_path: Union[Path, str],
    source_software: Literal["DeepLabCut", "SLEAP", "LightningPose"],
    fps: Optional[float] = None
``` 

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

## References

Closes #98 

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
