### PR TITLE
Added example using `median_filter()` and `savgol_filter()`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -166,6 +166,10 @@ linkcheck_anchors_ignore_for_url = [
     "https://neuroinformatics.zulipchat.com/",
     "https://github.com/talmolab/sleap/blob/v1.3.3/sleap/info/write_tracking_h5.py",
 ]
+# A list of regular expressions that match URIs that should not be checked
+linkcheck_ignore = [
+    "https://pubs.acs.org/doi/*",  # Checking dois is forbidden here
+]
 
 myst_url_schemes = {
     "http": None,

--- a/examples/compute_kinematics.py
+++ b/examples/compute_kinematics.py
@@ -2,7 +2,7 @@
 """Compute and visualise kinematics.
 ====================================
 
-Compute displacement, velocity and acceleration data on an example dataset and
+Compute displacement, velocity and acceleration, and
 visualise the results.
 """
 

--- a/examples/filter_and_interpolate.py
+++ b/examples/filter_and_interpolate.py
@@ -1,5 +1,5 @@
-"""Filtering and interpolation
-============================
+"""Drop outliers and interpolate
+================================
 
 Filter out points with low confidence scores and interpolate over
 missing values.

--- a/examples/smooth.py
+++ b/examples/smooth.py
@@ -15,43 +15,34 @@ from movement import sample_data
 from movement.filtering import (
     interpolate_over_time,
     median_filter,
+    savgol_filter,
 )
 
 # %%
 # Load some sample datasets
 # -------------------------
+# Let's load a sample dataset and print it to inspect its contents.
+#   Note that if you are running this notebook interactively, you can simply
+#   type the variable name (here ``ds_wasp``) in a cell to get an interactive
+#   display of the dataset's contents.
 
 ds_wasp = sample_data.fetch_dataset("DLC_single-wasp.predictions.h5")
-ds_mouse = sample_data.fetch_dataset("SLEAP_single-mouse_EPM.analysis.h5")
+print(ds_wasp)
 
 # %%
-# Let's inspect the loaded datasets
-
-ds_wasp
-
-# %%
-# We see that the wasp dataset has a single individual with two keypoints,
-# ``head`` and ``thorax`` tracked in 2D space. The video was recorded at 40 fps
-# and lasts for ~27 seconds.
-#
-# Now let's take a look at the mouse dataset.
-
-
-ds_mouse
+# We see that the dataset contains a single individual (a wasp) with two
+# keypoints tracked in 2D space. The video was recorded at 40 fps and lasts for
+# ~27 seconds.
 
 # %%
-# The mouse dataset has a single individual with six keypoints tracked in 2D
-# space. The video was recorded at 30 fps and lasts for ~616 seconds. We can
-# see that the data contains some missing (nan) values.
-#
-# Note also that the ``time unit``` for both datasets is seconds.
-
-
-# %%
-# Define some plotting functions
-# ------------------------------
-# Let us define some plotting functions that will help us visualise the
-# effects of smoothing.
+# Define a plotting function
+# --------------------------
+# Let's define a plotting function to help us visualise the effects smoothing
+# both in the time and frequency domains.
+# The function takes as inputs two datasets containing raw and smooth data
+# respectively, and plots the position time series and power spectral density
+# (PSD) for a given individual and keypoint. The function also allows you to
+# specify the spatial coordinate (``x`` or ``y``) and a time range to focus on.
 
 
 def plot_raw_and_smooth_timeseries_and_psd(
@@ -59,107 +50,78 @@ def plot_raw_and_smooth_timeseries_and_psd(
     ds_smooth,
     individual="individual_0",
     keypoint="stinger",
+    space="x",
     time_range=None,
 ):
-    """Plot position time series and PSD before and after smoothing.
-
-    Only the x coortinate of the chosen keypoint is plotted.
-    """
-    # If not time range is provided, plot the entire time series
+    # If no time range is specified, plot the entire time series
     if time_range is None:
         time_range = slice(0, ds_raw.time[-1])
+
     selection = {
         "time": time_range,
         "individuals": individual,
         "keypoints": keypoint,
-        "space": "x",
+        "space": space,
     }
 
-    pos_raw = ds_raw.position.sel(**selection)
-    pos_smooth = ds_smooth.position.sel(**selection)
+    fig, ax = plt.subplots(2, 1, figsize=(10, 6))
 
-    fig, ax = plt.subplots(2, 1, figsize=(10, 8))
+    for ds, color, label in zip(
+        [ds_raw, ds_smooth], ["k", "r"], ["raw", "smooth"]
+    ):
+        # plot position time series
+        pos = ds.position.sel(**selection)
+        ax[0].plot(
+            pos.time,
+            pos,
+            color=color,
+            lw=2,
+            alpha=0.7,
+            label=f"{label} {space}",
+        )
 
-    # Plot the time series for the x coordinate
-    ax[0].plot(
-        pos_raw.time,
-        pos_raw,
-        color="k",
-        lw=2,
-        alpha=0.7,
-        label="raw x",
-    )
-    ax[0].plot(
-        pos_smooth.time,
-        pos_smooth,
-        color="r",
-        lw=2,
-        alpha=0.7,
-        label="smooth x",
-    )
-    ax[0].legend()
-    ax[0].set_ylabel("x position (px)")
+        # generate interpolated dataset to avoid NaNs in the PSD calculation
+        ds_interp = interpolate_over_time(ds, max_gap=None, print_report=False)
+        pos_interp = ds_interp.position.sel(**selection)
+        # compute and plot the PSD
+        freq, psd = welch(pos_interp, fs=ds.fps, nperseg=256)
+        ax[1].semilogy(
+            freq,
+            psd,
+            color=color,
+            lw=2,
+            alpha=0.7,
+            label=f"{label} {space}",
+        )
+
+    ax[0].set_ylabel(f"{space} position (px)")
     ax[0].set_xlabel("Time (s)")
     ax[0].set_title("Time Domain")
+    ax[0].legend()
 
-    # Generate interpolated datasets to avoid NaNs in the PSD calculation
-    ds_raw_interp = interpolate_over_time(
-        ds_raw, max_gap=None, print_report=False
-    )
-    ds_smooth_interp = interpolate_over_time(
-        ds_smooth, max_gap=None, print_report=False
-    )
-    pos_raw_interp = ds_raw_interp.position.sel(**selection)
-    pos_smooth_interp = ds_smooth_interp.position.sel(**selection)
-
-    # Calculate and plot the PSD for the x coordinate
-    f_raw, Pxx_raw = welch(
-        pos_raw_interp,
-        fs=ds_raw.fps,
-        nperseg=256,
-    )
-    f_smooth, Pxx_smooth = welch(
-        pos_smooth_interp,
-        fs=ds_smooth.fps,
-        nperseg=256,
-    )
-
-    ax[1].semilogy(
-        f_raw,
-        Pxx_raw,
-        color="k",
-        lw=2,
-        alpha=0.7,
-        label="raw x",
-    )
-    ax[1].semilogy(
-        f_smooth,
-        Pxx_smooth,
-        color="r",
-        lw=2,
-        alpha=0.7,
-        label="smooth x",
-    )
-    ax[1].legend()
     ax[1].set_ylabel("PSD (dB/Hz)")
     ax[1].set_xlabel("Frequency (Hz)")
     ax[1].set_title("Frequency Domain")
+    ax[1].legend()
 
     plt.tight_layout()
-    plt.show()
+    fig.show()
 
 
 # %%
-# Smooth using median filter
-# --------------------------
-# Here we apply a rolling window median filter to the wasp dataset.
+# Smoothing with a median filter
+# ------------------------------
+# Here we use the :py:func:`movement.filtering.median_filter` function to
+# apply a rolling window median filter to the wasp dataset.
 # The ``window_length`` parameter is defined in seconds (according to the
-# ``time_unit``` dataset attribute).
+# ``time_unit`` dataset attribute).
 
 ds_wasp_medfilt = median_filter(ds_wasp, window_length=0.1)
 
 # %%
-# Let's visualise the effects of the median filter in the time domain.
+# We see from the printed report that the dataset has no missing values
+# neither before nor after smoothing. Let's visualise the effects of the
+# median filter in the time and frequency domains.
 
 plot_raw_and_smooth_timeseries_and_psd(
     ds_wasp, ds_wasp_medfilt, keypoint="stinger"
@@ -172,31 +134,43 @@ plot_raw_and_smooth_timeseries_and_psd(
 # the filter has reduced the power in the high frequencies, without
 # affecting the very low frequency components.
 #
-# This illustrated what the median filter is good at: removing brief "spikes"
+# This illustrates what the median filter is good at: removing brief "spikes"
 # (e.g. a keypoint abruptly jumping to a different location for a frame or two)
-# and high frequency "jitter" (which is often a consequence of pose estimation
-# working on a per-frame basis). In general, using the median filter is a good
-# idea, but you should choose ``window_length`` conservatively to avoid
-# removing relevant information. Always inspect the results (as we are doing
-# here) to ensure that the filter is not removing important features.
+# and high frequency "jitter" (often present due to pose estimation
+# working on a per-frame basis).
 
 # %%
-# What happens if the data contains missing values (NaNs). Let's apply the
-# same filter to the mouse dataset and see.
+# Choosing parameters for the median filter
+# -----------------------------------------
+# You can control the behaviour of :py:func:`movement.filtering.median_filter`
+# via two parameters: ``window_length`` and ``min_periods``.
+# To better understand the effect of these parameters, let's use a
+# dataset that contains missing values.
+
+ds_mouse = sample_data.fetch_dataset("SLEAP_single-mouse_EPM.analysis.h5")
+print(ds_mouse)
+
+# %%
+# The dataset contains a single mouse with six keypoints tracked in
+# 2D space. The video was recorded at 30 fps and lasts for ~616 seconds. We can
+# see that there are some missing values, indicated as "nan" in the
+# printed dataset. Let's apply the median filter to this dataset, with
+# the ``window_length`` set to 0.1 seconds.
 
 ds_mouse_medfilt = median_filter(ds_mouse, window_length=0.1)
 
 # %%
-# The report informs that the raw data contains some NaN values, particularly
-# for the ``snout`` and ``tail_end``` keypoints. After filtering, the number of
-# NaNs has increased. This is because the the default behaviour of the median
+# The report informs us that the raw data contains NaN values, particularly
+# for the ``snout`` and ``tail_end`` keypoints. After filtering, the number of
+# NaNs has increased. This is because the default behaviour of the median
 # filter is to propagate NaN values, i.e. if any value in the rolling window is
-# NaN, the output will also be NaN. To modify this behaviour, you can set the
-# value of the ``min_periods`` parameter to an integer value. This parameter
-# determines the minimum number of non-NaN values in the window for the output
-# to be non-NaN. For example, setting ``min_periods=2`` would mean that two
-# non-NaN values in the window are sufficient for the median to be calculated
-# (based only on those non-NaN values).
+# NaN, the output will also be NaN.
+#
+# To modify this behaviour, you can set the value of the ``min_periods``
+# parameter to an integer value. This parameter determines the minimum number
+# of non-NaN values in the window for the output to be non-NaN.
+# For example, setting ``min_periods=2`` means that two non-NaN values in the
+# window are sufficient for the median to be calculated. Let's try this.
 
 ds_mouse_medfilt = median_filter(ds_mouse, window_length=0.1, min_periods=2)
 
@@ -204,10 +178,86 @@ ds_mouse_medfilt = median_filter(ds_mouse, window_length=0.1, min_periods=2)
 # We see that this time the number of NaN values has not increased after
 # filtering. Instead, it has even decreased by a bit across keypoints.
 # Let's visualise the effects of the median filter in the time and frequency
-# domains. Here we focus on a 40 second time range for the `snout` keypoint.
+# domains. Here we focus on a 80 second time range for the ``snout`` keypoint.
 # You can adjust the ``keypoint`` and ``time_range`` arguments to explore other
 # parts of the data.
 
 plot_raw_and_smooth_timeseries_and_psd(
-    ds_mouse, ds_mouse_medfilt, keypoint="snout", time_range=slice(0, 40)
+    ds_mouse, ds_mouse_medfilt, keypoint="snout", time_range=slice(0, 80)
 )
+
+# %%
+# The smoothing has reduced high-frequency content but the
+# resulting time series stays quite close to the raw data.
+#
+# What happens if we increase the ``window_length`` to 2 seconds?
+
+ds_mouse_medfilt = median_filter(ds_mouse, window_length=1, min_periods=2)
+
+# %%
+# The number of NaN values has decreased even further. That's because the
+# chance of finding at least 2 valid values within a 2 second window is
+# quite high. Let's plot the results for the same keypoint and time range
+# as before.
+
+plot_raw_and_smooth_timeseries_and_psd(
+    ds_mouse, ds_mouse_medfilt, keypoint="snout", time_range=slice(0, 80)
+)
+# %%
+# We see that the filtered time series is much smoother and it has even
+# "bridged" over some small gaps. That said, it often deviates from the raw
+# data, in ways that may not be desirable, depending on the application.
+# That means that our choice of ``window_length`` may be too large.
+# In general, you should choose a ``window_length`` that is small enough to
+# preserve the original data structure, but large enough to remove
+# "spikes" and high-frequency noise. Always inspect the results to ensure
+# that the filter is not removing important features.
+
+# %%
+# Smoothing with a Savitzky-Golay filter
+# --------------------------------------
+# Here we use the :py:func:`movement.filtering.savgol_filter` function,
+# which is a wrapper around :py:func:`scipy.signal.savgol_filter`.
+# The Savitzky-Golay filter is a polynomial smoothing filter that can be
+# applied to time series data on a rolling window basis. A polynomial of
+# degree ``polyorder`` is fitted to the data in each window of length
+# ``window_length``, and the value of the polynomial at the center of the
+# window is used as the output value.
+#
+# Let's try it on the mouse dataset first.
+
+ds_mouse_savgol = savgol_filter(ds_mouse, window_length=0.2, polyorder=2)
+
+
+# %%
+# We see that the number of NaN values has increased after filtering. This is
+# for the same reason as with the median filter (in it's default mode), i.e.
+# if there is at least one NaN value in the window, the output will be NaN.
+# Unlike the median filter, the Savitzky-Golay filter does not provide a
+# ``min_periods`` parameter to control this behaviour. Let's visualise the
+# effects in the time and frequency domains.
+
+plot_raw_and_smooth_timeseries_and_psd(
+    ds_mouse, ds_mouse_savgol, keypoint="snout", time_range=slice(0, 80)
+)
+# %%
+# We indeed see that high-frequencies have been reduced but the gaps of missing
+# values have increase in extent. Now let's take a look at the wasp dataset.
+
+ds_wasp_savgol = savgol_filter(ds_wasp, window_length=0.2, polyorder=2)
+
+# %%
+plot_raw_and_smooth_timeseries_and_psd(
+    ds_wasp,
+    ds_wasp_savgol,
+    keypoint="stinger",
+)
+# %%
+# This example shows two important limitations of the Savitzky-Golay filter:
+# Firstly, it can introduce "wiggles" around sharp boundaries. For
+# example, focus on what happens around the sudden drop in position
+# during the final second. Secondly, the PSD appears to have large periodic
+# drops in power at certain frequencies. Both of these effects vary with the
+# choice of ``window_length`` and ``polyorder``. You can read more about these
+# and other limitations in
+# `this paper <https://pubs.acs.org/doi/10.1021/acsmeasuresciau.1c00054>`_.

--- a/examples/smooth.py
+++ b/examples/smooth.py
@@ -31,7 +31,7 @@ ds_wasp
 
 # %%
 # We see that the wasp dataset has a single individual with two keypoints,
-# `head` and `thorax` tracked in 2D space. The video was recorded at 40 fps
+# ``head`` and ``thorax`` tracked in 2D space. The video was recorded at 40 fps
 # and lasts for ~27 seconds.
 #
 # Now let's take a look at the mouse dataset.
@@ -44,7 +44,7 @@ ds_mouse
 # space. The video was recorded at 30 fps and lasts for ~616 seconds. We can
 # see that the data contains some missing (nan) values.
 #
-# Note also that the `time unit` for both datasets is seconds.
+# Note also that the ``time unit``` for both datasets is seconds.
 
 
 # %%
@@ -153,8 +153,8 @@ def plot_raw_and_smooth_timeseries_and_psd(
 # Smooth using median filter
 # --------------------------
 # Here we apply a rolling window median filter to the wasp dataset.
-# The `window_length` parameter is defined in seconds (according to the
-# `time_unit` dataset attribute).
+# The ``window_length`` parameter is defined in seconds (according to the
+# ``time_unit``` dataset attribute).
 
 ds_wasp_medfilt = median_filter(ds_wasp, window_length=0.1)
 
@@ -176,9 +176,9 @@ plot_raw_and_smooth_timeseries_and_psd(
 # (e.g. a keypoint abruptly jumping to a different location for a frame or two)
 # and high frequency "jitter" (which is often a consequence of pose estimation
 # working on a per-frame basis). In general, using the median filter is a good
-# idea, but you should choose `window_length` conservatively to avoid removing
-# relevant information. Always inspect the results (as we are doing here) to
-# ensure that the filter is not removing important features.
+# idea, but you should choose ``window_length`` conservatively to avoid
+# removing relevant information. Always inspect the results (as we are doing
+# here) to ensure that the filter is not removing important features.
 
 # %%
 # What happens if the data contains missing values (NaNs). Let's apply the
@@ -188,11 +188,11 @@ ds_mouse_medfilt = median_filter(ds_mouse, window_length=0.1)
 
 # %%
 # The report informs that the raw data contains some NaN values, particularly
-# for the `snout` and `tail_end` keypoints. After filtering, the number of NaNs
-# has increased. This is because the the default behaviour of the median filter
-# is to propagate NaN values, i.e. if any value in the rolling window is NaN,
-# the output will also be NaN. To modify this behaviour, you can set the value
-# of the ``min_periods`` parameter to an integer value. This parameter
+# for the ``snout`` and ``tail_end``` keypoints. After filtering, the number of
+# NaNs has increased. This is because the the default behaviour of the median
+# filter is to propagate NaN values, i.e. if any value in the rolling window is
+# NaN, the output will also be NaN. To modify this behaviour, you can set the
+# value of the ``min_periods`` parameter to an integer value. This parameter
 # determines the minimum number of non-NaN values in the window for the output
 # to be non-NaN. For example, setting ``min_periods=2`` would mean that two
 # non-NaN values in the window are sufficient for the median to be calculated
@@ -205,11 +205,9 @@ ds_mouse_medfilt = median_filter(ds_mouse, window_length=0.1, min_periods=2)
 # filtering. Instead, it has even decreased by a bit across keypoints.
 # Let's visualise the effects of the median filter in the time and frequency
 # domains. Here we focus on a 40 second time range for the `snout` keypoint.
-# You can adjust the `keypoint` and `time_range` arguments to explore other
+# You can adjust the ``keypoint`` and ``time_range`` arguments to explore other
 # parts of the data.
 
 plot_raw_and_smooth_timeseries_and_psd(
     ds_mouse, ds_mouse_medfilt, keypoint="snout", time_range=slice(0, 40)
 )
-
-# %%

--- a/examples/smooth.py
+++ b/examples/smooth.py
@@ -99,7 +99,7 @@ def plot_raw_and_smooth_timeseries_and_psd(
     ax[0].set_title("Time Domain")
     ax[0].legend()
 
-    ax[1].set_ylabel("PSD (dB/Hz)")
+    ax[1].set_ylabel("PSD (px$^2$/Hz)")
     ax[1].set_xlabel("Frequency (Hz)")
     ax[1].set_title("Frequency Domain")
     ax[1].legend()

--- a/examples/smooth.py
+++ b/examples/smooth.py
@@ -1,7 +1,7 @@
-"""Smoothing
-============
+"""Smooth pose tracks
+=====================
 
-Smoothing pose tracks using median and Savitzky-Golay filters.
+Smooth pose tracks using median or Savitzky-Golay filters.
 """
 
 # %%

--- a/examples/smooth.py
+++ b/examples/smooth.py
@@ -1,0 +1,215 @@
+"""Smoothing
+============
+
+Smoothing pose tracks using median and Savitzky-Golay filters.
+"""
+
+# %%
+# Imports
+# -------
+
+from matplotlib import pyplot as plt
+from scipy.signal import welch
+
+from movement import sample_data
+from movement.filtering import (
+    interpolate_over_time,
+    median_filter,
+)
+
+# %%
+# Load some sample datasets
+# -------------------------
+
+ds_wasp = sample_data.fetch_dataset("DLC_single-wasp.predictions.h5")
+ds_mouse = sample_data.fetch_dataset("SLEAP_single-mouse_EPM.analysis.h5")
+
+# %%
+# Let's inspect the loaded datasets
+
+ds_wasp
+
+# %%
+# We see that the wasp dataset has a single individual with two keypoints,
+# `head` and `thorax` tracked in 2D space. The video was recorded at 40 fps
+# and lasts for ~27 seconds.
+#
+# Now let's take a look at the mouse dataset.
+
+
+ds_mouse
+
+# %%
+# The mouse dataset has a single individual with six keypoints tracked in 2D
+# space. The video was recorded at 30 fps and lasts for ~616 seconds. We can
+# see that the data contains some missing (nan) values.
+#
+# Note also that the `time unit` for both datasets is seconds.
+
+
+# %%
+# Define some plotting functions
+# ------------------------------
+# Let us define some plotting functions that will help us visualise the
+# effects of smoothing.
+
+
+def plot_raw_and_smooth_timeseries_and_psd(
+    ds_raw,
+    ds_smooth,
+    individual="individual_0",
+    keypoint="stinger",
+    time_range=None,
+):
+    """Plot position time series and PSD before and after smoothing.
+
+    Only the x coortinate of the chosen keypoint is plotted.
+    """
+    # If not time range is provided, plot the entire time series
+    if time_range is None:
+        time_range = slice(0, ds_raw.time[-1])
+    selection = {
+        "time": time_range,
+        "individuals": individual,
+        "keypoints": keypoint,
+        "space": "x",
+    }
+
+    pos_raw = ds_raw.position.sel(**selection)
+    pos_smooth = ds_smooth.position.sel(**selection)
+
+    fig, ax = plt.subplots(2, 1, figsize=(10, 8))
+
+    # Plot the time series for the x coordinate
+    ax[0].plot(
+        pos_raw.time,
+        pos_raw,
+        color="k",
+        lw=2,
+        alpha=0.7,
+        label="raw x",
+    )
+    ax[0].plot(
+        pos_smooth.time,
+        pos_smooth,
+        color="r",
+        lw=2,
+        alpha=0.7,
+        label="smooth x",
+    )
+    ax[0].legend()
+    ax[0].set_ylabel("x position (px)")
+    ax[0].set_xlabel("Time (s)")
+    ax[0].set_title("Time Domain")
+
+    # Generate interpolated datasets to avoid NaNs in the PSD calculation
+    ds_raw_interp = interpolate_over_time(
+        ds_raw, max_gap=None, print_report=False
+    )
+    ds_smooth_interp = interpolate_over_time(
+        ds_smooth, max_gap=None, print_report=False
+    )
+    pos_raw_interp = ds_raw_interp.position.sel(**selection)
+    pos_smooth_interp = ds_smooth_interp.position.sel(**selection)
+
+    # Calculate and plot the PSD for the x coordinate
+    f_raw, Pxx_raw = welch(
+        pos_raw_interp,
+        fs=ds_raw.fps,
+        nperseg=256,
+    )
+    f_smooth, Pxx_smooth = welch(
+        pos_smooth_interp,
+        fs=ds_smooth.fps,
+        nperseg=256,
+    )
+
+    ax[1].semilogy(
+        f_raw,
+        Pxx_raw,
+        color="k",
+        lw=2,
+        alpha=0.7,
+        label="raw x",
+    )
+    ax[1].semilogy(
+        f_smooth,
+        Pxx_smooth,
+        color="r",
+        lw=2,
+        alpha=0.7,
+        label="smooth x",
+    )
+    ax[1].legend()
+    ax[1].set_ylabel("PSD (dB/Hz)")
+    ax[1].set_xlabel("Frequency (Hz)")
+    ax[1].set_title("Frequency Domain")
+
+    plt.tight_layout()
+    plt.show()
+
+
+# %%
+# Smooth using median filter
+# --------------------------
+# Here we apply a rolling window median filter to the wasp dataset.
+# The `window_length` parameter is defined in seconds (according to the
+# `time_unit` dataset attribute).
+
+ds_wasp_medfilt = median_filter(ds_wasp, window_length=0.1)
+
+# %%
+# Let's visualise the effects of the median filter in the time domain.
+
+plot_raw_and_smooth_timeseries_and_psd(
+    ds_wasp, ds_wasp_medfilt, keypoint="stinger"
+)
+
+# %%
+# We see that the median filter has removed the "spikes" present around the
+# 14 second mark in the raw data. However, it has not dealt the big shift
+# occurring during the final second. In the frequency domain, we can see that
+# the filter has reduced the power in the high frequencies, without
+# affecting the very low frequency components.
+#
+# This illustrated what the median filter is good at: removing brief "spikes"
+# (e.g. a keypoint abruptly jumping to a different location for a frame or two)
+# and high frequency "jitter" (which is often a consequence of pose estimation
+# working on a per-frame basis). In general, using the median filter is a good
+# idea, but you should choose `window_length` conservatively to avoid removing
+# relevant information. Always inspect the results (as we are doing here) to
+# ensure that the filter is not removing important features.
+
+# %%
+# What happens if the data contains missing values (NaNs). Let's apply the
+# same filter to the mouse dataset and see.
+
+ds_mouse_medfilt = median_filter(ds_mouse, window_length=0.1)
+
+# %%
+# The report informs that the raw data contains some NaN values, particularly
+# for the `snout` and `tail_end` keypoints. After filtering, the number of NaNs
+# has increased. This is because the the default behaviour of the median filter
+# is to propagate NaN values, i.e. if any value in the rolling window is NaN,
+# the output will also be NaN. To modify this behaviour, you can set the value
+# of the ``min_periods`` parameter to an integer value. This parameter
+# determines the minimum number of non-NaN values in the window for the output
+# to be non-NaN. For example, setting ``min_periods=2`` would mean that two
+# non-NaN values in the window are sufficient for the median to be calculated
+# (based only on those non-NaN values).
+
+ds_mouse_medfilt = median_filter(ds_mouse, window_length=0.1, min_periods=2)
+
+# %%
+# We see that this time the number of NaN values has not increased after
+# filtering. Instead, it has even decreased by a bit across keypoints.
+# Let's visualise the effects of the median filter in the time and frequency
+# domains. Here we focus on a 40 second time range for the `snout` keypoint.
+# You can adjust the `keypoint` and `time_range` arguments to explore other
+# parts of the data.
+
+plot_raw_and_smooth_timeseries_and_psd(
+    ds_mouse, ds_mouse_medfilt, keypoint="snout", time_range=slice(0, 40)
+)
+
+# %%

--- a/examples/smooth.py
+++ b/examples/smooth.py
@@ -131,17 +131,17 @@ plot_raw_and_smooth_timeseries_and_psd(
 # We see that the median filter has removed the "spikes" present around the
 # 14 second mark in the raw data. However, it has not dealt the big shift
 # occurring during the final second. In the frequency domain, we can see that
-# the filter has reduced the power in the high frequencies, without
-# affecting the very low frequency components.
+# the filter has reduced the power in the high-frequency components, without
+# affecting the low frequency components.
 #
 # This illustrates what the median filter is good at: removing brief "spikes"
 # (e.g. a keypoint abruptly jumping to a different location for a frame or two)
-# and high frequency "jitter" (often present due to pose estimation
+# and high-frequency "jitter" (often present due to pose estimation
 # working on a per-frame basis).
 
 # %%
 # Choosing parameters for the median filter
-# -----------------------------------------
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 # You can control the behaviour of :py:func:`movement.filtering.median_filter`
 # via two parameters: ``window_length`` and ``min_periods``.
 # To better understand the effect of these parameters, let's use a
@@ -160,25 +160,25 @@ print(ds_mouse)
 ds_mouse_medfilt = median_filter(ds_mouse, window_length=0.1)
 
 # %%
-# The report informs us that the raw data contains NaN values, particularly
-# for the ``snout`` and ``tail_end`` keypoints. After filtering, the number of
+# The report informs us that the raw data contains NaN values, most of which
+# occur at the ``snout`` and ``tail_end`` keypoints. After filtering, the number of
 # NaNs has increased. This is because the default behaviour of the median
 # filter is to propagate NaN values, i.e. if any value in the rolling window is
 # NaN, the output will also be NaN.
 #
 # To modify this behaviour, you can set the value of the ``min_periods``
 # parameter to an integer value. This parameter determines the minimum number
-# of non-NaN values in the window for the output to be non-NaN.
+# of non-NaN values required in the window for the output to be non-NaN.
 # For example, setting ``min_periods=2`` means that two non-NaN values in the
 # window are sufficient for the median to be calculated. Let's try this.
 
 ds_mouse_medfilt = median_filter(ds_mouse, window_length=0.1, min_periods=2)
 
 # %%
-# We see that this time the number of NaN values has not increased after
-# filtering. Instead, it has even decreased by a bit across keypoints.
+# We see that this time the number of NaN values has decreased 
+# across all keypoints.
 # Let's visualise the effects of the median filter in the time and frequency
-# domains. Here we focus on a 80 second time range for the ``snout`` keypoint.
+# domains. Here we focus on the first 80 seconds for the ``snout`` keypoint.
 # You can adjust the ``keypoint`` and ``time_range`` arguments to explore other
 # parts of the data.
 
@@ -187,12 +187,12 @@ plot_raw_and_smooth_timeseries_and_psd(
 )
 
 # %%
-# The smoothing has reduced high-frequency content but the
+# The smoothing once again reduces the power of high-frequency components, but the
 # resulting time series stays quite close to the raw data.
 #
 # What happens if we increase the ``window_length`` to 2 seconds?
 
-ds_mouse_medfilt = median_filter(ds_mouse, window_length=1, min_periods=2)
+ds_mouse_medfilt = median_filter(ds_mouse, window_length=2, min_periods=2)
 
 # %%
 # The number of NaN values has decreased even further. That's because the
@@ -224,14 +224,14 @@ plot_raw_and_smooth_timeseries_and_psd(
 # ``window_length``, and the value of the polynomial at the center of the
 # window is used as the output value.
 #
-# Let's try it on the mouse dataset first.
+# Let's try it on the mouse dataset.
 
 ds_mouse_savgol = savgol_filter(ds_mouse, window_length=0.2, polyorder=2)
 
 
 # %%
 # We see that the number of NaN values has increased after filtering. This is
-# for the same reason as with the median filter (in it's default mode), i.e.
+# for the same reason as with the median filter (in its default mode), i.e.
 # if there is at least one NaN value in the window, the output will be NaN.
 # Unlike the median filter, the Savitzky-Golay filter does not provide a
 # ``min_periods`` parameter to control this behaviour. Let's visualise the
@@ -241,8 +241,11 @@ plot_raw_and_smooth_timeseries_and_psd(
     ds_mouse, ds_mouse_savgol, keypoint="snout", time_range=slice(0, 80)
 )
 # %%
-# We indeed see that high-frequencies have been reduced but the gaps of missing
-# values have increase in extent. Now let's take a look at the wasp dataset.
+# Once again, the power of high-frequency components has been reduced, but more missing
+# values have been introduced. 
+
+# %%
+# Now let's take a look at the wasp dataset.
 
 ds_wasp_savgol = savgol_filter(ds_wasp, window_length=0.2, polyorder=2)
 
@@ -254,10 +257,10 @@ plot_raw_and_smooth_timeseries_and_psd(
 )
 # %%
 # This example shows two important limitations of the Savitzky-Golay filter.
-# Firstly, it can introduce "wiggles" around sharp boundaries. For
+# First, the filter can introduce artefacts around sharp boundaries. For
 # example, focus on what happens around the sudden drop in position
-# during the final second. Secondly, the PSD appears to have large periodic
-# drops in power at certain frequencies. Both of these effects vary with the
+# during the final second. Second, the PSD appears to have large periodic
+# drops at certain frequencies. Both of these effects vary with the
 # choice of ``window_length`` and ``polyorder``. You can read more about these
 # and other limitations of the Savitzky-Golay filter in
 # `this paper <https://pubs.acs.org/doi/10.1021/acsmeasuresciau.1c00054>`_.
@@ -268,7 +271,7 @@ plot_raw_and_smooth_timeseries_and_psd(
 # ------------------------------------
 # You can also combine multiple smoothing filters by applying them
 # sequentially. For example, we can first apply the median filter with a small
-# ``window_length`` to remove spikes and then apply the Savitzky-Golay filter
+# ``window_length`` to remove "spikes" and then apply the Savitzky-Golay filter
 # with a larger ``window_length`` to further smooth the data.
 # Between the two filters, we can interpolate over small gaps to avoid the
 # excessive proliferation of NaN values. Let's try this on the mouse dataset.
@@ -290,7 +293,7 @@ ds_mouse_medfilt_interp_savgol = savgol_filter(
 
 # %%
 # A record of all applied operations is stored in the dataset's ``log``
-# attribute. Let's inpsect it to summarise what we've done.
+# attribute. Let's inspect it to summarise what we've done.
 
 for entry in ds_mouse_medfilt_interp_savgol.log:
     print(entry)

--- a/examples/smooth.py
+++ b/examples/smooth.py
@@ -161,10 +161,10 @@ ds_mouse_medfilt = median_filter(ds_mouse, window_length=0.1)
 
 # %%
 # The report informs us that the raw data contains NaN values, most of which
-# occur at the ``snout`` and ``tail_end`` keypoints. After filtering, the number of
-# NaNs has increased. This is because the default behaviour of the median
-# filter is to propagate NaN values, i.e. if any value in the rolling window is
-# NaN, the output will also be NaN.
+# occur at the ``snout`` and ``tail_end`` keypoints. After filtering, the
+# number of NaNs has increased. This is because the default behaviour of the
+# median filter is to propagate NaN values, i.e. if any value in the rolling
+# window is NaN, the output will also be NaN.
 #
 # To modify this behaviour, you can set the value of the ``min_periods``
 # parameter to an integer value. This parameter determines the minimum number
@@ -187,8 +187,8 @@ plot_raw_and_smooth_timeseries_and_psd(
 )
 
 # %%
-# The smoothing once again reduces the power of high-frequency components, but the
-# resulting time series stays quite close to the raw data.
+# The smoothing once again reduces the power of high-frequency components, but
+# the resulting time series stays quite close to the raw data.
 #
 # What happens if we increase the ``window_length`` to 2 seconds?
 
@@ -241,8 +241,8 @@ plot_raw_and_smooth_timeseries_and_psd(
     ds_mouse, ds_mouse_savgol, keypoint="snout", time_range=slice(0, 80)
 )
 # %%
-# Once again, the power of high-frequency components has been reduced, but more missing
-# values have been introduced.
+# Once again, the power of high-frequency components has been reduced, but more
+# missing values have been introduced.
 
 # %%
 # Now let's take a look at the wasp dataset.

--- a/examples/smooth.py
+++ b/examples/smooth.py
@@ -175,7 +175,7 @@ ds_mouse_medfilt = median_filter(ds_mouse, window_length=0.1)
 ds_mouse_medfilt = median_filter(ds_mouse, window_length=0.1, min_periods=2)
 
 # %%
-# We see that this time the number of NaN values has decreased 
+# We see that this time the number of NaN values has decreased
 # across all keypoints.
 # Let's visualise the effects of the median filter in the time and frequency
 # domains. Here we focus on the first 80 seconds for the ``snout`` keypoint.
@@ -242,7 +242,7 @@ plot_raw_and_smooth_timeseries_and_psd(
 )
 # %%
 # Once again, the power of high-frequency components has been reduced, but more missing
-# values have been introduced. 
+# values have been introduced.
 
 # %%
 # Now let's take a look at the wasp dataset.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ per-file-ignores = { "tests/*" = [
   "D205", # missing blank line between summary and description
   "D103", # missing docstring in public function
 ], "examples/*" = [
+  "B018", # Found useless expression
   "D400", # first line should end with a period.
   "D415", # first line should end with a period, question mark...
   "D205", # missing blank line between summary and description

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ per-file-ignores = { "tests/*" = [
   "D103", # missing docstring in public function
 ], "examples/*" = [
   "B018", # Found useless expression
+  "D103", # Missing docstring in public function
   "D400", # first line should end with a period.
   "D415", # first line should end with a period, question mark...
   "D205", # missing blank line between summary and description


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

PR #163 added median and Savitzky-Golay filters but their usages has not beed documented in tutorials/examples.

**What does this PR do?**

This PR adds a new "Smooth pose tracks" example that guides the users through smoothing data using either or both new filters.
Additionally, the titles and subtitles of all examples are using the imperative case (e.g. "smooth" instead of "smoothing") to be consistent with our docstrings.

## References

Closes #179 
PRs #163 and #189 

## How has this PR been tested?

The documentation was [built locally](https://movement.neuroinformatics.dev/community/contributing.html#building-the-documentation-locally) and inspected. This is also the recommended way of reviewing this PR, as the rendered html is more readable than the `sphinx-gallery` source file.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

It is in itself an update to documentation.

## Checklist:

- [x] The code has been tested locally
- [n/a] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
