### PR TITLE
Rename roadmap -> roadmaps in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Pose estimation tools, such as [DeepLabCut](https://www.mackenziemathislab.org/d
 movement aims to provide a consistent modular interface to analyse pose tracks, allowing steps such as data cleaning, visualisation and motion quantification.
 We aim to support a range of pose estimation packages, along with 2D or 3D tracking of single or multiple individuals.
 
-Find out more on our [mission and scope](https://movement.neuroinformatics.dev/community/mission-scope.html) statement and our [roadmap](https://movement.neuroinformatics.dev/community/roadmap.html).
+Find out more on our [mission and scope](https://movement.neuroinformatics.dev/community/mission-scope.html) statement and our [roadmap](https://movement.neuroinformatics.dev/community/roadmaps.html).
 
 ## Status
 > [!Warning]

--- a/docs/source/community/index.md
+++ b/docs/source/community/index.md
@@ -3,7 +3,7 @@
 Contributions to movement are absolutely encouraged, whether to fix a bug,
 develop a new feature, or improve the documentation.
 To help you get started, we have prepared a statement on the project's [mission and scope](target-mission),
-a [roadmap](target-roadmap) outlining our current priorities, and a detailed [contributing guide](target-contributing).
+a [roadmap](target-roadmaps) outlining our current priorities, and a detailed [contributing guide](target-contributing).
 
 ```{include} ../snippets/get-in-touch.md
 ```
@@ -13,7 +13,7 @@ a [roadmap](target-roadmap) outlining our current priorities, and a detailed [co
 :hidden:
 
 mission-scope
-roadmap
+roadmaps
 contributing
 related-projects
 license

--- a/docs/source/community/mission-scope.md
+++ b/docs/source/community/mission-scope.md
@@ -9,7 +9,7 @@
 
 At its core, movement handles trajectories of *keypoints*, which are specific body parts of an *individual*. An individual's posture or *pose* is represented by a set of keypoint coordinates, given in 2D (x,y) or 3D (x,y,z). The sequential collection of poses over time forms *pose tracks*. In neuroscience, these tracks are typically extracted from video data using software like [DeepLabCut](dlc:) or [SLEAP](sleap:).
 
-With movement, our vision is to present a **consistent interface for pose tracks** and to **analyze them using modular and accessible tools**. We aim to accommodate data from a range of pose estimation packages, in **2D or 3D**, tracking **single or multiple individuals**. The focus will be on providing functionalities for data cleaning, visualisation and motion quantification (see the [Roadmap](target-roadmap) for details).
+With movement, our vision is to present a **consistent interface for pose tracks** and to **analyze them using modular and accessible tools**. We aim to accommodate data from a range of pose estimation packages, in **2D or 3D**, tracking **single or multiple individuals**. The focus will be on providing functionalities for data cleaning, visualisation and motion quantification (see the [Roadmap](target-roadmaps) for details).
 
 While movement is not designed for behaviour classification or action segmentation, it may extract features useful for these tasks. We are planning to develop separate packages for this purpose, which will be compatible with movement and the existing ecosystem of related tools.
 

--- a/docs/source/community/roadmaps.md
+++ b/docs/source/community/roadmaps.md
@@ -1,5 +1,5 @@
-(target-roadmap)=
-# Roadmap
+(target-roadmaps)=
+# Roadmaps
 
 The roadmap outlines **current development priorities** and aims to **guide core developers** and to **encourage community contributions**. It is a living document and will be updated as the project evolves.
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -37,7 +37,7 @@ Pose estimation tools, such as [DeepLabCut](dlc:) and [SLEAP](sleap:) are now co
 movement aims to provide a consistent modular interface to analyse pose tracks, allowing steps such as data cleaning, visualisation and motion quantification.
 We aim to support a range of pose estimation packages, along with 2D or 3D tracking of single or multiple individuals.
 
-Find out more on our [mission and scope](target-mission) statement and our [roadmap](target-roadmap).
+Find out more on our [mission and scope](target-mission) statement and our [roadmap](target-roadmaps).
 
 ```{include} /snippets/status-warning.md
 ```


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
For future-proofing, we decided to have in our docs a link to all our roadmaps (similar to [brainglobe](https://brainglobe.info/community/roadmaps/index.html)).

**What does this PR do?**
- Renames the title of the Roadmaps site to be in plural.
- Renames the .md file itself and the associated target variable for consistency.

## References
\

## How has this PR been tested?
Tests pass locally and in CI, docs build locally.

## Is this a breaking change?

\

## Does this PR require an update to the documentation?

\

## Checklist:

- [x] The code has been tested locally
- [ n/a ] Tests have been added to cover all new functionality
- [ n/a ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
