### PR TITLE
Support video and frames files associated with sample data

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -302,9 +302,9 @@ The relevant functionality is implemented in the `movement.sample_data.py` modul
 The most important parts of this module are:
 
 1. The `SAMPLE_DATA` download manager object.
-2. The `list_sample_data()` function, which returns a list of the available files in the data repository.
-3. The `fetch_sample_data_path()` function, which downloads a file (if not already cached locally) and returns the local path to it.
-4. The `fetch_sample_data()` function, which downloads a file and loads it into movement directly, returning an `xarray.Dataset` object.
+2. The `list_datasets()` function, which returns a list of the available files in the data repository.
+3. The `fetch_dataset_paths()` function, which downloads a file (if not already cached locally) and returns the local path to it.
+4. The `fetch_dataset()` function, which downloads a file and loads it into movement directly, returning an `xarray.Dataset` object.
 
 By default, the downloaded files are stored in the `~/.movement/data` folder.
 This can be changed by setting the `DATA_DIR` variable in the `movement.sample_data.py` module.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -290,7 +290,7 @@ GIN has a GitHub-like interface and git-like
 
 Currently, the data repository contains sample pose estimation data files
 stored in the `poses` folder. Metadata for these files, including information
-about their provenance, is stored in the `poses_files_metadata.yaml` file.
+about their provenance, is stored in the `metadata.yaml` file.
 
 ### Fetching data
 To fetch the data from GIN, we use the [pooch](https://www.fatiando.org/pooch/latest/index.html)
@@ -319,6 +319,6 @@ To add a new file, you will need to:
 4. Clone the movement data repository to your local machine, by running `gin get neuroinformatics/movement-test-data` in a terminal.
 5. Add your new files to `/movement-test-data/poses/`.
 6. Determine the sha256 checksum hash of each new file by running `sha256sum <filename>` in a terminal. Alternatively, you can use `pooch` to do this for you: `python -c "import pooch; hash = pooch.file_hash('/path/to/file'); print(hash)"`. If you wish to generate a text file containing the hashes of all the files in a given folder, you can use `python -c "import pooch; pooch.make_registry('/path/to/folder', 'sha256_registry.txt')`.
-7. Add metadata for your new files to `poses_files_metadata.yaml`, including their sha256 hashes.
+7. Add metadata for your new files to `metadata.yaml`, including their sha256 hashes.
 8. Commit your changes using `gin commit -m <message> <filename>`.
 9. Upload the committed changes to the GIN repository by running `gin upload`. Latest changes to the repository can be pulled via `gin download`. `gin sync` will synchronise the latest changes bidirectionally.

--- a/docs/source/api_index.rst
+++ b/docs/source/api_index.rst
@@ -40,9 +40,9 @@ Sample Data
 .. autosummary::
     :toctree: api
 
-    list_sample_data
-    fetch_sample_data_path
-    fetch_sample_data
+    list_datasets
+    fetch_dataset_paths
+    fetch_dataset
 
 Filtering
 ---------

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -122,13 +122,13 @@ ds = load_poses.from_file(
 
 ::::
 
-You can also try movement out on some sample data included in the package.
+You can also try movement out on some sample datasets included in the package.
 
-:::{dropdown} Fetching sample data
+:::{dropdown} Fetching sample datasets
 :color: primary
 :icon: unlock
 
-You can view the available sample data files with:
+To view the available sample datasets:
 
 ```python
 from movement import sample_data
@@ -141,25 +141,30 @@ This will print a list of file names containing sample pose data.
 Each file is prefixed with the name of the pose estimation software package
 that was used to generate it - either "DLC", "SLEAP", or "LP".
 
-To get the path to one of the sample files,
-you can use the `fetch_pose_data_path` function:
-
-```python
-file_path = sample_data.fetch_dataset_paths("DLC_two-mice.predictions.csv")
-```
-The first time you call this function, it will download the corresponding file
-to your local machine and save it in the `~/.movement/data` directory. On
-subsequent calls, it will simply return the path to that local file.
-
-You can feed the path to the `from_dlc_file`, `from_sleap_file`, or
-`from_lp_file` functions and load the data, as shown above.
-
-Alternatively, you can skip the `fetch_dataset_paths()` step and load the
-data directly using the `fetch_dataset()` function:
+To load one of the sample datasets into `movement`, you can use the
+```sample_data.fetch_dataset()``` function:
 
 ```python
 ds = sample_data.fetch_dataset("DLC_two-mice.predictions.csv")
 ```
+
+This function loads the sample pose data into `movement` as an `xarray.Dataset`
+object. Some sample datasets may also have an associated video file
+(the video based on which the poses were predicted)
+or a single frame extracted from that video. These files are not directly
+loaded into `movement`, but their paths can be accessed as dataset attributes:
+
+```python
+ds.frame_path
+ds.video_path
+```
+If the value of one of these attributes are `None`, it means that the
+associated file is not available for the sample dataset.
+
+Under the hood, the first time you call the `fetch_dataset()` function,
+it will download the corresponding files to your local machine and cache them
+in the `~/.movement/data` directory. On subsequent calls, the data are directly
+loaded from the local cache.
 
 :::
 

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -133,7 +133,7 @@ You can view the available sample data files with:
 ```python
 from movement import sample_data
 
-file_names = sample_data.list_sample_data()
+file_names = sample_data.list_datasets()
 print(file_names)
 ```
 
@@ -145,7 +145,7 @@ To get the path to one of the sample files,
 you can use the `fetch_pose_data_path` function:
 
 ```python
-file_path = sample_data.fetch_sample_data_path("DLC_two-mice.predictions.csv")
+file_path = sample_data.fetch_dataset_paths("DLC_two-mice.predictions.csv")
 ```
 The first time you call this function, it will download the corresponding file
 to your local machine and save it in the `~/.movement/data` directory. On
@@ -154,11 +154,11 @@ subsequent calls, it will simply return the path to that local file.
 You can feed the path to the `from_dlc_file`, `from_sleap_file`, or
 `from_lp_file` functions and load the data, as shown above.
 
-Alternatively, you can skip the `fetch_sample_data_path()` step and load the
-data directly using the `fetch_sample_data()` function:
+Alternatively, you can skip the `fetch_dataset_paths()` step and load the
+data directly using the `fetch_dataset()` function:
 
 ```python
-ds = sample_data.fetch_sample_data("DLC_two-mice.predictions.csv")
+ds = sample_data.fetch_dataset("DLC_two-mice.predictions.csv")
 ```
 
 :::

--- a/examples/compute_kinematics.py
+++ b/examples/compute_kinematics.py
@@ -24,7 +24,7 @@ from movement import sample_data
 # ------------------------
 # First, we load an example dataset. In this case, we select the
 # ``SLEAP_three-mice_Aeon_proofread`` sample data.
-ds = sample_data.fetch_sample_data(
+ds = sample_data.fetch_dataset(
     "SLEAP_three-mice_Aeon_proofread.analysis.h5",
 )
 

--- a/examples/filter_and_interpolate.py
+++ b/examples/filter_and_interpolate.py
@@ -15,7 +15,7 @@ from movement.filtering import filter_by_confidence, interpolate_over_time
 # Load a sample dataset
 # ---------------------
 
-ds = sample_data.fetch_sample_data("DLC_single-wasp.predictions.h5")
+ds = sample_data.fetch_dataset("DLC_single-wasp.predictions.h5")
 print(ds)
 
 # %%

--- a/examples/load_and_explore_poses.py
+++ b/examples/load_and_explore_poses.py
@@ -17,16 +17,16 @@ from movement.io import load_poses
 # ------------------------
 # Print a list of available datasets:
 
-for file_name in sample_data.list_sample_data():
+for file_name in sample_data.list_datasets():
     print(file_name)
 
 # %%
 # Fetch the path to an example dataset.
 # Feel free to replace this with the path to your own dataset.
 # e.g., ``file_path = "/path/to/my/data.h5"``)
-file_path = sample_data.fetch_sample_data_path(
+file_path = sample_data.fetch_dataset_paths(
     "SLEAP_three-mice_Aeon_proofread.analysis.h5"
-)
+)["poses"]
 
 # %%
 # Load the dataset

--- a/examples/load_and_explore_poses.py
+++ b/examples/load_and_explore_poses.py
@@ -1,5 +1,5 @@
 """Load and explore pose tracks
-============================
+===============================
 
 Load and explore an example dataset of pose tracks.
 """
@@ -13,24 +13,27 @@ from movement import sample_data
 from movement.io import load_poses
 
 # %%
-# Fetch an example dataset
-# ------------------------
-# Print a list of available datasets:
+# Define the file path
+# --------------------
+# This should be a file output by one of our supported pose estimation
+# frameworks (e.g., DeepLabCut, SLEAP), containing predicted pose tracks.
+# For example, the path could be something like:
 
-for file_name in sample_data.list_datasets():
-    print(file_name)
+# uncomment and edit the following line to point to your own local file
+# file_path = "/path/to/my/data.h5"
 
 # %%
-# Fetch the path to an example dataset.
-# Feel free to replace this with the path to your own dataset.
-# e.g., ``file_path = "/path/to/my/data.h5"``)
+# For the sake of this example, we will use the path to one of
+# the sample datasets provided with ``movement``.
+
 file_path = sample_data.fetch_dataset_paths(
     "SLEAP_three-mice_Aeon_proofread.analysis.h5"
 )["poses"]
+print(file_path)
 
 # %%
-# Load the dataset
-# ----------------
+# Load the data into movement
+# ---------------------------
 
 ds = load_poses.from_sleap_file(file_path, fps=50)
 print(ds)

--- a/movement/sample_data.py
+++ b/movement/sample_data.py
@@ -35,7 +35,7 @@ def _download_metadata_file(file_name: str, data_dir: Path = DATA_DIR) -> Path:
     """Download the metadata yaml file.
 
     This function downloads the yaml file containing sample metadata from
-    the *movement* data repository and saves it in the specified directory
+    the ``movement`` data repository and saves it in the specified directory
     with a temporary filename - temp_{file_name} - to avoid overwriting any
     existing files.
 
@@ -81,7 +81,7 @@ def _fetch_metadata(file_name: str, data_dir: Path = DATA_DIR) -> list[dict]:
     Returns
     -------
     list[dict]
-        A list of dictionaries containing metadata for each sample file.
+        A list of dictionaries containing metadata for each sample dataset.
 
     """
     local_file_path = Path(data_dir / file_name)
@@ -110,7 +110,7 @@ def _fetch_metadata(file_name: str, data_dir: Path = DATA_DIR) -> list[dict]:
 def _generate_file_registry(metadata: list[dict]) -> dict[str, str]:
     """Generate a file registry based on the contents of the metadata.
 
-    This includes files containing pose data, frames, or entire videos.
+    This includes files containing poses, frames, or entire videos.
 
     Parameters
     ----------
@@ -129,22 +129,21 @@ def _generate_file_registry(metadata: list[dict]) -> dict[str, str]:
 
     ds_with_frames = [ds for ds in metadata if ds["frame"]["file_name"]]
     frames_registry = {
-        "frames" + ds["frame"]["file_name"]: ds["frame"]["sha256sum"]
+        "frames/" + ds["frame"]["file_name"]: ds["frame"]["sha256sum"]
         for ds in ds_with_frames
     }
 
     ds_with_videos = [ds for ds in metadata if ds["video"]["file_name"]]
     videos_registry = {
-        "videos" + ds["video"]["file_name"]: ds["video"]["sha256sum"]
+        "videos/" + ds["video"]["file_name"]: ds["video"]["sha256sum"]
         for ds in ds_with_videos
     }
     return {**poses_registry, **frames_registry, **videos_registry}
 
 
+# Create a download manager for the pose data
 metadata = _fetch_metadata("metadata.yaml")
 file_registry = _generate_file_registry(metadata)
-
-# Create a download manager for the pose data
 SAMPLE_DATA = pooch.create(
     path=DATA_DIR,
     base_url=f"{DATA_URL}/",
@@ -153,13 +152,13 @@ SAMPLE_DATA = pooch.create(
 )
 
 
-def list_sample_data() -> list[str]:
-    """Find available sample pose data in the *movement* data repository.
+def list_datasets() -> list[str]:
+    """Find available sample datasets.
 
     Returns
     -------
     filenames : list of str
-    List of filenames for available pose data.
+        List of filenames for available pose data.
 
     """
     return [
@@ -169,43 +168,78 @@ def list_sample_data() -> list[str]:
     ]
 
 
-def fetch_sample_data_path(filename: str) -> Path:
-    """Download sample pose data and return its local filepath.
+def fetch_dataset_paths(filename: str) -> dict:
+    """Get paths to sample pose data and any associated frames or videos.
 
-    The data are downloaded from the *movement* data repository to the user's
+    The data are downloaded from the ``movement`` data repository to the user's
     local machine upon first use and are stored in a local cache directory.
-    The function returns the path to the downloaded file,
-    not the contents of the file itself.
+    The function returns the paths to the downloaded files.
 
     Parameters
     ----------
     filename : str
-        Name of the file to fetch.
+        Name of the pose file to fetch.
 
     Returns
     -------
-    path : pathlib.Path
-        Path to the downloaded file.
+    paths : dict
+        Dictionary mapping file types to their respective paths. The possible
+        file types are: "poses", "frame", "video". If "frame" or "video" are
+        not available, the corresponding value is None.
+
+    Examples
+    --------
+    >>> from movement.sample_data import fetch_dataset_paths
+    >>> paths = fetch_dataset_paths("DLC_single-mouse_EPM.predictions.h5")
+    >>> poses_path = paths["poses"]
+    >>> frame_path = paths["frame"]
+    >>> video_path = paths["video"]
+
+    See Also
+    --------
+    fetch_dataset
 
     """
-    try:
-        return Path(SAMPLE_DATA.fetch(f"poses/{filename}", progressbar=True))
-    except ValueError as error:
-        raise log_error(
-            ValueError,
+    available_pose_files = list_datasets()
+    if filename not in available_pose_files:
+        raise ValueError(
             f"File '{filename}' is not in the registry. Valid "
-            f"filenames are: {list_sample_data()}",
-        ) from error
+            f"filenames are: {available_pose_files}"
+        )
+
+    metadata_ = next(
+        file for file in metadata if file["file_name"] == filename
+    )
+
+    paths = {
+        "poses": Path(
+            SAMPLE_DATA.fetch(f"poses/{filename}", progressbar=True)
+        ),
+        "frame": None,
+        "video": None,
+    }
+
+    frame_file_name = metadata_["frame"]["file_name"]
+    video_file_name = metadata_["video"]["file_name"]
+
+    if frame_file_name:
+        paths["frame"] = Path(SAMPLE_DATA.fetch(f"frames/{frame_file_name}"))
+    if video_file_name:
+        paths["video"] = Path(SAMPLE_DATA.fetch(f"videos/{video_file_name}"))
+
+    return paths
 
 
-def fetch_sample_data(
+def fetch_dataset(
     filename: str,
 ) -> xarray.Dataset:
-    """Download sample pose data and load it as an xarray Dataset.
+    """Load a sample dataset containing pose data.
 
-    The data are downloaded from the *movement* data repository to the user's
+    The data are downloaded from the ``movement`` data repository to the user's
     local machine upon first use and are stored in a local cache directory.
     This function returns the pose data as an xarray Dataset.
+    If there are any associated frames or videos, these files are also
+    downloaded and the paths are stored as dataset attributes.
 
     Parameters
     ----------
@@ -217,15 +251,30 @@ def fetch_sample_data(
     ds : xarray.Dataset
         Pose data contained in the fetched sample file.
 
+    Examples
+    --------
+    >>> from movement.sample_data import fetch_dataset
+    >>> ds = fetch_dataset("DLC_single-mouse_EPM.predictions.h5")
+    >>> frame_path = ds.video_path
+    >>> video_path = ds.frame_path
+
+    See Also
+    --------
+    fetch_dataset_paths
+
     """
-    file_path = fetch_sample_data_path(filename)
-    file_metadata = next(
+    file_paths = fetch_dataset_paths(filename)
+
+    metadata_ = next(
         file for file in metadata if file["file_name"] == filename
     )
 
     ds = load_poses.from_file(
-        file_path,
-        source_software=file_metadata["source_software"],
-        fps=file_metadata["fps"],
+        file_paths["poses"],
+        source_software=metadata_["source_software"],
+        fps=metadata_["fps"],
     )
+    ds.attrs["frame_path"] = file_paths["frame"]
+    ds.attrs["video_path"] = file_paths["video"]
+
     return ds

--- a/movement/sample_data.py
+++ b/movement/sample_data.py
@@ -202,9 +202,10 @@ def fetch_dataset_paths(filename: str) -> dict:
     """
     available_pose_files = list_datasets()
     if filename not in available_pose_files:
-        raise ValueError(
-            f"File '{filename}' is not in the registry. Valid "
-            f"filenames are: {available_pose_files}"
+        raise log_error(
+            ValueError,
+            f"File '{filename}' is not in the registry. "
+            f"Valid filenames are: {available_pose_files}",
         )
 
     metadata_ = next(

--- a/movement/sample_data.py
+++ b/movement/sample_data.py
@@ -127,15 +127,15 @@ def _generate_file_registry(metadata: list[dict]) -> dict[str, str]:
         "poses/" + ds["file_name"]: ds["sha256sum"] for ds in metadata
     }
 
-    ds_with_frames = [ds for ds in metadata if ds["frame"]["file"]]
+    ds_with_frames = [ds for ds in metadata if ds["frame"]["file_name"]]
     frames_registry = {
-        "frames" + ds["frame"]["file"]: ds["frame"]["sha256sum"]
+        "frames" + ds["frame"]["file_name"]: ds["frame"]["sha256sum"]
         for ds in ds_with_frames
     }
 
-    ds_with_videos = [ds for ds in metadata if ds["video"]["file"]]
+    ds_with_videos = [ds for ds in metadata if ds["video"]["file_name"]]
     videos_registry = {
-        "videos" + ds["video"]["file"]: ds["video"]["sha256sum"]
+        "videos" + ds["video"]["file_name"]: ds["video"]["sha256sum"]
         for ds in ds_with_videos
     }
     return {**poses_registry, **frames_registry, **videos_registry}

--- a/movement/sample_data.py
+++ b/movement/sample_data.py
@@ -107,7 +107,7 @@ def _fetch_metadata(file_name: str, data_dir: Path = DATA_DIR) -> list[dict]:
     return metadata
 
 
-metadata = _fetch_metadata("poses_files_metadata.yaml")
+metadata = _fetch_metadata("metadata.yaml")
 
 # Create a download manager for the pose data
 SAMPLE_DATA = pooch.create(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ import xarray as xr
 
 from movement.logging import configure_logging
 from movement.move_accessor import MoveAccessor
-from movement.sample_data import fetch_sample_data_path, list_sample_data
+from movement.sample_data import fetch_dataset_paths, list_datasets
 
 
 def pytest_configure():
@@ -21,8 +21,8 @@ def pytest_configure():
     Fetches pose data file paths as a dictionary for tests.
     """
     pytest.POSE_DATA_PATHS = {
-        file_name: fetch_sample_data_path(file_name)
-        for file_name in list_sample_data()
+        file_name: fetch_dataset_paths(file_name)["poses"]
+        for file_name in list_datasets()
     }
 
 

--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -7,13 +7,13 @@ from movement.filtering import (
     interpolate_over_time,
     log_to_attrs,
 )
-from movement.sample_data import fetch_sample_data
+from movement.sample_data import fetch_dataset
 
 
 @pytest.fixture(scope="module")
 def sample_dataset():
     """Return a single-individual sample dataset."""
-    return fetch_sample_data("DLC_single-mouse_EPM.predictions.h5")
+    return fetch_dataset("DLC_single-mouse_EPM.predictions.h5")
 
 
 def test_log_to_attrs(sample_dataset):

--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -74,7 +74,7 @@ def test_filter_by_confidence(sample_dataset, caplog):
             ).values[:, 0]
         )
     )
-    assert n_nans == 3213
+    assert n_nans == 2555
 
     # Check that diagnostics are being logged correctly
     assert f"snout: {n_nans}/{ds_filtered.time.values.shape[0]}" in caplog.text

--- a/tests/test_unit/test_sample_data.py
+++ b/tests/test_unit/test_sample_data.py
@@ -36,7 +36,8 @@ def validate_metadata(metadata: list[dict]) -> None:
         "species",
         "number_of_individuals",
         "shared_by",
-        "video_frame_file",
+        "frame",
+        "video",
         "note",
     ]
     check_yaml_msg = "Check the format of the metadata yaml file."

--- a/tests/test_unit/test_sample_data.py
+++ b/tests/test_unit/test_sample_data.py
@@ -77,7 +77,7 @@ def test_fetch_metadata(tmp_path, caplog, download_fails, local_exists):
     fails, it will try to load an existing local file. If neither succeeds,
     an error is raised.
     """
-    metadata_file_name = "poses_files_metadata.yaml"
+    metadata_file_name = "metadata.yaml"
     local_file_path = tmp_path / metadata_file_name
 
     with patch("movement.sample_data.DATA_DIR", tmp_path):


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Having video files, and/or frames extracted from those videos, associated with existing sample pose files will greatly facilitate the development and debugging of GUIs, because it would allow us to plot trajectories over a meaningful background, define ROIs etc. See all the issues linked in References.

**What does this PR do?**

It overhauls the `sample_data.py` module to allow for the fetching of videos and/or frames alongside the fetching of pose files.
All the changes were done in conjunction with changes to the [data repository on GIN](https://gin.g-node.org/neuroinformatics/movement-test-data) and should be interpreted together.

Changes to the data repository:
- added folders for "videos" and "frames", in addition to the existing "poses" folder. Populated these folders with files for which the researcher(s) have given permission to share. Some video/frame file are shared across multiple pose files (because e.g. the same video was analysed with DeepLabCut and SLEAP).
- the metadata file is now named `metadata.yaml`. I added new metadata fields, to express the association between pose datasets and videos/frames. Here's an example entry:
```yaml
- file_name: "SLEAP_three-mice_Aeon_proofread.analysis.h5"
  sha256sum: "82ebd281c406a61536092863bc51d1a5c7c10316275119f7daf01c1ff33eac2a"
  source_software: "SLEAP"
  fps: 50
  species: "mouse"
  number_of_individuals: 3
  shared_by:
    name: "Chang Huan Lo"
    affiliation: "Sainsbury Wellcome Centre, UCL"
  frame:
    file_name: "three-mice_Aeon_frame-5sec.png"
    sha256sum: "889e1bbee6cb23eb6d52820748123579acbd0b2a7265cf72a903dabb7fcc3d1a"
  video:
    file_name: "three-mice_Aeon_video.avi"
    sha256sum: "bc7406442c90467f11a982fd6efd85258ec5ec7748228b245caf0358934f0e7d"
  note: "All labels were proofread (user-defined) and can be considered ground truth. It was exported from the .slp file with the same prefix."
```
- added a new convenience script `get_sha256_hashes.py` which will iterate over all files in `poses`, `videos`, and `frames` and write the results to txt files (`poses_hashes.txt`, `videos_hashes.txt`, `frames_hashes.txt`). It doesn't go all the way to fully automate the generation of metadata.yaml entries, but it is an improvement on previous practices.

Changes to the code repository (this PR):
- The `sample_data.py` module now exposes 3 public functions:
	- `list_datasets()`: returns the filenames of the sample pose files (the one in the `poses` folder)
	- `fetch_dataset_paths(filename)`: given a filename of a valid pose dataset (one that the above function returns), return a dict of 3 local paths, with keys "poses", "video", "frame". If video or frame is missing, their value is None.
	```python
	from movement.sample_data import fetch_dataset_paths
	paths = fetch_dataset_paths("DLC_single-mouse_EPM.predictions.h5")
	poses_path = paths["poses"]
	frame_path = paths["frame"]
	video_path = paths["video"]
	```
	- `fetch_dataset(filename`) : given a filename of a valid pose dataset (one that `list_datasets()` returns), calls `fetch_dataset_paths(filename)` and proceed to load the "poses" into a movement dataset. The "video" and "frame" paths do not get loaded (for now), they are simply stored as dataset attributes.
	```python
	from movement.sample_data import fetch_dataset
	ds = fetch_dataset("DLC_single-mouse_EPM.predictions.h5")
	frame_path = ds.video_path
	video_path = ds.frame_path
	```
	This is the function we expect to be most used, and the updated docs reflect that. 
- Tests, docs, and contributing guide have been updated accordingly. The availability of video frames means that we can also add images to the plots in our examples, but I haven't done this here, as it will be part of the big docs re-organisation #70.


## References
Closes #38.
Closes #121 because the syntax is much less awkward (with fewer redundancies), and I think there is no longer a clear need for rewriting the `sample_data.py` module into a class.

Facilitates #105, #49, #50, #48, #164.

## How has this PR been tested?
Updated existing tests in `test_sample_data.py`.

## Is this a breaking change?

Yes, the API for fetching sample datasets has changed. This PR need to be merged ahead of any others, because the changes to the GIN data repository have broken CI, and it will remain broken until this is merged.

## Does this PR require an update to the documentation?

Yes, I've updated the relevant sections of the docs.


## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
