### PR TITLE
update pypi dev status from pre-alpha to alpha

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 
 classifiers = [
-  "Development Status :: 2 - Pre-Alpha",
+  "Development Status :: 3 - Alpha",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
I had completely forgotten this was still set to "Pre-Alpha".
I think "Alpha" is justified in our case? 