### PR TITLE
Implement Median and Savitzky-Golay Filters

### DIFF
--- a/movement/filtering.py
+++ b/movement/filtering.py
@@ -187,10 +187,6 @@ def median_filter(ds: xr.Dataset, window_length: int = 3) -> xr.Dataset:
         The provided dataset (ds), where pose tracks have been smoothed
         using a median filter with the provided parameters
     """
-    # TODO: I'll start by implementing this as a separate fxn, but later
-    #  down the line we can consider clumping smoothing fxns into a single
-    #  fxn where method can just be passed as a kwarg (similar to DLC's
-    #  implementation).
 
     ds_smoothed = ds.copy()
 

--- a/movement/filtering.py
+++ b/movement/filtering.py
@@ -168,9 +168,7 @@ def filter_by_confidence(
 
 
 @log_to_attrs
-def median_filter(
-    ds: Union[xr.Dataset, xr.DataArray], window_length: int, **kwargs
-) -> xr.Dataset:
+def median_filter(ds: xr.Dataset, window_length: int) -> xr.Dataset:
     """Smooths pose tracks by applying a median filter over time.
 
     Parameters
@@ -180,9 +178,6 @@ def median_filter(
     window_length : int
         The size of the filter window. Window length is interpreted
         as being in the input dataset's time unit.
-    **kwargs : dict
-        Additional keyword arguments are passed to scipy.ndimage.median_filter.
-        Note that the ``axis`` keyword argument may not be overridden.
 
     Returns
     -------
@@ -191,8 +186,6 @@ def median_filter(
         using a median filter with the provided parameters.
 
     """
-    assert "axes" not in kwargs, "The ``axes`` argument may not be overridden."
-
     ds_smoothed = ds.copy()
 
     if ds.time_unit == "seconds":
@@ -211,7 +204,7 @@ def median_filter(
 
 @log_to_attrs
 def savgol_filter(
-    ds: Union[xr.Dataset, xr.DataArray],
+    ds: xr.Dataset,
     window_length: int,
     polyorder: int = 2,
     **kwargs,
@@ -227,7 +220,8 @@ def savgol_filter(
         as being in the input dataset's time unit.
     polyorder : int
         The order of the polynomial used to fit the samples. Must be
-        less than ``window_length``.
+        less than ``window_length``. By default, a ``polyorder`` of
+        2 is used.
     **kwargs : dict
         Additional keyword arguments are passed to scipy.signal.savgol_filter.
         Note that the ``axis`` keyword argument may not be overridden.

--- a/movement/filtering.py
+++ b/movement/filtering.py
@@ -243,7 +243,12 @@ def savgol_filter(
     ds_smoothed.update(
         {
             "position": signal.savgol_filter(
-                ds.position, window_length, polyorder, axis=0
+                ds.position,
+                window_length,
+                polyorder,
+                axis=0,
+                mode="constant",
+                cval=nan,
             )
         }
     )

--- a/movement/filtering.py
+++ b/movement/filtering.py
@@ -185,6 +185,17 @@ def median_filter(ds: xr.Dataset, window_length: int) -> xr.Dataset:
         The provided dataset (ds), where pose tracks have been smoothed
         using a median filter with the provided parameters.
 
+    Notes
+    -----
+    This function is not robust to the presence of NaNs in the input
+    dataset - whenever one or more NaNs is present in the filter
+    window, a NaN is returned to the output array. As a result, any
+    stretch of NaNs present in the input dataset will be propagated
+    proportionally to the size of the window (specifically, by
+    ``floor(window_length/2)``). Additionally, this filter introduces
+    new NaNs at each edge of the input array (i.e. in the first and
+    last ``floor(window_length/2)`` frames).
+
     """
     ds_smoothed = ds.copy()
 
@@ -232,6 +243,17 @@ def savgol_filter(
     ds_smoothed : xarray.Dataset
         The provided dataset (ds), where pose tracks have been smoothed
         using a Savitzky-Golay filter with the provided parameters.
+
+    Notes
+    -----
+    This function is not robust to the presence of NaNs in the input
+    dataset - whenever one or more NaNs is present in the filter
+    window, a NaN is returned to the output array. As a result, any
+    stretch of NaNs present in the input dataset will be propagated
+    proportionally to the size of the window (specifically, by
+    ``floor(window_length/2)``). Note that, unlike
+    ``movement.filtering.median_filter()``, this function does not
+    introduce new NaNs at the beginning and end of the input array.
 
     """
     assert "axis" not in kwargs, "The ``axis`` argument may not be overridden."

--- a/movement/filtering.py
+++ b/movement/filtering.py
@@ -49,7 +49,7 @@ def report_nan_values(ds: xr.Dataset, ds_label: str = "dataset"):
     Parameters
     ----------
     ds : xarray.Dataset
-        Dataset containing pose tracks, confidence scores, and metadata.
+        Dataset containing position, confidence scores, and metadata.
     ds_label : str
         Label to identify the dataset in the report. Default is "dataset".
 
@@ -87,7 +87,7 @@ def interpolate_over_time(
     Parameters
     ----------
     ds : xarray.Dataset
-        Dataset containing pose tracks, confidence scores, and metadata.
+        Dataset containing position, confidence scores, and metadata.
     method : str
         String indicating which method to use for interpolation.
         Default is ``linear``. See documentation for
@@ -131,7 +131,7 @@ def filter_by_confidence(
     Parameters
     ----------
     ds : xarray.Dataset
-        Dataset containing pose tracks, confidence scores, and metadata.
+        Dataset containing position, confidence scores, and metadata.
     threshold : float
         The confidence threshold below which datapoints are filtered.
         A default value of ``0.6`` is used. See notes for more information.
@@ -177,7 +177,7 @@ def median_filter(ds: xr.Dataset, window_length: int = 3) -> xr.Dataset:
     Parameters
     ----------
     ds : xarray.Dataset
-        Dataset containing pose tracks, confidence scores, and metadata
+        Dataset containing position, confidence scores, and metadata
     window_length : int
         The size of the filter window
 
@@ -221,7 +221,7 @@ def savgol_filter(
     Parameters
     ----------
     ds : xarray.Dataset
-        Dataset containing pose tracks, confidence scores, and metadata
+        Dataset containing position, confidence scores, and metadata
 
     Returns
     -------

--- a/movement/filtering.py
+++ b/movement/filtering.py
@@ -254,7 +254,7 @@ def savgol_filter(
         axis=0,
         **kwargs,
     )
-    position_smoothed_da = ds.air.copy(data=position_smoothed)
+    position_smoothed_da = ds.position.copy(data=position_smoothed)
 
     ds_smoothed.update({"position": position_smoothed_da})
 

--- a/movement/filtering.py
+++ b/movement/filtering.py
@@ -187,16 +187,17 @@ def median_filter(ds: xr.Dataset, window_length: int = 3) -> xr.Dataset:
         The provided dataset (ds), where pose tracks have been smoothed
         using a median filter with the provided parameters
     """
-    # TODO: I'll start by implementing this as a separate fxn, but think
-    #  that ultimately it might be nicer to clump smoothing fxns into a
-    #  single fxn where method can just be passed as a kwarg.
+    # TODO: I'll start by implementing this as a separate fxn, but later
+    #  down the line we can consider clumping smoothing fxns into a single
+    #  fxn where method can just be passed as a kwarg (similar to DLC's
+    #  implementation).
 
     ds_smoothed = ds.copy()
 
     ds_smoothed.update(
         {
-            "pose_tracks": ndimage.median_filter(
-                ds.pose_tracks,
+            "position": ndimage.median_filter(
+                ds.position,
                 size=window_length,
                 axes=0,
                 mode="constant",
@@ -241,8 +242,8 @@ def savgol_filter(
 
     ds_smoothed.update(
         {
-            "pose_tracks": signal.savgol_filter(
-                ds.pose_tracks, window_length, polyorder, axis=0
+            "position": signal.savgol_filter(
+                ds.position, window_length, polyorder, axis=0
             )
         }
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -343,9 +343,11 @@ class Helpers:
         )
         return n_nans
 
+    @staticmethod
     def count_nan_repeats(ds):
-        """Count the number of NaN repeats in the x coordinate timeseries
-        of the first keypoint of the first individual in the dataset.
+        """Count the number of continuous stretches of NaNs in the
+        x coordinate timeseries of the first keypoint of the first individual
+        in the dataset.
         """
         x = ds.position.isel(individuals=0, keypoints=0, space=0).values
         repeats = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -343,6 +343,27 @@ class Helpers:
         )
         return n_nans
 
+    def count_nan_repeats(ds):
+        """Count the number of NaN repeats in the x coordinate timeseries
+        of the first keypoint of the first individual in the dataset.
+        """
+        x = ds.position.isel(individuals=0, keypoints=0, space=0).values
+        repeats = []
+        running_count = 1
+        for i in range(len(x)):
+            if i != len(x) - 1:
+                if np.isnan(x[i]) and np.isnan(x[i + 1]):
+                    running_count += 1
+                elif np.isnan(x[i]):
+                    repeats.append(running_count)
+                    running_count = 1
+                else:
+                    running_count = 1
+            elif np.isnan(x[i]):
+                repeats.append(running_count)
+                running_count = 1
+        return len(repeats)
+
 
 @pytest.fixture
 def helpers():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -326,3 +326,25 @@ def invalid_poses_dataset(request):
 def kinematic_property(request):
     """Return a kinematic property."""
     return request.param
+
+
+class Helpers:
+    """Generic helper methods for ``movement`` testing modules."""
+
+    @staticmethod
+    def count_nans(ds):
+        """Count NaNs in the x coordinate timeseries of the first keypoint
+        of the first individual in the dataset.
+        """
+        n_nans = np.count_nonzero(
+            np.isnan(
+                ds.position.isel(individuals=0, keypoints=0, space=0).values
+            )
+        )
+        return n_nans
+
+
+@pytest.fixture
+def helpers():
+    """Return an instance of the ``Helpers`` class."""
+    return Helpers

--- a/tests/test_integration/test_filtering.py
+++ b/tests/test_integration/test_filtering.py
@@ -1,0 +1,72 @@
+import pytest
+
+from movement.filtering import (
+    filter_by_confidence,
+    interpolate_over_time,
+    median_filter,
+    savgol_filter,
+)
+from movement.io import load_poses
+from movement.sample_data import fetch_dataset_paths
+
+
+@pytest.fixture(scope="module")
+def sample_dataset():
+    """Return a single-animal sample dataset, with time unit in frames.
+    This allows us to better control the expected number of NaNs in the tests.
+    """
+    ds_path = fetch_dataset_paths("DLC_single-mouse_EPM.predictions.h5")[
+        "poses"
+    ]
+    return load_poses.from_dlc_file(ds_path, fps=None)
+
+
+@pytest.mark.parametrize("window_length", [3, 5, 6, 13])
+def test_nan_propagation_through_filters(
+    sample_dataset, window_length, helpers
+):
+    """Tests how NaNs are propagated when passing a dataset through multiple
+    filters sequentially. For the ``median_filter`` and ``savgol_filter``,
+    we expect the number of NaNs to increase at most by the filter's window
+    length minus one (``window_length - 1``) multiplied by the number of
+    continuous stretches of NaNs present in the input dataset.
+    """
+    # Introduce nans via filter_by_confidence
+    ds_with_nans = filter_by_confidence(sample_dataset, threshold=0.6)
+    nans_after_confilt = helpers.count_nans(ds_with_nans)
+    nan_repeats_after_confilt = helpers.count_nan_repeats(ds_with_nans)
+    assert nans_after_confilt == 2555, (
+        f"Unexpected number of NaNs in filtered dataset: "
+        f"expected: 2555, got: {nans_after_confilt}"
+    )
+
+    # Apply median filter and check that
+    # it doesn't introduce too many or too few NaNs
+    ds_medfilt = median_filter(ds_with_nans, window_length)
+    nans_after_medfilt = helpers.count_nans(ds_medfilt)
+    nan_repeats_after_medfilt = helpers.count_nan_repeats(ds_medfilt)
+    max_nans_increase = (window_length - 1) * nan_repeats_after_confilt
+    assert (
+        nans_after_medfilt <= nans_after_confilt + max_nans_increase
+    ), "Median filter introduced more NaNs than expected."
+    assert (
+        nans_after_medfilt >= nans_after_confilt
+    ), "Median filter mysteriously removed NaNs."
+
+    # Apply savgol filter and check that
+    # it doesn't introduce too many or too few NaNs
+    ds_savgol = savgol_filter(
+        ds_medfilt, window_length, polyorder=2, print_report=True
+    )
+    nans_after_savgol = helpers.count_nans(ds_savgol)
+    max_nans_increase = (window_length - 1) * nan_repeats_after_medfilt
+    assert (
+        nans_after_savgol <= nans_after_medfilt + max_nans_increase
+    ), "Savgol filter introduced more NaNs than expected."
+    assert (
+        nans_after_savgol >= nans_after_medfilt
+    ), "Savgol filter mysteriously removed NaNs."
+
+    # Apply interpolate_over_time (without max_gap) to eliminate all NaNs
+    ds_interpolated = interpolate_over_time(ds_savgol, print_report=True)
+    assert helpers.count_nans(ds_interpolated) == 0

--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -6,6 +6,8 @@ from movement.filtering import (
     filter_by_confidence,
     interpolate_over_time,
     log_to_attrs,
+    median_filter,
+    savgol_filter,
 )
 from movement.sample_data import fetch_dataset
 
@@ -35,6 +37,17 @@ def test_log_to_attrs(sample_dataset):
     )
 
 
+def count_nans(ds):
+    n_nans = np.count_nonzero(
+        np.isnan(
+            ds.position.sel(
+                individuals="individual_0", keypoints="snout"
+            ).values[:, 0]
+        )
+    )
+    return n_nans
+
+
 def test_interpolate_over_time(sample_dataset):
     """Test the ``interpolate_over_time`` function.
 
@@ -44,21 +57,11 @@ def test_interpolate_over_time(sample_dataset):
     ds_filtered = filter_by_confidence(sample_dataset)
     ds_interpolated = interpolate_over_time(ds_filtered)
 
-    def count_nans(ds):
-        n_nans = np.count_nonzero(
-            np.isnan(
-                ds.position.sel(
-                    individuals="individual_0", keypoints="snout"
-                ).values[:, 0]
-            )
-        )
-        return n_nans
-
     assert count_nans(ds_interpolated) < count_nans(ds_filtered)
 
 
 def test_filter_by_confidence(sample_dataset, caplog):
-    """Tests for the ``filter_by_confidence`` function.
+    """Tests for the ``filter_by_confidence()`` function.
     Checks that the function filters the expected amount of values
     from a known dataset, and tests that this value is logged
     correctly.
@@ -78,3 +81,30 @@ def test_filter_by_confidence(sample_dataset, caplog):
 
     # Check that diagnostics are being logged correctly
     assert f"snout: {n_nans}/{ds_filtered.time.values.shape[0]}" in caplog.text
+
+
+def test_median_filter(sample_dataset):
+    """Tests for the ``median_filter()`` function. Checks that
+    the function successfully receives the input data and
+    returns a different xr.Dataset with the correct dimensions.
+    """
+    ds_smoothed = median_filter(sample_dataset)
+
+    # Test whether filter received and returned correct data
+    assert isinstance(ds_smoothed, xr.Dataset) and ~(
+        ds_smoothed == sample_dataset
+    )
+    assert ds_smoothed.position.shape == sample_dataset.position.shape
+
+
+def test_savgol_filter(sample_dataset):
+    """Tests for the ``savgol_filter()`` function.
+    Checks that ... .
+    """
+    ds_smoothed = savgol_filter(sample_dataset)
+
+    # Test whether filter received and returned correct data
+    assert isinstance(ds_smoothed, xr.Dataset)
+    assert ds_smoothed.position.shape == sample_dataset.position.shape
+
+    # TODO: Test that NaNs are not propagated

--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 import xarray as xr
 
@@ -14,7 +13,7 @@ from movement.sample_data import fetch_dataset
 
 @pytest.fixture(scope="module")
 def sample_dataset():
-    """Return a single-individual sample dataset."""
+    """Return a single-animal sample dataset, with time unit in seconds."""
     return fetch_dataset("DLC_single-mouse_EPM.predictions.h5")
 
 
@@ -37,18 +36,7 @@ def test_log_to_attrs(sample_dataset):
     )
 
 
-def count_nans(ds):
-    n_nans = np.count_nonzero(
-        np.isnan(
-            ds.position.sel(
-                individuals="individual_0", keypoints="snout"
-            ).values[:, 0]
-        )
-    )
-    return n_nans
-
-
-def test_interpolate_over_time(sample_dataset):
+def test_interpolate_over_time(sample_dataset, helpers):
     """Test the ``interpolate_over_time`` function.
 
     Check that the number of nans is decreased after running this function
@@ -57,38 +45,35 @@ def test_interpolate_over_time(sample_dataset):
     ds_filtered = filter_by_confidence(sample_dataset)
     ds_interpolated = interpolate_over_time(ds_filtered)
 
-    assert count_nans(ds_interpolated) < count_nans(ds_filtered)
+    assert helpers.count_nans(ds_interpolated) < helpers.count_nans(
+        ds_filtered
+    )
 
 
-def test_filter_by_confidence(sample_dataset, caplog):
+def test_filter_by_confidence(sample_dataset, caplog, helpers):
     """Tests for the ``filter_by_confidence()`` function.
     Checks that the function filters the expected amount of values
     from a known dataset, and tests that this value is logged
     correctly.
     """
-    ds_filtered = filter_by_confidence(sample_dataset)
+    ds_filtered = filter_by_confidence(sample_dataset, threshold=0.6)
 
     assert isinstance(ds_filtered, xr.Dataset)
 
-    n_nans = np.count_nonzero(
-        np.isnan(
-            ds_filtered.position.sel(
-                individuals="individual_0", keypoints="snout"
-            ).values[:, 0]
-        )
-    )
+    n_nans = helpers.count_nans(ds_filtered)
     assert n_nans == 2555
 
     # Check that diagnostics are being logged correctly
     assert f"snout: {n_nans}/{ds_filtered.time.values.shape[0]}" in caplog.text
 
 
-def test_median_filter(sample_dataset):
+@pytest.mark.parametrize("window_size", [0.2, 1, 4, 12])
+def test_median_filter(sample_dataset, window_size):
     """Tests for the ``median_filter()`` function. Checks that
     the function successfully receives the input data and
     returns a different xr.Dataset with the correct dimensions.
     """
-    ds_smoothed = median_filter(sample_dataset, 1)
+    ds_smoothed = median_filter(sample_dataset, window_size)
 
     # Test whether filter received and returned correct data
     assert isinstance(ds_smoothed, xr.Dataset) and ~(
@@ -97,16 +82,63 @@ def test_median_filter(sample_dataset):
     assert ds_smoothed.position.shape == sample_dataset.position.shape
 
 
-def test_savgol_filter(sample_dataset):
+@pytest.mark.parametrize("window_length", [0.2, 1, 4, 12])
+@pytest.mark.parametrize("polyorder", [1, 2, 3])
+def test_savgol_filter(sample_dataset, window_length, polyorder):
     """Tests for the ``savgol_filter()`` function.
     Checks that the function successfully receives the input
     data and returns a different xr.Dataset with the correct
     dimensions.
     """
-    ds_smoothed = savgol_filter(sample_dataset, 1)
+    ds_smoothed = savgol_filter(
+        sample_dataset, window_length, polyorder=polyorder
+    )
 
     # Test whether filter received and returned correct data
     assert isinstance(ds_smoothed, xr.Dataset) and ~(
         ds_smoothed == sample_dataset
     )
     assert ds_smoothed.position.shape == sample_dataset.position.shape
+
+
+@pytest.mark.parametrize(
+    "override_kwargs",
+    [
+        {"mode": "nearest"},
+        {"axis": 1},
+        {"mode": "nearest", "axis": 1},
+    ],
+)
+def test_savgol_filter_kwargs_override(sample_dataset, override_kwargs):
+    """Further tests for the ``savgol_filter()`` function.
+    Checks that the function raises a ValueError when the ``axis`` keyword
+    argument is overridden, as this is not allowed. Overriding other keyword
+    arguments (e.g. ``mode``) should not raise an error.
+    """
+    if "axis" in override_kwargs:
+        with pytest.raises(ValueError):
+            savgol_filter(sample_dataset, 5, **override_kwargs)
+    else:
+        ds_smoothed = savgol_filter(sample_dataset, 5, **override_kwargs)
+        assert isinstance(ds_smoothed, xr.Dataset)
+
+
+def test_median_filter_with_nans(valid_poses_dataset_with_nan, helpers):
+    """Test nan behavior of the ``median_filter()`` function. The
+    ``valid_poses_dataset_with_nan`` dataset (fixture defined in conftest.py)
+    contains NaN values in all keypoints of the first individual at times
+    3, 7, and 8 (0-indexed, 10 total timepoints).
+    The median filter should propagate NaNs within the windows of the filter,
+    but it should not introduce any NaNs for the second individual.
+    """
+    ds_smoothed = median_filter(valid_poses_dataset_with_nan, 3)
+    # There should be NaNs at 7 timepoints for the first individual
+    # all except for timepoints 0, 1 and 5
+    assert helpers.count_nans(ds_smoothed) == 7
+    assert (
+        ~ds_smoothed.position.isel(individuals=0, time=[0, 1, 5])
+        .isnull()
+        .any()
+    )
+    # The second individual should not contain any NaNs
+    assert ~ds_smoothed.position.sel(individuals="ind2").isnull().any()

--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -88,7 +88,7 @@ def test_median_filter(sample_dataset):
     the function successfully receives the input data and
     returns a different xr.Dataset with the correct dimensions.
     """
-    ds_smoothed = median_filter(sample_dataset)
+    ds_smoothed = median_filter(sample_dataset, 1)
 
     # Test whether filter received and returned correct data
     assert isinstance(ds_smoothed, xr.Dataset) and ~(
@@ -99,12 +99,14 @@ def test_median_filter(sample_dataset):
 
 def test_savgol_filter(sample_dataset):
     """Tests for the ``savgol_filter()`` function.
-    Checks that ... .
+    Checks that the function successfully receives the input
+    data and returns a different xr.Dataset with the correct
+    dimensions.
     """
-    ds_smoothed = savgol_filter(sample_dataset)
+    ds_smoothed = savgol_filter(sample_dataset, 1)
 
     # Test whether filter received and returned correct data
-    assert isinstance(ds_smoothed, xr.Dataset)
+    assert isinstance(ds_smoothed, xr.Dataset) and ~(
+        ds_smoothed == sample_dataset
+    )
     assert ds_smoothed.position.shape == sample_dataset.position.shape
-
-    # TODO: Test that NaNs are not propagated

--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -149,8 +149,8 @@ def test_savgol_filter_with_nans(valid_poses_dataset_with_nan, helpers):
     ``valid_poses_dataset_with_nan`` dataset (fixture defined in conftest.py)
     contains NaN values in all keypoints of the first individual at times
     3, 7, and 8 (0-indexed, 10 total timepoints).
-    The median filter should propagate NaNs within the windows of the filter,
-    but it should not introduce any NaNs for the second individual.
+    The Savitzky-Golay filter should propagate NaNs within the windows of
+    the filter, but it should not introduce any NaNs for the second individual.
     """
     ds_smoothed = savgol_filter(valid_poses_dataset_with_nan, 3, polyorder=2)
     # There should be NaNs at 7 timepoints for the first individual


### PR DESCRIPTION
_Edited 08/05/2024_:

This PR introduces two new smoothing functions to the `filtering` module:

1. `median_filter(ds, window_length)`: Smooths pose tracks in the input dataset by applying a median filter along the time dimension. Window length must be specified by the user, and is interpreted as being in the input dataset's time unit (usually seconds). The filter window is centered over the filter origin.
2. `savgol_filter(ds, window_length, polyorder, **kwargs)`: Smooths pose tracks over time using a Savitzky-Golay filter. Again, window length must be specified by the user, and is interpreted as being in the input dataset's time unit. The order of the polynomial used to fit the samples can optionally be specified by the user. If omitted, a default value of `2` is used. Additional keyword arguments (`**kwargs`) are passed to  `scipy.signal.savgol_filter()` directly, but note that the `axis` kwarg may not be overwritten. 

**What is this PR**

- [ ] Bug fix
- [X] Addition of a new feature
- [ ] Other

## References

Closes #55, closes #139 

## Checklist:

- [X] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
