### PR TITLE
use Dataset.sizes instead of Dataset.dims for getting dimension sizes

### DIFF
--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -40,8 +40,8 @@ def _xarray_to_dlc_df(ds: xr.Dataset, columns: pd.MultiIndex) -> pd.DataFrame:
 
     # Create DataFrame with multi-index columns
     df = pd.DataFrame(
-        data=tracks_with_scores.reshape(ds.dims["time"], -1),
-        index=np.arange(ds.dims["time"], dtype=int),
+        data=tracks_with_scores.reshape(ds.sizes["time"], -1),
+        index=np.arange(ds.sizes["time"], dtype=int),
         columns=columns,
         dtype=float,
     )

--- a/tests/test_unit/test_load_poses.py
+++ b/tests/test_unit/test_load_poses.py
@@ -82,7 +82,7 @@ class TestLoadPoses:
         DIM_NAMES = MoveAccessor.dim_names
         assert all([i in dataset.dims for i in DIM_NAMES])
         for d, dim in enumerate(DIM_NAMES[1:]):
-            assert dataset.dims[dim] == dataset.position.shape[d + 1]
+            assert dataset.sizes[dim] == dataset.position.shape[d + 1]
             assert all(
                 [isinstance(s, str) for s in dataset.coords[dim].values]
             )
@@ -208,7 +208,7 @@ class TestLoadPoses:
             assert ds.fps == expected_fps
             np.testing.assert_allclose(
                 ds.coords["time"].data,
-                np.arange(ds.dims["time"], dtype=int) / ds.attrs["fps"],
+                np.arange(ds.sizes["time"], dtype=int) / ds.attrs["fps"],
             )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Multiple instances of the following warning are being raised during tests:
> FutureWarning: The return type of `Dataset.dims` will be changed to return a set of dimension names in future, in order to be more consistent with `DataArray.dims`. To access a mapping from dimension names to lengths, please use `Dataset.sizes`

**What does this PR do?**

It uses `Datasets.sizes` instead of `Dataset.dims` when getting the lengths of each dimension. `Dataset.dims` is still in use when we simply want the names of the dimensions.

## How has this PR been tested?

Existing tests still pass.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
