### PR TITLE
Refactor accessor to provide methods instead of properties

### DIFF
--- a/examples/compute_kinematics.py
+++ b/examples/compute_kinematics.py
@@ -117,8 +117,9 @@ plt.gcf().show()
 # ---------------------
 # We can start off by computing the distance travelled by the mice along
 # their trajectories.
-# For this, we can use the ``displacement`` method of the ``move`` accessor.
-displacement = ds.move.displacement
+# For this, we can use the ``compute_displacement`` method of the
+# ``move`` accessor.
+displacement = ds.move.compute_displacement()
 
 # %%
 # This method will return a data array equivalent to the ``position`` one,
@@ -133,14 +134,6 @@ displacement = ds.move.displacement
 import movement.analysis.kinematics as kin
 
 displacement_kin = kin.compute_displacement(position)
-
-# %%
-# However, we encourage our users to familiarise themselves with the ``move``
-# accessor, since it has a very interesting advantage: if we use
-# ``ds.move.displacement`` to compute the displacement data array, it
-# will be automatically added to the ``ds`` dataset. This is very
-# convenient for later analyses!
-# See further details in :ref:`target-access-kinematics`.
 
 # %%
 # The ``displacement`` data array holds, for a given individual and keypoint
@@ -277,7 +270,7 @@ print(
 # ----------------
 # We can easily compute the velocity vectors for all individuals in our data
 # array:
-velocity = ds.move.velocity
+velocity = ds.move.compute_velocity()
 
 # %%
 # The ``velocity`` method will return a data array equivalent to the
@@ -358,7 +351,7 @@ fig.show()
 # Compute acceleration
 # ---------------------
 # We can compute the acceleration of the data with an equivalent method:
-accel = ds.move.acceleration
+accel = ds.move.compute_acceleration()
 
 # %%
 # and plot of the components of the acceleration vector ``ax``, ``ay`` per
@@ -399,30 +392,3 @@ for mouse_name, ax in zip(accel.individuals.values, axes):
     ax.set_xlabel("time (s)")
     ax.set_ylabel("accel (px/s**2)")
 fig.tight_layout()
-
-
-# %%
-# .. _target-access-kinematics:
-#
-# Accessing pre-computed kinematic variables
-# ------------------------------------------
-# Once each kinematic variable has been computed via the ``move`` accessor,
-# (e.g. by calling ``ds.move.velocity``), the resulting data array will
-# also be available as a dataset property, (e.g. as ``ds.velocity``).
-# Since we've already computed ``displacement``, ``velocity`` and
-# ``acceleration`` above, they should be listed among the data arrays
-# contained in the dataset:
-print(ds)
-
-# %%
-# Indeed we see that in addition to the original data arrays ``position``
-# and ``confidence``, the ``ds`` dataset now also contains data arrays called
-# ``displacement``, ``velocity`` and ``acceleration``.
-
-print(ds.displacement)
-
-# %%
-print(ds.velocity)
-
-# %%
-print(ds.acceleration)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -322,9 +322,7 @@ def invalid_poses_dataset(request):
     return request.getfixturevalue(request.param)
 
 
-@pytest.fixture(
-    params=["position", "displacement", "velocity", "acceleration"]
-)
+@pytest.fixture(params=["displacement", "velocity", "acceleration"])
 def kinematic_property(request):
     """Return a kinematic property."""
     return request.param

--- a/tests/test_integration/test_kinematics_vector_transform.py
+++ b/tests/test_integration/test_kinematics_vector_transform.py
@@ -27,7 +27,7 @@ class TestKinematicsVectorTransform:
         """
         ds = request.getfixturevalue(ds)
         with expected_exception:
-            data = getattr(ds.move, kinematic_property)
+            data = getattr(ds.move, f"compute_{kinematic_property}")()
             pol_data = vector.cart2pol(data)
             cart_data = vector.pol2cart(pol_data)
             xr.testing.assert_allclose(cart_data, data)

--- a/tests/test_unit/test_move_accessor.py
+++ b/tests/test_unit/test_move_accessor.py
@@ -8,9 +8,9 @@ class TestMoveAccessor:
     def test_compute_kinematics_with_valid_dataset(
         self, valid_poses_dataset, kinematic_property
     ):
-        """Test that computing a kinematic property (in Cartesian
-        coordinates) of a valid pose dataset via accessor functions
-        returns an instance of xr.DataArray.
+        """Test that computing a kinematic property of a valid
+        pose dataset via accessor methods returns an instance of
+        xr.DataArray.
         """
         result = getattr(
             valid_poses_dataset.move, f"compute_{kinematic_property}"
@@ -20,9 +20,8 @@ class TestMoveAccessor:
     def test_compute_kinematics_with_invalid_dataset(
         self, invalid_poses_dataset, kinematic_property
     ):
-        """Test that computing a kinematic property (in Cartesian
-        coordinates) of an invalid pose dataset via accessor functions
-        raises the appropriate error.
+        """Test that computing a kinematic property of an invalid
+        pose dataset via accessor methods raises the appropriate error.
         """
         expected_exception = (
             ValueError
@@ -38,6 +37,6 @@ class TestMoveAccessor:
         "method", ["compute_invalid_property", "do_something"]
     )
     def test_invalid_compute(self, valid_poses_dataset, method):
-        """Test that invalid method calls raise an AttributeError."""
+        """Test that invalid accessor method calls raise an AttributeError."""
         with pytest.raises(AttributeError):
             getattr(valid_poses_dataset.move, method)()

--- a/tests/test_unit/test_move_accessor.py
+++ b/tests/test_unit/test_move_accessor.py
@@ -5,26 +5,23 @@ import xarray as xr
 class TestMoveAccessor:
     """Test suite for the move_accessor module."""
 
-    @pytest.mark.parametrize("suffix", ["", "_pol"])
-    def test_property_with_valid_dataset(
-        self, valid_poses_dataset, kinematic_property, suffix
+    def test_compute_kinematics_with_valid_dataset(
+        self, valid_poses_dataset, kinematic_property
     ):
-        """Test that accessing a kinematic property (in Cartesian
-        or polar coordinates) of a valid pose dataset returns an
-        instance of xr.DataArray with the correct name, and that
-        the input xr.Dataset now contains the property as a data
-        variable.
+        """Test that computing a kinematic property (in Cartesian
+        coordinates) of a valid pose dataset via accessor functions
+        returns an instance of xr.DataArray.
         """
-        kinematic_property += suffix
-        result = getattr(valid_poses_dataset.move, kinematic_property)
+        result = getattr(
+            valid_poses_dataset.move, f"compute_{kinematic_property}"
+        )()
         assert isinstance(result, xr.DataArray)
-        assert result.name == kinematic_property
-        assert kinematic_property in valid_poses_dataset.data_vars
 
-    def test_property_with_invalid_dataset(
+    def test_compute_kinematics_with_invalid_dataset(
         self, invalid_poses_dataset, kinematic_property
     ):
-        """Test that accessing a property of an invalid pose dataset
+        """Test that computing a kinematic property (in Cartesian
+        coordinates) of an invalid pose dataset via accessor functions
         raises the appropriate error.
         """
         expected_exception = (
@@ -33,4 +30,14 @@ class TestMoveAccessor:
             else AttributeError
         )
         with pytest.raises(expected_exception):
-            getattr(invalid_poses_dataset.move, kinematic_property)
+            getattr(
+                invalid_poses_dataset.move, f"compute_{kinematic_property}"
+            )()
+
+    @pytest.mark.parametrize(
+        "method", ["compute_invalid_property", "do_something"]
+    )
+    def test_invalid_compute(self, valid_poses_dataset, method):
+        """Test that invalid method calls raise an AttributeError."""
+        with pytest.raises(AttributeError):
+            getattr(valid_poses_dataset.move, method)()


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
This PR closes #162.
 
**What does this PR do?**
This PR refactors the `MoveAccessor` by replacing the kinematic property accessors with "convenience" `compute` methods, which allow users to compute kinematic variables of a Dataset, for instance, by calling `ds.move.compute_velocity()`. It does so by overriding the `__getattr__` method to "forward" method calls to the relevant modules. Atm, it only calls `compute_` methods implemented in the `kinematics` module, but this can be expanded upon for other modules as needed. 

## References
#162

## How has this PR been tested?
Tests have been updated accordingly.

## Does this PR require an update to the documentation?
The compute kinematics example has been updated accordingly.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
