### PR TITLE
Unpin sphinx version in docs requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ myst-parser
 nbsphinx
 pydata-sphinx-theme
 setuptools-scm
-sphinx<7.2
+sphinx>=7.0
 sphinx-autodoc-typehints
 sphinx-design
 sphinx-gallery


### PR DESCRIPTION
## Description
For some reason, which I have since forgotten, we had pinned the sphinx version to <7.2
It could have been [this reason](https://github.com/neuroinformatics-unit/HowTo/pull/55#issuecomment-2118312367) described by @JoeZiminski. If that was the reason, it shouldn't be a problem anymore, since we are already applying the `exclude_patterns` solution.

This PR changes the dependency constraint from <7.2 to >=7.0, so we should get the latest version.

I tested with sphinx local builds, and it works without error/warnings.
Let' see if the CI passes....