### PR TITLE
Add codecov token to test_and_deploy.yml

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -49,6 +49,7 @@ jobs:
       - uses: neuroinformatics-unit/actions/test@v2
         with:
           python-version: ${{ matrix.python-version }}
+          secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   build_sdist_wheels:
     name: Build source distribution

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -46,7 +46,7 @@ jobs:
             ~/.movement/*
           key: cached-test-data
           enableCrossOsArchive: true
-      - uses: neuroinformatics-unit/actions/test@main
+      - uses: neuroinformatics-unit/actions/test@v2
         with:
           python-version: ${{ matrix.python-version }}
           secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -46,7 +46,7 @@ jobs:
             ~/.movement/*
           key: cached-test-data
           enableCrossOsArchive: true
-      - uses: neuroinformatics-unit/actions/test@v2
+      - uses: neuroinformatics-unit/actions/test@main
         with:
           python-version: ${{ matrix.python-version }}
           secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This will have to wait until @lochhh has tested the updated action in [PR 128](https://github.com/neuroinformatics-unit/movement/pull/128), and a new v2 release of NIU actions is made.
- [x] test updated action from `neuroinformatics-unit/actions/test@main`
- [x]  release a new v2 version of `neuroinformatics-unit/actions`
