### PR TITLE
Suggestion to rename private loader

### DIFF
--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -307,7 +307,7 @@ def _from_lp_or_dlc_file(
 
     # Load the DLC poses into a DataFrame
     if file.path.suffix == ".csv":
-        df = _parse_dlc_csv_to_df(file.path)
+        df = _load_df_from_dlc_csv(file.path)
     else:  # file.path.suffix == ".h5"
         df = _load_df_from_dlc_h5(file.path)
 
@@ -484,7 +484,7 @@ def _sleap_labels_to_numpy(labels: Labels) -> np.ndarray:
     return tracks
 
 
-def _parse_dlc_csv_to_df(file_path: Path) -> pd.DataFrame:
+def _load_df_from_dlc_csv(file_path: Path) -> pd.DataFrame:
     """Parse a DeepLabCut-style .csv file into a pandas DataFrame.
 
     If poses are loaded from a DeepLabCut .csv file, the DataFrame


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
We have two private data loading functions to read DLC files into a dataframe: `_parse_dlc_csv_to_df` and `_load_df_from_dlc_h5`. 

This PR proposes to rename one of them (`_parse_dlc_csv_to_df` -> `_load_df_from_dlc_csv`) , for a more consistent naming of the two.

**What does this PR do?**
Renames a private data loading function.

## References
\

## How has this PR been tested?

Tests pass locally and in CI.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No because it is a private function.

## Checklist:

- [x] The code has been tested locally
- [ n/a ] Tests have been added to cover all new functionality
- [ n/a ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
