### PR TITLE
Changed macos runners for GitHub CI

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -30,9 +30,9 @@ jobs:
         # Run all supported Python versions on linux
         python-version: ["3.9", "3.10", "3.11"]
         os: [ubuntu-latest]
-        # Include 1 windows, 1 Intel mac and 1 M1 mac (macos-14) run
+        # Include 1 Intel macos (13) and 1 M1 macos (latest) and 1 Windows run
         include:
-        - os: macos-14
+        - os: macos-13
           python-version: "3.10"
         - os: macos-latest
           python-version: "3.10"


### PR DESCRIPTION
This is because GitHub recently updated `macos-latest` to mean `macos-14` (M1) instead on `macos-12` (intel mac).
Therefore, with our current setup we are running duplicate tests on M1 Macs and none on intel Macs.

I changed the CI testing matrix to include both `macos-latest` (M1) and `macos-13` (intel).

I'm using [GitHub docs for reference](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories).