### PR TITLE
Enforce linting of docstrings

### DIFF
--- a/examples/compute_kinematics.py
+++ b/examples/compute_kinematics.py
@@ -1,7 +1,6 @@
 # ruff: noqa: E402
-"""
-Compute and visualise kinematics
-=================================
+"""Compute and visualise kinematics.
+====================================
 
 Compute displacement, velocity and acceleration data on an example dataset and
 visualise the results.

--- a/examples/filter_and_interpolate.py
+++ b/examples/filter_and_interpolate.py
@@ -1,5 +1,4 @@
-"""
-Filtering and interpolation
+"""Filtering and interpolation
 ============================
 
 Filter out points with low confidence scores and interpolate over

--- a/examples/load_and_explore_poses.py
+++ b/examples/load_and_explore_poses.py
@@ -1,5 +1,4 @@
-"""
-Load and explore pose tracks
+"""Load and explore pose tracks
 ============================
 
 Load and explore an example dataset of pose tracks.

--- a/movement/analysis/kinematics.py
+++ b/movement/analysis/kinematics.py
@@ -1,3 +1,5 @@
+"""Functions for computing kinematic variables."""
+
 import numpy as np
 import xarray as xr
 
@@ -5,8 +7,12 @@ from movement.logging import log_error
 
 
 def compute_displacement(data: xr.DataArray) -> xr.DataArray:
-    """Compute the displacement between consecutive positions
-    of each keypoint for each individual across time.
+    """Compute displacement between consecutive positions.
+
+    This is the difference between consecutive positions of each keypoint for
+    each individual across time. At each time point ``t``, it's defined as a
+    vector in cartesian ``(x,y)`` coordinates, pointing from the previous
+    ``(t-1)`` to the current ``(t)`` position.
 
     Parameters
     ----------
@@ -17,6 +23,7 @@ def compute_displacement(data: xr.DataArray) -> xr.DataArray:
     -------
     xarray.DataArray
         An xarray DataArray containing the computed displacement.
+
     """
     _validate_time_dimension(data)
     result = data.diff(dim="time")
@@ -25,8 +32,11 @@ def compute_displacement(data: xr.DataArray) -> xr.DataArray:
 
 
 def compute_velocity(data: xr.DataArray) -> xr.DataArray:
-    """Compute the velocity between consecutive positions
-    of each keypoint for each individual across time.
+    """Compute the velocity in cartesian ``(x,y)`` coordinates.
+
+    Velocity is the first derivative of position for each keypoint
+    and individual across time. It's computed using numerical differentiation
+    and assumes equidistant time spacing.
 
     Parameters
     ----------
@@ -38,17 +48,16 @@ def compute_velocity(data: xr.DataArray) -> xr.DataArray:
     xarray.DataArray
         An xarray DataArray containing the computed velocity.
 
-    Notes
-    -----
-    This function computes velocity using numerical differentiation
-    and assumes equidistant time spacing.
     """
     return _compute_approximate_derivative(data, order=1)
 
 
 def compute_acceleration(data: xr.DataArray) -> xr.DataArray:
-    """Compute the acceleration between consecutive positions
-    of each keypoint for each individual across time.
+    """Compute acceleration in cartesian ``(x,y)`` coordinates.
+
+    Acceleration represents the second derivative of position for each keypoint
+    and individual across time. It's computed using numerical differentiation
+    and assumes equidistant time spacing.
 
     Parameters
     ----------
@@ -60,10 +69,6 @@ def compute_acceleration(data: xr.DataArray) -> xr.DataArray:
     xarray.DataArray
         An xarray DataArray containing the computed acceleration.
 
-    Notes
-    -----
-    This function computes acceleration using numerical differentiation
-    and assumes equidistant time spacing.
     """
     return _compute_approximate_derivative(data, order=2)
 
@@ -71,8 +76,9 @@ def compute_acceleration(data: xr.DataArray) -> xr.DataArray:
 def _compute_approximate_derivative(
     data: xr.DataArray, order: int
 ) -> xr.DataArray:
-    """Compute velocity or acceleration using numerical differentiation,
-    assuming equidistant time spacing.
+    """Compute the derivative using numerical differentiation.
+
+    This assumes equidistant time spacing.
 
     Parameters
     ----------
@@ -86,6 +92,7 @@ def _compute_approximate_derivative(
     -------
     xarray.DataArray
         An xarray DataArray containing the derived variable.
+
     """
     if not isinstance(order, int):
         raise log_error(
@@ -119,6 +126,7 @@ def _validate_time_dimension(data: xr.DataArray) -> None:
     ------
     ValueError
         If the input data does not contain a ``time`` dimension.
+
     """
     if "time" not in data.dims:
         raise log_error(

--- a/movement/filtering.py
+++ b/movement/filtering.py
@@ -1,3 +1,5 @@
+"""Functions for filtering and interpolating pose tracks in xarray datasets."""
+
 import logging
 from datetime import datetime
 from functools import wraps
@@ -7,9 +9,9 @@ import xarray as xr
 
 
 def log_to_attrs(func):
-    """
-    Decorator that logs the operation performed by the wrapped function
-    and appends the log entry to the xarray.Dataset's "log" attribute.
+    """Log the operation performed by the wrapped function.
+
+    This decorator appends log entries to the xarray.Dataset's "log" attribute.
     For the decorator to work, the wrapped function must accept an
     xarray.Dataset as its first argument and return an xarray.Dataset.
     """
@@ -37,9 +39,9 @@ def log_to_attrs(func):
 
 
 def report_nan_values(ds: xr.Dataset, ds_label: str = "dataset"):
-    """
-    Report the number and percentage of points that are NaN for each individual
-    and each keypoint in the provided dataset.
+    """Report the number and percentage of points that are NaN.
+
+    Numbers are reported for each individual and keypoint in the dataset.
 
     Parameters
     ----------
@@ -47,8 +49,8 @@ def report_nan_values(ds: xr.Dataset, ds_label: str = "dataset"):
         Dataset containing pose tracks, confidence scores, and metadata.
     ds_label : str
         Label to identify the dataset in the report. Default is "dataset".
-    """
 
+    """
     # Compile the report
     nan_report = f"\nMissing points (marked as NaN) in {ds_label}:"
     for ind in ds.individuals.values:
@@ -77,8 +79,7 @@ def interpolate_over_time(
     max_gap: Union[int, None] = None,
     print_report: bool = True,
 ) -> Union[xr.Dataset, None]:
-    """
-    Fill in NaN values by interpolating over the time dimension.
+    """Fill in NaN values by interpolating over the time dimension.
 
     Parameters
     ----------
@@ -100,6 +101,7 @@ def interpolate_over_time(
     ds_interpolated : xr.Dataset
         The provided dataset (ds), where NaN values have been
         interpolated over using the parameters provided.
+
     """
     ds_interpolated = ds.copy()
     position_interpolated = ds.position.interpolate_na(
@@ -118,9 +120,10 @@ def filter_by_confidence(
     threshold: float = 0.6,
     print_report: bool = True,
 ) -> Union[xr.Dataset, None]:
-    """
-    Drop all points where the associated confidence value falls below a
-    user-defined threshold.
+    """Drop all points below a certain confidence threshold.
+
+    Position points with an associated confidence value below the threshold are
+    converted to NaN.
 
     Parameters
     ----------
@@ -150,6 +153,7 @@ def filter_by_confidence(
     datasets and does not have the same meaning across pose estimation
     frameworks. We advise users to inspect the confidence values
     in their dataset and adjust the threshold accordingly.
+
     """
     ds_thresholded = ds.copy()
     ds_thresholded.update(

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -28,7 +28,7 @@ def from_file(
     source_software: Literal["DeepLabCut", "SLEAP", "LightningPose"],
     fps: Optional[float] = None,
 ) -> xr.Dataset:
-    """Load pose tracking data from a any supported file format.
+    """Load pose tracking data from any supported file format.
 
     Data can be loaded from a DeepLabCut (DLC), LightningPose (LP) or
     SLEAP output file into an xarray Dataset.

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -153,7 +153,7 @@ def to_dlc_file(
     file_path: Union[str, Path],
     split_individuals: Union[bool, Literal["auto"]] = "auto",
 ) -> None:
-    r"""Save the xarray dataset to a DeepLabCut-style .h5 or .csv file.
+    """Save the xarray dataset to a DeepLabCut-style .h5 or .csv file.
 
     Parameters
     ----------
@@ -189,7 +189,7 @@ def to_dlc_file(
     >>> ds = load_poses.from_sleap_file("/path/to/file_sleap.analysis.h5")
     >>> save_poses.to_dlc_file(ds, "/path/to/file_dlc.h5")
 
-    """
+    """  # noqa: D301
     file = _validate_file_path(file_path, expected_suffix=[".csv", ".h5"])
 
     # Sets default behaviour for the function

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -1,3 +1,5 @@
+"""Functions for saving pose tracking data to various file formats."""
+
 import logging
 from pathlib import Path
 from typing import Literal, Union
@@ -14,8 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 def _xarray_to_dlc_df(ds: xr.Dataset, columns: pd.MultiIndex) -> pd.DataFrame:
-    """Takes an xarray dataset and DLC-style multi-index columns and outputs
-    a pandas dataframe.
+    """Convert an xarray dataset to DLC-style multi-index pandas DataFrame.
 
     Parameters
     ----------
@@ -27,8 +28,8 @@ def _xarray_to_dlc_df(ds: xr.Dataset, columns: pd.MultiIndex) -> pd.DataFrame:
     Returns
     -------
     pandas.DataFrame
-    """
 
+    """
     # Concatenate the pose tracks and confidence scores into one array
     tracks_with_scores = np.concatenate(
         (
@@ -50,9 +51,7 @@ def _xarray_to_dlc_df(ds: xr.Dataset, columns: pd.MultiIndex) -> pd.DataFrame:
 
 
 def _auto_split_individuals(ds: xr.Dataset) -> bool:
-    """Returns True if there is only one individual in the dataset,
-    else returns False."""
-
+    """Return True if there is only one individual in the dataset."""
     n_individuals = ds.sizes["individuals"]
     return n_individuals == 1
 
@@ -67,8 +66,8 @@ def _save_dlc_df(filepath: Path, df: pd.DataFrame) -> None:
         must be either .h5 (recommended) or .csv.
     df : pandas.DataFrame
         Pandas Dataframe to save
-    """
 
+    """
     if filepath.suffix == ".csv":
         df.to_csv(filepath, sep=",")
     else:  # at this point it can only be .h5 (because of validation)
@@ -78,9 +77,7 @@ def _save_dlc_df(filepath: Path, df: pd.DataFrame) -> None:
 def to_dlc_df(
     ds: xr.Dataset, split_individuals: bool = False
 ) -> Union[pd.DataFrame, dict[str, pd.DataFrame]]:
-    """Convert an xarray dataset containing pose tracks into a single
-    DeepLabCut-style pandas DataFrame or a dictionary of DataFrames
-    per individual, depending on the 'split_individuals' argument.
+    """Convert an xarray dataset to DeepLabCut-style pandas DataFrame(s).
 
     Parameters
     ----------
@@ -112,8 +109,8 @@ def to_dlc_df(
     --------
     to_dlc_file : Save the xarray dataset containing pose tracks directly
         to a DeepLabCut-style .h5 or .csv file.
-    """
 
+    """
     _validate_dataset(ds)
     scorer = ["movement"]
     bodyparts = ds.coords["keypoints"].data.tolist()
@@ -156,8 +153,7 @@ def to_dlc_file(
     file_path: Union[str, Path],
     split_individuals: Union[bool, Literal["auto"]] = "auto",
 ) -> None:
-    """Save the xarray dataset containing pose tracks to a
-    DeepLabCut-style .h5 or .csv file.
+    r"""Save the xarray dataset to a DeepLabCut-style .h5 or .csv file.
 
     Parameters
     ----------
@@ -192,8 +188,8 @@ def to_dlc_file(
     >>> from movement.io import save_poses, load_poses
     >>> ds = load_poses.from_sleap_file("/path/to/file_sleap.analysis.h5")
     >>> save_poses.to_dlc_file(ds, "/path/to/file_dlc.h5")
-    """
 
+    """
     file = _validate_file_path(file_path, expected_suffix=[".csv", ".h5"])
 
     # Sets default behaviour for the function
@@ -229,8 +225,7 @@ def to_lp_file(
     ds: xr.Dataset,
     file_path: Union[str, Path],
 ) -> None:
-    """Save the xarray dataset containing pose tracks to a LightningPose-style
-    .csv file. See Notes for more details.
+    """Save the xarray dataset to a LightningPose-style .csv file (see Notes).
 
     Parameters
     ----------
@@ -252,8 +247,8 @@ def to_lp_file(
     --------
     to_dlc_file : Save the xarray dataset containing pose tracks to a
         DeepLabCut-style .h5 or .csv file.
-    """
 
+    """
     file = _validate_file_path(file_path=file_path, expected_suffix=[".csv"])
     _validate_dataset(ds)
     to_dlc_file(ds, file.path, split_individuals=True)
@@ -262,8 +257,7 @@ def to_lp_file(
 def to_sleap_analysis_file(
     ds: xr.Dataset, file_path: Union[str, Path]
 ) -> None:
-    """Save the xarray dataset containing pose tracks to a SLEAP-style
-    .h5 analysis file.
+    """Save the xarray dataset to a SLEAP-style .h5 analysis file.
 
     Parameters
     ----------
@@ -298,8 +292,8 @@ def to_sleap_analysis_file(
     >>> save_poses.to_sleap_analysis_file(
     ...     ds, "/path/to/file_sleap.analysis.h5"
     ... )
-    """
 
+    """
     file = _validate_file_path(file_path=file_path, expected_suffix=[".h5"])
     _validate_dataset(ds)
 
@@ -372,8 +366,8 @@ def _remove_unoccupied_tracks(ds: xr.Dataset):
     -------
     xarray.Dataset
         The input dataset without the unoccupied tracks.
-    """
 
+    """
     all_nan = ds.position.isnull().all(dim=["keypoints", "space", "time"])
     return ds.where(~all_nan, drop=True)
 
@@ -381,9 +375,9 @@ def _remove_unoccupied_tracks(ds: xr.Dataset):
 def _validate_file_path(
     file_path: Union[str, Path], expected_suffix: list[str]
 ) -> ValidFile:
-    """Validate the input file path by checking that the file has
-    write permission and expected suffix(es). If the file is not valid,
-    an appropriate error is raised.
+    """Validate the input file path.
+
+    We check that the file has write permission and the expected suffix(es).
 
     Parameters
     ----------
@@ -403,8 +397,8 @@ def _validate_file_path(
         If the file cannot be written.
     ValueError
         If the file does not have the expected suffix.
-    """
 
+    """
     try:
         file = ValidFile(
             file_path,
@@ -429,8 +423,8 @@ def _validate_dataset(ds: xr.Dataset) -> None:
     ------
     ValueError
         If `ds` is not an xarray Dataset with valid poses.
-    """
 
+    """
     if not isinstance(ds, xr.Dataset):
         raise log_error(
             ValueError, f"Expected an xarray Dataset, but got {type(ds)}."

--- a/movement/logging.py
+++ b/movement/logging.py
@@ -1,3 +1,5 @@
+"""Logging utilities for the movement package."""
+
 import logging
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
@@ -15,6 +17,7 @@ def configure_logging(
     log_directory: Path = DEFAULT_LOG_DIRECTORY,
 ):
     """Configure the logging module.
+
     This function sets up a circular log file with a rotating file handler.
 
     Parameters
@@ -28,8 +31,8 @@ def configure_logging(
         The directory to store the log file in. Defaults to
         ~/.movement. A different directory can be specified,
         for example for testing purposes.
-    """
 
+    """
     # Set the log directory and file path
     log_directory.mkdir(parents=True, exist_ok=True)
     log_file = (log_directory / f"{logger_name}.log").as_posix()
@@ -80,6 +83,7 @@ def log_error(error, message: str, logger_name: str = "movement"):
     -------
     Exception
         The error that was passed in.
+
     """
     logger = logging.getLogger(logger_name)
     logger.error(message)
@@ -95,6 +99,7 @@ def log_warning(message: str, logger_name: str = "movement"):
         The warning message.
     logger_name : str, optional
         The name of the logger to use. Defaults to "movement".
+
     """
     logger = logging.getLogger(logger_name)
     logger.warning(message)

--- a/movement/sample_data.py
+++ b/movement/sample_data.py
@@ -32,9 +32,12 @@ DATA_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def _download_metadata_file(file_name: str, data_dir: Path = DATA_DIR) -> Path:
-    """Download the yaml file containing sample metadata from the *movement*
-    data repository and save it in the specified directory with a temporary
-    filename - temp_{file_name} - to avoid overwriting any existing files.
+    """Download the metadata yaml file.
+
+    This function downloads the yaml file containing sample metadata from
+    the *movement* data repository and saves it in the specified directory
+    with a temporary filename - temp_{file_name} - to avoid overwriting any
+    existing files.
 
     Parameters
     ----------
@@ -48,6 +51,7 @@ def _download_metadata_file(file_name: str, data_dir: Path = DATA_DIR) -> Path:
     -------
     path : pathlib.Path
         Path to the downloaded file.
+
     """
     local_file_path = pooch.retrieve(
         url=f"{DATA_URL}/{file_name}",
@@ -64,8 +68,7 @@ def _download_metadata_file(file_name: str, data_dir: Path = DATA_DIR) -> Path:
 
 
 def _fetch_metadata(file_name: str, data_dir: Path = DATA_DIR) -> list[dict]:
-    """Download the yaml file containing metadata from the *movement* sample
-    data repository and load it as a list of dictionaries.
+    """Download the metadata yaml file and load it as a list of dictionaries.
 
     Parameters
     ----------
@@ -79,8 +82,8 @@ def _fetch_metadata(file_name: str, data_dir: Path = DATA_DIR) -> list[dict]:
     -------
     list[dict]
         A list of dictionaries containing metadata for each sample file.
-    """
 
+    """
     local_file_path = Path(data_dir / file_name)
     failed_msg = "Failed to download the newest sample metadata file."
 
@@ -121,17 +124,19 @@ def list_sample_data() -> list[str]:
     Returns
     -------
     filenames : list of str
-        List of filenames for available pose data."""
+    List of filenames for available pose data.
+
+    """
     return list(SAMPLE_DATA.registry.keys())
 
 
 def fetch_sample_data_path(filename: str) -> Path:
-    """Download sample pose data from the *movement* data repository and return
-    its local filepath.
+    """Download sample pose data and return its local filepath.
 
-    The data are downloaded to the user's local machine the first time they are
-    used and are stored in a local cache directory. The function returns the
-    path to the downloaded file, not the contents of the file itself.
+    The data are downloaded from the *movement* data repository to the user's
+    local machine upon first use and are stored in a local cache directory.
+    The function returns the path to the downloaded file,
+    not the contents of the file itself.
 
     Parameters
     ----------
@@ -142,6 +147,7 @@ def fetch_sample_data_path(filename: str) -> Path:
     -------
     path : pathlib.Path
         Path to the downloaded file.
+
     """
     try:
         return Path(SAMPLE_DATA.fetch(filename, progressbar=True))
@@ -156,12 +162,11 @@ def fetch_sample_data_path(filename: str) -> Path:
 def fetch_sample_data(
     filename: str,
 ) -> xarray.Dataset:
-    """Download and return sample pose data from the *movement* data
-    repository.
+    """Download sample pose data and load it as an xarray Dataset.
 
-    The data are downloaded to the user's local machine the first time they are
-    used and are stored in a local cache directory. Returns sample pose data as
-    an xarray Dataset.
+    The data are downloaded from the *movement* data repository to the user's
+    local machine upon first use and are stored in a local cache directory.
+    This function returns the pose data as an xarray Dataset.
 
     Parameters
     ----------
@@ -172,8 +177,8 @@ def fetch_sample_data(
     -------
     ds : xarray.Dataset
         Pose data contained in the fetched sample file.
-    """
 
+    """
     file_path = fetch_sample_data_path(filename)
     file_metadata = next(
         file for file in metadata if file["file_name"] == filename

--- a/movement/utils/vector.py
+++ b/movement/utils/vector.py
@@ -1,3 +1,5 @@
+"""Utility functions for vector operations."""
+
 import numpy as np
 import xarray as xr
 
@@ -20,6 +22,7 @@ def cart2pol(data: xr.DataArray) -> xr.DataArray:
         stored in the ``space_pol`` dimension, with ``rho``
         and ``phi`` in the dimension coordinate. The angles
         ``phi`` returned are in radians, in the range ``[-pi, pi]``.
+
     """
     _validate_dimension_coordinates(data, {"space": ["x", "y"]})
     rho = xr.apply_ufunc(
@@ -60,6 +63,7 @@ def pol2cart(data: xr.DataArray) -> xr.DataArray:
         An xarray DataArray containing the Cartesian coordinates
         stored in the ``space`` dimension, with ``x`` and ``y``
         in the dimension coordinate.
+
     """
     _validate_dimension_coordinates(data, {"space_pol": ["rho", "phi"]})
     rho = data.sel(space_pol="rho")
@@ -81,8 +85,9 @@ def pol2cart(data: xr.DataArray) -> xr.DataArray:
 def _validate_dimension_coordinates(
     data: xr.DataArray, required_dim_coords: dict
 ) -> None:
-    """Validate the input data contains the required dimensions and
-    coordinate values.
+    """Validate the input data array.
+
+    Ensure that it contains the required dimensions and coordinates.
 
     Parameters
     ----------
@@ -97,6 +102,7 @@ def _validate_dimension_coordinates(
     ValueError
         If the input data does not contain the required dimension(s)
         and/or the required coordinate(s).
+
     """
     missing_dims = [dim for dim in required_dim_coords if dim not in data.dims]
     error_message = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,8 +94,15 @@ ignore_missing_imports = true
 [tool.ruff]
 line-length = 79
 exclude = ["__init__.py", "build", ".eggs"]
+fix = true
+
+[tool.ruff.lint]
 # See https://docs.astral.sh/ruff/rules/
-lint.select = [
+ignore = [
+  "D203", # one blank line before class
+  "D213", # multi-line-summary second line
+]
+select = [
   "E",   # pycodestyle errors
   "F",   # Pyflakes
   "UP",  # pyupgrade
@@ -103,9 +110,17 @@ lint.select = [
   "B",   # flake8 bugbear
   "SIM", # flake8 simplify
   "C90", # McCabe complexity
-  #"D",  # pydocstyle
+  "D",   # pydocstyle
 ]
-fix = true
+per-file-ignores = { "tests/*" = [
+  "D100", # missing docstring in public module
+  "D205", # missing blank line between summary and description
+  "D103", # missing docstring in public function
+], "examples/*" = [
+  "D400", # first line should end with a period.
+  "D415", # first line should end with a period, question mark...
+  "D205", # missing blank line between summary and description
+] }
 
 [tool.ruff.format]
 docstring-code-format = true # Also format code in docstrings

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+"""Fixtures and configurations applied to the entire test suite."""
+
 import logging
 import os
 from pathlib import Path
@@ -16,7 +18,8 @@ from movement.sample_data import fetch_sample_data_path, list_sample_data
 
 def pytest_configure():
     """Perform initial configuration for pytest.
-    Fetches pose data file paths as a dictionary for tests."""
+    Fetches pose data file paths as a dictionary for tests.
+    """
     pytest.POSE_DATA_PATHS = {
         file_name: fetch_sample_data_path(file_name)
         for file_name in list_sample_data()
@@ -26,7 +29,8 @@ def pytest_configure():
 @pytest.fixture(autouse=True)
 def setup_logging(tmp_path):
     """Set up logging for the test module.
-    Redirects all logging to a temporary directory."""
+    Redirects all logging to a temporary directory.
+    """
     configure_logging(
         log_level=logging.DEBUG,
         logger_name="movement",
@@ -37,7 +41,8 @@ def setup_logging(tmp_path):
 @pytest.fixture
 def unreadable_file(tmp_path):
     """Return a dictionary containing the file path and
-    expected permission for an unreadable .h5 file."""
+    expected permission for an unreadable .h5 file.
+    """
     file_path = tmp_path / "unreadable.h5"
     file_mock = mock_open()
     file_mock.return_value.read.side_effect = PermissionError
@@ -54,7 +59,8 @@ def unreadable_file(tmp_path):
 @pytest.fixture
 def unwriteable_file(tmp_path):
     """Return a dictionary containing the file path and
-    expected permission for an unwriteable .h5 file."""
+    expected permission for an unwriteable .h5 file.
+    """
     unwriteable_dir = tmp_path / "no_write"
     unwriteable_dir.mkdir()
     original_access = os.access
@@ -93,7 +99,8 @@ def wrong_ext_file(tmp_path):
 @pytest.fixture
 def nonexistent_file(tmp_path):
     """Return a dictionary containing the file path and
-    expected permission for a nonexistent file."""
+    expected permission for a nonexistent file.
+    """
     file_path = tmp_path / "nonexistent.h5"
     return {
         "file_path": file_path,
@@ -104,7 +111,8 @@ def nonexistent_file(tmp_path):
 @pytest.fixture
 def directory(tmp_path):
     """Return a dictionary containing the file path and
-    expected permission for a directory."""
+    expected permission for a directory.
+    """
     file_path = tmp_path / "directory"
     file_path.mkdir()
     return {
@@ -116,7 +124,8 @@ def directory(tmp_path):
 @pytest.fixture
 def h5_file_no_dataframe(tmp_path):
     """Return a dictionary containing the file path and
-    expected datasets for a .h5 file with no dataframe."""
+    expected datasets for a .h5 file with no dataframe.
+    """
     file_path = tmp_path / "no_dataframe.h5"
     with h5py.File(file_path, "w") as f:
         f.create_dataset("data_in_list", data=[1, 2, 3])
@@ -208,7 +217,8 @@ def sleap_file(request):
 @pytest.fixture
 def valid_position_array():
     """Return a function that generates different kinds
-    of a valid position array."""
+    of a valid position array.
+    """
 
     def _valid_position_array(array_type):
         """Return a valid position array."""

--- a/tests/test_integration/test_io.py
+++ b/tests/test_integration/test_io.py
@@ -17,7 +17,8 @@ class TestPosesIO:
 
     def test_load_and_save_to_dlc_df(self, dlc_style_df):
         """Test that loading pose tracks from a DLC-style DataFrame and
-        converting back to a DataFrame returns the same data values."""
+        converting back to a DataFrame returns the same data values.
+        """
         ds = load_poses.from_dlc_df(dlc_style_df)
         df = save_poses.to_dlc_df(ds, split_individuals=False)
         np.testing.assert_allclose(df.values, dlc_style_df.values)
@@ -26,7 +27,8 @@ class TestPosesIO:
         self, dlc_output_file, valid_poses_dataset
     ):
         """Test that saving pose tracks to DLC .h5 and .csv files and then
-        loading them back in returns the same Dataset."""
+        loading them back in returns the same Dataset.
+        """
         save_poses.to_dlc_file(
             valid_poses_dataset, dlc_output_file, split_individuals=False
         )
@@ -36,7 +38,8 @@ class TestPosesIO:
     def test_convert_sleap_to_dlc_file(self, sleap_file, dlc_output_file):
         """Test that pose tracks loaded from SLEAP .slp and .h5 files,
         when converted to DLC .h5 and .csv files and re-loaded return
-        the same Datasets."""
+        the same Datasets.
+        """
         sleap_ds = load_poses.from_sleap_file(sleap_file)
         save_poses.to_dlc_file(
             sleap_ds, dlc_output_file, split_individuals=False
@@ -57,7 +60,8 @@ class TestPosesIO:
     ):
         """Test that saving pose tracks (loaded from a SLEAP analysis
         file) to a SLEAP-style .h5 analysis file returns the same file
-        contents."""
+        contents.
+        """
         sleap_h5_file_path = POSE_DATA_PATHS.get(sleap_h5_file)
         ds = load_poses.from_sleap_file(sleap_h5_file_path, fps=fps)
         save_poses.to_sleap_analysis_file(ds, new_h5_file)
@@ -87,7 +91,8 @@ class TestPosesIO:
     def test_to_sleap_analysis_file_source_file(self, file, new_h5_file):
         """Test that saving pose tracks (loaded from valid source files)
         to a SLEAP-style .h5 analysis file stores the .slp labels path
-        only when the source file is a .slp file."""
+        only when the source file is a .slp file.
+        """
         file_path = POSE_DATA_PATHS.get(file)
         if file.startswith("DLC"):
             ds = load_poses.from_dlc_file(file_path)

--- a/tests/test_integration/test_kinematics_vector_transform.py
+++ b/tests/test_integration/test_kinematics_vector_transform.py
@@ -8,7 +8,8 @@ from movement.utils import vector
 
 class TestKinematicsVectorTransform:
     """Test the vector transformation functionality with
-    various kinematic properties."""
+    various kinematic properties.
+    """
 
     @pytest.mark.parametrize(
         "ds, expected_exception",
@@ -22,7 +23,8 @@ class TestKinematicsVectorTransform:
         self, ds, expected_exception, kinematic_property, request
     ):
         """Test transformation between Cartesian and polar coordinates
-        with various kinematic properties."""
+        with various kinematic properties.
+        """
         ds = request.getfixturevalue(ds)
         with expected_exception:
             data = getattr(ds.move, kinematic_property)

--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -1,5 +1,3 @@
-"""Testing suite for the filtering module."""
-
 import numpy as np
 import pytest
 import xarray as xr
@@ -14,13 +12,14 @@ from movement.sample_data import fetch_sample_data
 
 @pytest.fixture(scope="module")
 def sample_dataset():
-    """Return a single-individual sample dataset"""
+    """Return a single-individual sample dataset."""
     return fetch_sample_data("DLC_single-mouse_EPM.predictions.h5")
 
 
 def test_log_to_attrs(sample_dataset):
     """Test for the ``log_to_attrs()`` decorator. Decorates a mock function and
-    checks that ``attrs`` contains all expected values."""
+    checks that ``attrs`` contains all expected values.
+    """
 
     @log_to_attrs
     def fake_func(ds, arg, kwarg=None):
@@ -37,10 +36,11 @@ def test_log_to_attrs(sample_dataset):
 
 
 def test_interpolate_over_time(sample_dataset):
-    """Tests the ``interpolate_over_time`` function by checking
-    that the number of nans is decreased after running this function
-    on a filtered dataset"""
+    """Test the ``interpolate_over_time`` function.
 
+    Check that the number of nans is decreased after running this function
+    on a filtered dataset
+    """
     ds_filtered = filter_by_confidence(sample_dataset)
     ds_interpolated = interpolate_over_time(ds_filtered)
 
@@ -61,8 +61,8 @@ def test_filter_by_confidence(sample_dataset, caplog):
     """Tests for the ``filter_by_confidence`` function.
     Checks that the function filters the expected amount of values
     from a known dataset, and tests that this value is logged
-    correctly."""
-
+    correctly.
+    """
     ds_filtered = filter_by_confidence(sample_dataset)
 
     assert isinstance(ds_filtered, xr.Dataset)

--- a/tests/test_unit/test_kinematics.py
+++ b/tests/test_unit/test_kinematics.py
@@ -13,11 +13,13 @@ class TestKinematics:
     @pytest.fixture
     def expected_dataarray(self, valid_poses_dataset):
         """Return a function to generate the expected dataarray
-        for different kinematic properties."""
+        for different kinematic properties.
+        """
 
         def _expected_dataarray(property):
             """Return an xarray.DataArray with default values and
-            the expected dimensions and coordinates."""
+            the expected dimensions and coordinates.
+            """
             # Expected x,y values for velocity
             x_vals = np.array(
                 [1.0, 2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 17.0]

--- a/tests/test_unit/test_load_poses.py
+++ b/tests/test_unit/test_load_poses.py
@@ -65,6 +65,7 @@ class TestLoadPoses:
         ]
     )
     def sleap_file_without_tracks(self, request):
+        """Fixture to parametrize the SLEAP files without tracks."""
         return request.getfixturevalue(request.param)
 
     def assert_dataset(
@@ -102,7 +103,8 @@ class TestLoadPoses:
 
     def test_load_from_sleap_file(self, sleap_file):
         """Test that loading pose tracks from valid SLEAP files
-        returns a proper Dataset."""
+        returns a proper Dataset.
+        """
         ds = load_poses.from_sleap_file(sleap_file)
         self.assert_dataset(ds, sleap_file, "SLEAP")
 
@@ -112,7 +114,8 @@ class TestLoadPoses:
         """Test that loading pose tracks from valid SLEAP files
         with tracks removed returns a dataset that matches the
         original file, except for the individual names which are
-        set to default."""
+        set to default.
+        """
         ds_from_trackless = load_poses.from_sleap_file(
             sleap_file_without_tracks
         )
@@ -148,7 +151,8 @@ class TestLoadPoses:
         self, slp_file, h5_file
     ):
         """Test that loading pose tracks from SLEAP .slp and .h5 files
-        return the same Dataset."""
+        return the same Dataset.
+        """
         slp_file_path = POSE_DATA_PATHS.get(slp_file)
         h5_file_path = POSE_DATA_PATHS.get(h5_file)
         ds_from_slp = load_poses.from_sleap_file(slp_file_path)
@@ -165,20 +169,23 @@ class TestLoadPoses:
     )
     def test_load_from_dlc_file(self, file_name):
         """Test that loading pose tracks from valid DLC files
-        returns a proper Dataset."""
+        returns a proper Dataset.
+        """
         file_path = POSE_DATA_PATHS.get(file_name)
         ds = load_poses.from_dlc_file(file_path)
         self.assert_dataset(ds, file_path, "DeepLabCut")
 
     def test_load_from_dlc_df(self, dlc_style_df):
         """Test that loading pose tracks from a valid DLC-style DataFrame
-        returns a proper Dataset."""
+        returns a proper Dataset.
+        """
         ds = load_poses.from_dlc_df(dlc_style_df)
         self.assert_dataset(ds)
 
     def test_load_from_dlc_file_csv_or_h5_file_returns_same(self):
         """Test that loading pose tracks from DLC .csv and .h5 files
-        return the same Dataset."""
+        return the same Dataset.
+        """
         csv_file_path = POSE_DATA_PATHS.get("DLC_single-wasp.predictions.csv")
         h5_file_path = POSE_DATA_PATHS.get("DLC_single-wasp.predictions.h5")
         ds_from_csv = load_poses.from_dlc_file(csv_file_path)
@@ -220,7 +227,8 @@ class TestLoadPoses:
     )
     def test_load_from_lp_file(self, file_name):
         """Test that loading pose tracks from valid LightningPose (LP) files
-        returns a proper Dataset."""
+        returns a proper Dataset.
+        """
         file_path = POSE_DATA_PATHS.get(file_name)
         ds = load_poses.from_lp_file(file_path)
         self.assert_dataset(ds, file_path, "LightningPose")
@@ -228,7 +236,8 @@ class TestLoadPoses:
     def test_load_from_lp_or_dlc_file_returns_same(self):
         """Test that loading a single-animal DeepLabCut-style .csv file
         using either the `from_lp_file` or `from_dlc_file` function
-        returns the same Dataset (except for the source_software)."""
+        returns the same Dataset (except for the source_software).
+        """
         file_path = POSE_DATA_PATHS.get("LP_mouse-face_AIND.predictions.csv")
         ds_drom_lp = load_poses.from_lp_file(file_path)
         ds_from_dlc = load_poses.from_dlc_file(file_path)
@@ -238,7 +247,8 @@ class TestLoadPoses:
 
     def test_load_multi_individual_from_lp_file_raises(self):
         """Test that loading a multi-individual .csv file using the
-        `from_lp_file` function raises a ValueError."""
+        `from_lp_file` function raises a ValueError.
+        """
         file_path = POSE_DATA_PATHS.get("DLC_two-mice.predictions.csv")
         with pytest.raises(ValueError):
             load_poses.from_lp_file(file_path)
@@ -249,8 +259,8 @@ class TestLoadPoses:
     @pytest.mark.parametrize("fps", [None, 30, 60.0])
     def test_from_file_delegates_correctly(self, source_software, fps):
         """Test that the from_file() function delegates to the correct
-        loader function according to the source_software."""
-
+        loader function according to the source_software.
+        """
         software_to_loader = {
             "SLEAP": "movement.io.load_poses.from_sleap_file",
             "DeepLabCut": "movement.io.load_poses.from_dlc_file",

--- a/tests/test_unit/test_logging.py
+++ b/tests/test_unit/test_logging.py
@@ -15,7 +15,8 @@ log_messages = {
 @pytest.mark.parametrize("level, message", log_messages.items())
 def test_logfile_contains_message(level, message):
     """Check if the last line of the logfile contains
-    the expected message."""
+    the expected message.
+    """
     logger = logging.getLogger("movement")
     eval(f"logger.{level.lower()}('{message}')")
     log_file = logger.handlers[0].baseFilename
@@ -27,7 +28,8 @@ def test_logfile_contains_message(level, message):
 
 def test_log_error(caplog):
     """Check if the log_error function
-    logs the error message and returns an Exception."""
+    logs the error message and returns an Exception.
+    """
     with pytest.raises(ValueError):
         raise log_error(ValueError, "This is a test error")
     assert caplog.records[0].message == "This is a test error"
@@ -36,7 +38,8 @@ def test_log_error(caplog):
 
 def test_log_warning(caplog):
     """Check if the log_warning function
-    logs the warning message."""
+    logs the warning message.
+    """
     log_warning("This is a test warning")
     assert caplog.records[0].message == "This is a test warning"
     assert caplog.records[0].levelname == "WARNING"

--- a/tests/test_unit/test_move_accessor.py
+++ b/tests/test_unit/test_move_accessor.py
@@ -13,7 +13,8 @@ class TestMoveAccessor:
         or polar coordinates) of a valid pose dataset returns an
         instance of xr.DataArray with the correct name, and that
         the input xr.Dataset now contains the property as a data
-        variable."""
+        variable.
+        """
         kinematic_property += suffix
         result = getattr(valid_poses_dataset.move, kinematic_property)
         assert isinstance(result, xr.DataArray)
@@ -24,7 +25,8 @@ class TestMoveAccessor:
         self, invalid_poses_dataset, kinematic_property
     ):
         """Test that accessing a property of an invalid pose dataset
-        raises the appropriate error."""
+        raises the appropriate error.
+        """
         expected_exception = (
             ValueError
             if isinstance(invalid_poses_dataset, xr.Dataset)

--- a/tests/test_unit/test_sample_data.py
+++ b/tests/test_unit/test_sample_data.py
@@ -17,7 +17,8 @@ from movement.sample_data import (
 @pytest.fixture(scope="module")
 def valid_file_names_with_fps():
     """Return a dict containing one valid file name and the corresponding fps
-    for each supported pose estimation tool."""
+    for each supported pose estimation tool.
+    """
     return {
         "SLEAP_single-mouse_EPM.analysis.h5": 30,
         "DLC_single-wasp.predictions.h5": 40,
@@ -73,7 +74,8 @@ def test_fetch_metadata(tmp_path, caplog, download_fails, local_exists):
     failed download and pre-existing local file. The expected behavior is
     that the function will try to download the metadata file, and if that
     fails, it will try to load an existing local file. If neither succeeds,
-    an error is raised."""
+    an error is raised.
+    """
     metadata_file_name = "poses_files_metadata.yaml"
     local_file_path = tmp_path / metadata_file_name
 

--- a/tests/test_unit/test_save_poses.py
+++ b/tests/test_unit/test_save_poses.py
@@ -56,7 +56,8 @@ class TestSavePoses:
     @pytest.fixture(params=output_files)
     def output_file_params(self, request):
         """Return a dictionary containing parameters for testing saving
-        valid pose datasets to DeepLabCut- or SLEAP-style files."""
+        valid pose datasets to DeepLabCut- or SLEAP-style files.
+        """
         return request.param
 
     @pytest.mark.parametrize(
@@ -99,7 +100,8 @@ class TestSavePoses:
     )
     def test_to_dlc_df(self, ds, expected_exception):
         """Test that converting a valid/invalid xarray dataset to
-        a DeepLabCut-style pandas DataFrame returns the expected result."""
+        a DeepLabCut-style pandas DataFrame returns the expected result.
+        """
         with expected_exception as e:
             df = save_poses.to_dlc_df(ds, split_individuals=False)
             if e is None:  # valid input
@@ -116,7 +118,8 @@ class TestSavePoses:
         self, output_file_params, valid_poses_dataset, request
     ):
         """Test that saving a valid pose dataset to a valid/invalid
-        DeepLabCut-style file returns the appropriate errors."""
+        DeepLabCut-style file returns the appropriate errors.
+        """
         with output_file_params.get("to_dlc_file_expected_exception"):
             file_fixture = output_file_params.get("file_fixture")
             val = request.getfixturevalue(file_fixture)
@@ -127,7 +130,8 @@ class TestSavePoses:
         self, invalid_poses_dataset, tmp_path
     ):
         """Test that saving an invalid pose dataset to a valid
-        DeepLabCut-style file returns the appropriate errors."""
+        DeepLabCut-style file returns the appropriate errors.
+        """
         with pytest.raises(ValueError):
             save_poses.to_dlc_file(
                 invalid_poses_dataset,
@@ -142,7 +146,8 @@ class TestSavePoses:
     )
     def test_auto_split_individuals(self, valid_poses_dataset, split_value):
         """Test that setting 'split_individuals' to 'auto' yields True
-        for single-individual datasets and False for multi-individual ones."""
+        for single-individual datasets and False for multi-individual ones.
+        """
         assert (
             save_poses._auto_split_individuals(valid_poses_dataset)
             == split_value
@@ -164,7 +169,7 @@ class TestSavePoses:
         split_individuals,
     ):
         """Test that the `split_individuals` argument affects the behaviour
-        of the `to_dlc_df` function as expected
+        of the `to_dlc_df` function as expected.
         """
         df = save_poses.to_dlc_df(valid_poses_dataset, split_individuals)
         # Get the names of the individuals in the dataset
@@ -239,7 +244,8 @@ class TestSavePoses:
         self, output_file_params, valid_poses_dataset, request
     ):
         """Test that saving a valid pose dataset to a valid/invalid
-        LightningPose-style file returns the appropriate errors."""
+        LightningPose-style file returns the appropriate errors.
+        """
         with output_file_params.get("to_lp_file_expected_exception"):
             file_fixture = output_file_params.get("file_fixture")
             val = request.getfixturevalue(file_fixture)
@@ -248,7 +254,8 @@ class TestSavePoses:
 
     def test_to_lp_file_invalid_dataset(self, invalid_poses_dataset, tmp_path):
         """Test that saving an invalid pose dataset to a valid
-        LightningPose-style file returns the appropriate errors."""
+        LightningPose-style file returns the appropriate errors.
+        """
         with pytest.raises(ValueError):
             save_poses.to_lp_file(
                 invalid_poses_dataset,
@@ -259,7 +266,8 @@ class TestSavePoses:
         self, output_file_params, valid_poses_dataset, request
     ):
         """Test that saving a valid pose dataset to a valid/invalid
-        SLEAP-style file returns the appropriate errors."""
+        SLEAP-style file returns the appropriate errors.
+        """
         with output_file_params.get("to_sleap_file_expected_exception"):
             file_fixture = output_file_params.get("file_fixture")
             val = request.getfixturevalue(file_fixture)
@@ -270,7 +278,8 @@ class TestSavePoses:
         self, invalid_poses_dataset, new_h5_file
     ):
         """Test that saving an invalid pose dataset to a valid
-        SLEAP-style file returns the appropriate errors."""
+        SLEAP-style file returns the appropriate errors.
+        """
         with pytest.raises(ValueError):
             save_poses.to_sleap_analysis_file(
                 invalid_poses_dataset,
@@ -279,7 +288,8 @@ class TestSavePoses:
 
     def test_remove_unoccupied_tracks(self, valid_poses_dataset):
         """Test that removing unoccupied tracks from a valid pose dataset
-        returns the expected result."""
+        returns the expected result.
+        """
         new_individuals = [f"ind{i}" for i in range(1, 4)]
         # Add new individual with NaN data
         ds = valid_poses_dataset.reindex(individuals=new_individuals)

--- a/tests/test_unit/test_validators.py
+++ b/tests/test_unit/test_validators.py
@@ -66,7 +66,8 @@ class TestValidators:
     @pytest.fixture(params=position_arrays)
     def position_array_params(self, request):
         """Return a dictionary containing parameters for testing
-        position array keypoint and individual names."""
+        position array keypoint and individual names.
+        """
         return request.param
 
     @pytest.mark.parametrize(
@@ -218,7 +219,8 @@ class TestValidators:
         self, valid_position_array, source_software, expected_exception
     ):
         """Test that the source_software attribute is validated properly.
-        LightnigPose is incompatible with multi-individual arrays."""
+        LightnigPose is incompatible with multi-individual arrays.
+        """
         with expected_exception:
             ds = ValidPosesDataset(
                 position_array=valid_position_array("multi_individual_array"),

--- a/tests/test_unit/test_vector.py
+++ b/tests/test_unit/test_vector.py
@@ -43,7 +43,8 @@ class TestVector:
     @pytest.fixture
     def cart_pol_dataset_with_nan(self, cart_pol_dataset):
         """Return an xarray.Dataset with Cartesian and polar coordinates,
-        where some values are NaN."""
+        where some values are NaN.
+        """
         cart_pol_dataset.cart.loc[{"time": slice(2, 3)}] = np.nan
         cart_pol_dataset.pol.loc[{"time": slice(2, 3)}] = np.nan
         return cart_pol_dataset
@@ -51,28 +52,32 @@ class TestVector:
     @pytest.fixture
     def cart_pol_dataset_missing_cart_dim(self, cart_pol_dataset):
         """Return an xarray.Dataset with Cartesian and polar coordinates,
-        where the required ``space`` dimension is missing."""
+        where the required ``space`` dimension is missing.
+        """
         return cart_pol_dataset.rename({"space": "spice"})
 
     @pytest.fixture
     def cart_pol_dataset_missing_cart_coords(self, cart_pol_dataset):
         """Return an xarray.Dataset with Cartesian and polar coordinates,
         where the required ``space["x"]`` and ``space["y"]`` coordinates
-        are missing."""
+        are missing.
+        """
         cart_pol_dataset["space"] = ["a", "b"]
         return cart_pol_dataset
 
     @pytest.fixture
     def cart_pol_dataset_missing_pol_dim(self, cart_pol_dataset):
         """Return an xarray.Dataset with Cartesian and polar coordinates,
-        where the required ``space_pol`` dimension is missing."""
+        where the required ``space_pol`` dimension is missing.
+        """
         return cart_pol_dataset.rename({"space_pol": "spice_pol"})
 
     @pytest.fixture
     def cart_pol_dataset_missing_pol_coords(self, cart_pol_dataset):
         """Return an xarray.Dataset with Cartesian and polar coordinates,
         where the required ``space_pol["rho"]`` and ``space_pol["phi"]``
-        coordinates are missing."""
+        coordinates are missing.
+        """
         cart_pol_dataset["space_pol"] = ["a", "b"]
         return cart_pol_dataset
 


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

We recently implemented a linting/code formatting overhaul, relying on `ruff` #156.
However, we are still missing linting/formatting for docstrings. Would be nice to have them all formatted in a uniform way.

**What does this PR do?**
It adds the ["D" (pydocstyle) ruleset](https://docs.astral.sh/ruff/rules/#pydocstyle-d) to the `ruff` config.
That enforces a bunch of rules on docstring formatting, and most problems are auto-fixed.
However, I had to fix lots of issues manually, because many of our existing docstrings were non-compliant.

The rules that necessitated most manual work were the ones stipulating that docstrings should start with a one-line short description ending in a period, optionally followed by a longer description (separated from the one-liner by 1 blank line), e.g.:

```python

def foo(bar):
    """Perform some function (has to fit in one line).
    
    Here is the longer description which can extend over
    multiple lines.
    """
```

This is a bit restrictive and I had to rewrite a bunch of docstrings accordingly, but I like the consistent result we end up with.
Going forward this should be much less work, because we'll get immediate feedback on this via `pre-commit`, so no additional inconsistencies should creep in.

I relaxed the rules quite a bit for the `tests` folder, because those docstrings are not public-facing.

The relevant configuration changes are to be found in `pyproject.toml`. All the other diffs have to do with fixing issues encountered during `pre-commit run --all-files`.

## How has this PR been tested?

Visually checked the locally rendered sphinx API docs.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
