### PR TITLE
add merge_group as workflow trigger

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -12,6 +12,7 @@ on:
     tags:
       - '*'
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -7,6 +7,7 @@ on:
     tags:
       - '*'
   pull_request:
+  merge_group:
 
 jobs:
   linting:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,7 @@ A typical PR workflow would be:
 * Push your changes to GitHub and open a draft pull request, with a meaningful title and a thorough description of the changes.
 * If all checks (e.g. linting, type checking, testing) run successfully, you may mark the pull request as ready for review.
 * Respond to review comments and implement any requested changes.
+* One of the maintainers will approve the PR and add it to the [merge queue](https://github.blog/changelog/2023-02-08-pull-request-merge-queue-public-beta/).
 * Success 🎉 !! Your PR will be (squash-)merged into the _main_ branch.
 
 ## Development guidelines


### PR DESCRIPTION
I've enabled [Merge Queues](https://github.blog/changelog/2023-02-08-pull-request-merge-queue-public-beta/) for the `main` branch.
For this to work in conjunction with our CI, `merge_group` has to be added as a workflow trigger. This [trigger will be emitted when a PR is marked as "Merge when Ready"](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions).

In our day-to-day work this simply means that PRs are accepted by clicking "Merge when Ready" and Github will automatically perform the necessary CI checks and merge PRs in first-in-first-out order.

It was not immediately apparent to me why the new "merge_group" trigger is needed. This [post](https://medium.com/@kojoru/how-to-set-up-merge-queues-in-github-actions-59381e5f435a) explains it:
> The merge queues are based on two other features of GitHub you’ll need to understand first: branch protection rules and automerging of pull requests.
>
>Branch protection rules allow you to force a certain set of ceremonies around merging to your branch. For example, you can forbid directly pushing to main or force a CI run before merging. If you are looking into merge queues, you probably > have both of those already enabled.
>
>The merge queues themselves are also a form of branch protection so this is a new checkbox you’ll need to enable in that interface.
>
>Automerging is a feature on top of the protection rules. It allows you to press the “Merge” button before the CI is finished, and the merge will be performed when/if it’s successful.
>
>Merge queues surprisingly do not replace the CI step before the automerge, but instead adds a separate later step to it. So, the end flow looks like that:
>
> 1. A pull request is created.
> 2. CI runs on the pull request’s unmerged code.
> 3. At any point before, during or after the CI run the PR is marked for merge.
> 4. If the CI succeeded, the pull request is put in the merge queue.
> 5. In the merge queue, a separate CI is run on the merged code.
> 6. If that succeeds, the pull request is merged (provided the rest of the queue also got merged before that).

The thing that worries me about this is that we would be running our checks multiple times, i.e. during a push on the feature branch, when a PR is opened, then again when it's put in the merge queue, and again after being merged to main.
That amount of checking seems excessive to me, and perhaps we need to rethink our CI workflow? Or perhaps we are not at the scale of needing merge queues yet. They seem to be most useful for repos with multiple merges per day.