### PR TITLE
Include M1 runners in CI and update install instructions accordingly

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -29,8 +29,10 @@ jobs:
         # Run all supported Python versions on linux
         python-version: ["3.9", "3.10", "3.11"]
         os: [ubuntu-latest]
-        # Include one windows and macOS run
+        # Include 1 windows, 1 Intel mac and 1 M1 mac (macos-14) run
         include:
+        - os: macos-14
+          python-version: "3.10"
         - os: macos-latest
           python-version: "3.10"
         - os: windows-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,12 +9,15 @@ or [mamba](mamba:) to create a
 development environment for movement. In the following we assume you have
 `conda` installed, but the same commands will also work with `mamba`/`micromamba`.
 
-First, create and activate a `conda` environment:
+First, create and activate a `conda` environment with some prerequisites:
 
 ```sh
-conda create -n movement-dev python=3.10
+conda create -n movement-dev -c conda-forge python=3.10 hdf5
 conda activate movement-dev
 ```
+
+The above method ensures that you will get packages that often can't be
+installed via `pip`, including [hdf5](https://www.hdfgroup.org/solutions/hdf5/).
 
 To install movement for development, clone the GitHub repository,
 and then run from inside the repository:

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -8,18 +8,17 @@ We recommend you install movement inside a [conda](conda:)
 or [mamba](mamba:) environment, to avoid dependency conflicts with other packages.
 In the following we assume you have `conda` installed,
 but the same commands will also work with `mamba`/`micromamba`.
+:::
 
-
-First, create and activate an environment.
+First, create and activate an environment with some prerequisites.
 You can call your environment whatever you like, we've used "movement-env".
 
 ```sh
-conda create -n movement-env python=3.10
+conda create -n movement-env -c conda-forge python=3.10 hdf5
 conda activate movement-env
 ```
 
 Then install the `movement` package as described below.
-:::
 
 ::::{tab-set}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,37 +1,37 @@
 [project]
 name = "movement"
 authors = [
-  {name = "Niko Sirmpilatze", email = "niko.sirbiladze@gmail.com"},
-  {name = "Chang Huan Lo", email = "changhuan.lo@ucl.ac.uk"},
+  { name = "Niko Sirmpilatze", email = "niko.sirbiladze@gmail.com" },
+  { name = "Chang Huan Lo", email = "changhuan.lo@ucl.ac.uk" },
 ]
 description = "Analysis of body movement"
 readme = "README.md"
 requires-python = ">=3.9.0"
 dynamic = ["version"]
 
-license = {text = "BSD-3-Clause"}
+license = { text = "BSD-3-Clause" }
 
 dependencies = [
-    "numpy",
-    "pandas[hdf5]",
-    "h5py",
-    "attrs",
-    "pooch",
-    "tqdm",
-    "sleap-io",
-    "xarray",
-    "PyYAML",
+  "numpy",
+  "pandas[hdf5]",
+  "h5py",
+  "attrs",
+  "pooch",
+  "tqdm",
+  "sleap-io",
+  "xarray",
+  "PyYAML",
 ]
 
 classifiers = [
-    "Development Status :: 2 - Pre-Alpha",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Operating System :: OS Independent",
-    "License :: OSI Approved :: BSD License",
+  "Development Status :: 2 - Pre-Alpha",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Operating System :: OS Independent",
+  "License :: OSI Approved :: BSD License",
 ]
 
 [project.urls]
@@ -60,11 +60,7 @@ dev = [
 ]
 
 [build-system]
-requires = [
-    "setuptools>=45",
-    "wheel",
-    "setuptools_scm[toml]>=6.2",
-]
+requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
@@ -97,16 +93,12 @@ ignore = [
 ]
 
 [[tool.mypy.overrides]]
-module = [
-  "pooch.*",
-  "h5py.*",
-  "sleap_io.*",
-]
+module = ["pooch.*", "h5py.*", "sleap_io.*"]
 ignore_missing_imports = true
 
 [tool.ruff]
 line-length = 79
-exclude = ["__init__.py","build",".eggs"]
+exclude = ["__init__.py", "build", ".eggs"]
 select = ["I", "E", "F"]
 fix = true
 
@@ -119,6 +111,7 @@ archs = ["x86_64", "arm64"]
 [tool.tox]
 legacy_tox_ini = """
 [tox]
+requires = tox-conda
 envlist = py{39,310,311}
 isolated_build = True
 
@@ -129,6 +122,10 @@ python =
     3.11: py311
 
 [testenv]
+conda_deps =
+    hdf5
+conda_channels =
+    conda-forge
 extras =
     dev
 commands =


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

- Many of our users will use M1/2 Macs
- We want to double-check if simple pip install works on M1/2 Macs (or if we have to revert to conda, see #104)

## References

closes  #123 

## How has this PR been tested?

The real test are the CI checks in this PR.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)

## EDIT 2024-02-26
The CI tests were failing on M1 runners, because the hdf5 binaries could not be found (see discussion below). Therefore, this PR has been amended to also change `movement`'s installation procedure, which should now be:

```bash
conda create -n movement-env -c conda-forge python=3.10 hdf5
conda activate movement-env
pip install movement
```
The above should work cross-platform.
I've renamed the PR from "Include CI tests on macOS 14 M1 runner" to "Include M1 runners in CI and update install instructions accordingly".
