### PR TITLE
Add viz extras to xarray dependency

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,5 @@
 -e .
 linkify-it-py
-matplotlib
 myst-parser
 nbsphinx
 pydata-sphinx-theme

--- a/docs/source/environment.yml
+++ b/docs/source/environment.yml
@@ -7,4 +7,3 @@ dependencies:
   - pytables
   - pip:
     - movement
-    - matplotlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "pooch",
   "tqdm",
   "sleap-io",
-  "xarray[accel]",
+  "xarray[accel,viz]",
   "PyYAML",
 ]
 


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Closes #158 . Thanks @antortjim for reporting the bug.

**What does this PR do?**

We now depend on `xarray[accel,viz]`, instead of just `xarray[accel]`, meaning we also require `matplotlib` and `seaborn`.

Accordingly, `matplotlib` is no longer listed as an additional dependency for docs and binder (no need, since it will now come bundled with `movement`).

## References

See #158 and [xarray's installation instructions](https://docs.xarray.dev/en/stable/getting-started-guide/installing.html#instructions).

## How has this PR been tested?
Example notebooks were run in a fresh environment.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
