### PR TITLE
Add and configure codespell

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -15,6 +15,13 @@ on:
   workflow_dispatch:
 
 jobs:
+  linting:
+    # scheduled workflows should not run on forks
+    if: (${{ github.event_name == 'schedule' }} && ${{ github.repository_owner == 'neuroinformatics-unit' }} && ${{ github.ref == 'refs/heads/main' }}) || (${{ github.event_name != 'schedule' }})
+    runs-on: ubuntu-latest
+    steps:
+      - uses: neuroinformatics-unit/actions/lint@v2
+
   build_sphinx_docs:
     name: Build Sphinx Docs
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,4 +46,5 @@ repos:
       hooks:
       - id: codespell
         additional_dependencies:
+        # tomli dependency can be removed when we drop support for Python 3.10
         - tomli

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,10 @@ repos:
           - id: check-manifest
             args: [--no-build-isolation]
             additional_dependencies: [setuptools-scm]
+    - repo: https://github.com/codespell-project/codespell
+      # Configuration for codespell is in pyproject.toml
+      rev: v2.2.6
+      hooks:
+      - id: codespell
+        additional_dependencies:
+        - tomli

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,7 @@ Running `pre-commit install` will set up [pre-commit hooks](https://pre-commit.c
 * [black](https://black.readthedocs.io/en/stable/) for auto-formatting
 * [mypy](https://mypy.readthedocs.io/en/stable/index.html) as a static type checker
 * [check-manifest](https://github.com/mgedmin/check-manifest) to ensure that the right files are included in the pip package.
+* [codespell](https://github.com/codespell-project/codespell) to check for common misspellings.
 
 These will prevent code from being committed if any of these hooks fail. To run them individually (from the root of the repository), you can use:
 
@@ -78,6 +79,7 @@ ruff .
 black ./
 mypy -p movement
 check-manifest
+codespell
 ```
 
 To run all the hooks before committing:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ We use [Sphinx](https://www.sphinx-doc.org/en/master/) and the
 to build the source files into HTML output.
 This is handled by a GitHub actions workflow (`.github/workflows/docs_build_and_deploy.yml`).
 The build job is triggered on each PR, ensuring that the documentation build is not broken by new changes.
-The deployment job is only triggerred whenever a tag is pushed to the _main_ branch,
+The deployment job is only triggered whenever a tag is pushed to the _main_ branch,
 ensuring that the documentation is published in sync with each PyPI release.
 
 ### Editing the documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
   "mypy",
   "pre-commit",
   "ruff",
+  "codespell",
   "setuptools_scm",
   "pandas-stubs",
   "types-attrs",
@@ -109,7 +110,7 @@ build = "cp39-* cp310-* cp311-*"
 archs = ["x86_64", "arm64"]
 
 [tool.codespell]
-skip = '.git'
+skip = '.git,.tox'
 check-hidden = true
 
 [tool.tox]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,10 @@ build = "cp39-* cp310-* cp311-*"
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]
 
+[tool.codespell]
+skip = '.git'
+check-hidden = true
+
 [tool.tox]
 legacy_tox_ini = """
 [tox]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -236,7 +236,7 @@ def valid_tracks_array():
 def valid_pose_dataset(valid_tracks_array, request):
     """Return a valid pose tracks dataset."""
     dim_names = MoveAccessor.dim_names
-    # create a multi_track_array by default unless overriden via param
+    # create a multi_track_array by default unless overridden via param
     try:
         array_format = request.param
     except AttributeError:


### PR DESCRIPTION
We are already using `codespell` on several other repos and it works quite well for catching common misspellings.