### PR TITLE
Add binder configuration and dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,6 +213,13 @@ To add new examples, you will need to create a new `.py` file in `examples/`.
 The file should be structured as specified in the relevant
 [sphinx-gallery documentation](sphinx-gallery:syntax).
 
+We are using sphinx-gallery's [integration with binder](https://sphinx-gallery.github.io/stable/configuration.html#binder-links)
+to provide interactive versions of the examples.
+If your examples rely on packages that are not among movement's dependencies,
+you will need to add them to the `docs/source/environment.yml` file.
+That file is used by binder to create the conda environment in which the
+examples are run. See the relevant section of the
+[binder documentation](https://mybinder.readthedocs.io/en/latest/using/config_files.html).
 
 ### Building the documentation locally
 We recommend that you build and view the documentation website locally, before you push it.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -96,6 +96,15 @@ sphinx_gallery_conf = {
     "filename_pattern": "/*.py",  # which files to execute before inclusion
     "gallery_dirs": ["examples"],  # output directory
     "run_stale_examples": True,  # re-run examples on each build
+    # Integration with Binder, see https://sphinx-gallery.github.io/stable/configuration.html#generate-binder-links-for-gallery-notebooks-experimental
+    "binder": {
+        "org": "neuroinformatics-unit",
+        "repo": "movement",
+        "branch": "gh-pages",
+        "binderhub_url": "https://mybinder.org",
+        "dependencies": ["environment.yml"],
+
+     },
 }
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/source/environment.yml
+++ b/docs/source/environment.yml
@@ -1,0 +1,10 @@
+# Requirements for Binder
+# i.e. what is needed to run the example notebooks
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  - pytables
+  - pip:
+    - movement
+    - matplotlib


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Would be nice for people to be able to interactively run our sphinx-gallery examples in the browser, without the need for installing anything.

**What does this PR do?**
It configures `sphinx-gallery` to integrate with binder, as described in the [relevant section of sphinx-gallery docs](https://sphinx-gallery.github.io/stable/configuration.html#binder-links).
It also adds an `environment.yml` file which specifies the dependencies needed for binder to run the examples. It was not possible to simply reuse the `pyproject.toml` or the `docs/requirements.txt` file for this purpose.  This is probably not a bad thing, since the examples may rely on additional packages that are not among our dependencies, and sphinx-related dependencies (found in `docs/requirements.txt`) are not needed for binder to run the notebooks. So we have to live with (and maintain) an additional dependency file.

> [!NOTE]
> Moreover, the binder `environment.yml` file will install the latest `movement` version from pip, which is probably fine, since the environment will be instantiated when someone fires up a binder instance (not during the docs build). This is fine I think, since we anyway want all examples to work with every latest release of `movement`.

## References

Closes #134

## How has this PR been tested?

I'm not sure how to test it without merging this PR and releasing a new version.
By building the examples locally, I could verify that the built jupyter notebooks are placed in the correct folder in the docs, and that the binder link appears within the examples (see screenshot).

![Screenshot 2024-03-14 at 14 54 04](https://github.com/neuroinformatics-unit/movement/assets/20923448/ae470b38-1f2a-4015-ba3a-de01fe18e9ed)

To actually run the examples, binder needs to get the notebooks from the `gh-pages` branch, which gets updated only when the docs are built anew (typically triggered by a new release)

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

If any features have changed, or have been added. Please explain how the
documentation has been updated.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
