### PR TITLE
Refactored modules related to input-output

### DIFF
--- a/docs/source/api_index.rst
+++ b/docs/source/api_index.rst
@@ -10,6 +10,7 @@ Input/Output
 .. autosummary::
     :toctree: api
 
+    from_numpy
     from_file
     from_sleap_file
     from_dlc_file

--- a/docs/source/api_index.rst
+++ b/docs/source/api_index.rst
@@ -14,7 +14,7 @@ Input/Output
     from_file
     from_sleap_file
     from_dlc_file
-    from_dlc_df
+    from_dlc_style_df
     from_lp_file
 
 .. currentmodule:: movement.io.save_poses

--- a/docs/source/api_index.rst
+++ b/docs/source/api_index.rst
@@ -4,8 +4,8 @@ API Reference
 =============
 
 
-Input/Output
-------------
+Load poses
+----------
 .. currentmodule:: movement.io.load_poses
 .. autosummary::
     :toctree: api
@@ -17,6 +17,9 @@ Input/Output
     from_lp_file
     from_dlc_style_df
 
+Save poses
+----------
+
 .. currentmodule:: movement.io.save_poses
 .. autosummary::
     :toctree: api
@@ -26,7 +29,8 @@ Input/Output
     to_sleap_analysis_file
     to_dlc_style_df
 
-
+Validators
+----------
 .. currentmodule:: movement.io.validators
 .. autosummary::
     :toctree: api
@@ -60,7 +64,7 @@ Filtering
 
 
 Analysis
------------
+--------
 .. currentmodule:: movement.analysis.kinematics
 .. autosummary::
     :toctree: api

--- a/docs/source/api_index.rst
+++ b/docs/source/api_index.rst
@@ -14,17 +14,18 @@ Input/Output
     from_file
     from_sleap_file
     from_dlc_file
-    from_dlc_style_df
     from_lp_file
+    from_dlc_style_df
 
 .. currentmodule:: movement.io.save_poses
 .. autosummary::
     :toctree: api
 
     to_dlc_file
-    to_dlc_df
-    to_sleap_analysis_file
     to_lp_file
+    to_sleap_analysis_file
+    to_dlc_style_df
+
 
 .. currentmodule:: movement.io.validators
 .. autosummary::

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -316,7 +316,7 @@ def from_lp_file(
     >>> ds = load_poses.from_lp_file("path/to/file.csv", fps=30)
 
     """
-    return _from_lp_or_dlc_file(
+    return _ds_from_lp_or_dlc_file(
         file_path=file_path, source_software="LightningPose", fps=fps
     )
 
@@ -351,12 +351,12 @@ def from_dlc_file(
     >>> ds = load_poses.from_dlc_file("path/to/file.h5", fps=30)
 
     """
-    return _from_lp_or_dlc_file(
+    return _ds_from_lp_or_dlc_file(
         file_path=file_path, source_software="DeepLabCut", fps=fps
     )
 
 
-def _from_lp_or_dlc_file(
+def _ds_from_lp_or_dlc_file(
     file_path: Union[Path, str],
     source_software: Literal["LightningPose", "DeepLabCut"],
     fps: Optional[float] = None,

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 def from_numpy(
     position_array: np.ndarray,
-    confidence_array: Optional[np.ndarray],
+    confidence_array: Optional[np.ndarray] = None,
     individual_names: Optional[list[str]] = None,
     keypoint_names: Optional[list[str]] = None,
     fps: Optional[float] = None,

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -91,7 +91,7 @@ def from_numpy(
         fps=fps,
         source_software=source_software,
     )
-    return _from_valid_data(valid_data)
+    return _ds_from_valid_data(valid_data)
 
 
 def from_file(
@@ -272,9 +272,9 @@ def from_sleap_file(
 
     # Load and validate data
     if file.path.suffix == ".h5":
-        ds = _load_from_sleap_analysis_file(file.path, fps=fps)
+        ds = _ds_from_sleap_analysis_file(file.path, fps=fps)
     else:  # file.path.suffix == ".slp"
-        ds = _load_from_sleap_labels_file(file.path, fps=fps)
+        ds = _ds_from_sleap_labels_file(file.path, fps=fps)
 
     # Add metadata as attrs
     ds.attrs["source_file"] = file.path.as_posix()
@@ -381,9 +381,9 @@ def _from_lp_or_dlc_file(
 
     # Load the DLC poses into a DataFrame
     if file.path.suffix == ".csv":
-        df = _load_df_from_dlc_csv(file.path)
+        df = _df_from_dlc_csv(file.path)
     else:  # file.path.suffix == ".h5"
-        df = _load_df_from_dlc_h5(file.path)
+        df = _df_from_dlc_h5(file.path)
 
     logger.debug(f"Loaded poses from {file.path} into a DataFrame.")
     # Convert the DataFrame to an xarray dataset
@@ -397,7 +397,7 @@ def _from_lp_or_dlc_file(
     return ds
 
 
-def _load_from_sleap_analysis_file(
+def _ds_from_sleap_analysis_file(
     file_path: Path, fps: Optional[float]
 ) -> xr.Dataset:
     """Validate and load data from a SLEAP analysis file.
@@ -444,7 +444,7 @@ def _load_from_sleap_analysis_file(
         )
 
 
-def _load_from_sleap_labels_file(
+def _ds_from_sleap_labels_file(
     file_path: Path, fps: Optional[float]
 ) -> xr.Dataset:
     """Validate and load data from a SLEAP labels file.
@@ -551,7 +551,7 @@ def _sleap_labels_to_numpy(labels: Labels) -> np.ndarray:
     return tracks
 
 
-def _load_df_from_dlc_csv(file_path: Path) -> pd.DataFrame:
+def _df_from_dlc_csv(file_path: Path) -> pd.DataFrame:
     """Parse a DeepLabCut-style .csv file into a pandas DataFrame.
 
     If poses are loaded from a DeepLabCut .csv file, the DataFrame
@@ -598,7 +598,7 @@ def _load_df_from_dlc_csv(file_path: Path) -> pd.DataFrame:
     return df
 
 
-def _load_df_from_dlc_h5(file_path: Path) -> pd.DataFrame:
+def _df_from_dlc_h5(file_path: Path) -> pd.DataFrame:
     """Load data from a DeepLabCut .h5 file into a pandas DataFrame.
 
     Parameters
@@ -619,7 +619,7 @@ def _load_df_from_dlc_h5(file_path: Path) -> pd.DataFrame:
     return df
 
 
-def _from_valid_data(data: ValidPosesDataset) -> xr.Dataset:
+def _ds_from_valid_data(data: ValidPosesDataset) -> xr.Dataset:
     """Convert already validated pose tracking data to an xarray Dataset.
 
     Parameters

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -142,10 +142,10 @@ def from_file(
         )
 
 
-def from_dlc_df(
+def from_dlc_style_df(
     df: pd.DataFrame,
     fps: Optional[float] = None,
-    source_software: Optional[str] = "DeepLabCut",
+    source_software: Literal["DeepLabCut", "LightningPose"] = "DeepLabCut",
 ) -> xr.Dataset:
     """Create an xarray.Dataset from a DeepLabCut-style pandas DataFrame.
 
@@ -159,8 +159,8 @@ def from_dlc_df(
         the `time` coordinates will be in frame numbers.
     source_software : str, optional
         Name of the pose estimation software from which the data originate.
-        Defaults to "DeepLabCut", but other values can be supplied (because
-        other software may also output data in the same format).
+        Defaults to "DeepLabCut", but it can also be "LightningPose"
+        (because it uses the same dataframe format).
 
     Returns
     -------
@@ -178,7 +178,7 @@ def from_dlc_df(
 
     See Also
     --------
-    movement.io.load_poses.from_dlc_file : Load pose tracks directly from file.
+    movement.io.load_poses.from_dlc_file
 
     """
     # read names of individuals and keypoints from the DataFrame
@@ -334,7 +334,7 @@ def from_dlc_file(
 
     See Also
     --------
-    movement.io.load_poses.from_dlc_df : Load pose tracks from a DataFrame.
+    movement.io.load_poses.from_dlc_style_df
 
     Examples
     --------
@@ -387,7 +387,7 @@ def _from_lp_or_dlc_file(
 
     logger.debug(f"Loaded poses from {file.path} into a DataFrame.")
     # Convert the DataFrame to an xarray dataset
-    ds = from_dlc_df(df=df, fps=fps, source_software=source_software)
+    ds = from_dlc_style_df(df=df, fps=fps, source_software=source_software)
 
     # Add metadata as attrs
     ds.attrs["source_file"] = file.path.as_posix()

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -62,7 +62,7 @@ def from_numpy(
     Returns
     -------
     xarray.Dataset
-        Dataset containing the pose tracks, confidence scores,
+        ``movement`` dataset containing the pose tracks, confidence scores,
         and associated metadata.
 
     Examples
@@ -99,18 +99,15 @@ def from_file(
     source_software: Literal["DeepLabCut", "SLEAP", "LightningPose"],
     fps: Optional[float] = None,
 ) -> xr.Dataset:
-    """Load pose tracking data from any supported file format.
-
-    Data can be loaded from a DeepLabCut (DLC), LightningPose (LP) or
-    SLEAP output file into an xarray Dataset.
+    """Create a ``movement`` dataset from any supported file.
 
     Parameters
     ----------
     file_path : pathlib.Path or str
         Path to the file containing predicted poses. The file format must
         be among those supported by the ``from_dlc_file()``,
-        ``from_slp_file()`` or ``from_lp_file()`` functions,
-        since one of these functions will be called internally, based on
+        ``from_slp_file()`` or ``from_lp_file()`` functions. One of these
+        these functions will be called internally, based on
         the value of ``source_software``.
     source_software : "DeepLabCut", "SLEAP" or "LightningPose"
         The source software of the file.
@@ -121,13 +118,21 @@ def from_file(
     Returns
     -------
     xarray.Dataset
-        Dataset containing the pose tracks, confidence scores, and metadata.
+        ``movement`` dataset containing the pose tracks, confidence scores,
+        and associated metadata.
 
     See Also
     --------
     movement.io.load_poses.from_dlc_file
     movement.io.load_poses.from_sleap_file
     movement.io.load_poses.from_lp_file
+
+    Examples
+    --------
+    >>> from movement.io import load_poses
+    >>> ds = load_poses.from_file(
+    ...     "path/to/file.h5", source_software="DeepLabCut", fps=30
+    ... )
 
     """
     if source_software == "DeepLabCut":
@@ -147,7 +152,7 @@ def from_dlc_style_df(
     fps: Optional[float] = None,
     source_software: Literal["DeepLabCut", "LightningPose"] = "DeepLabCut",
 ) -> xr.Dataset:
-    """Create an xarray.Dataset from a DeepLabCut-style pandas DataFrame.
+    """Create a ``movement`` dataset from a DeepLabCut-style DataFrame.
 
     Parameters
     ----------
@@ -160,12 +165,13 @@ def from_dlc_style_df(
     source_software : str, optional
         Name of the pose estimation software from which the data originate.
         Defaults to "DeepLabCut", but it can also be "LightningPose"
-        (because it uses the same dataframe format).
+        (because they the same DataFrame format).
 
     Returns
     -------
     xarray.Dataset
-        Dataset containing the pose tracks, confidence scores, and metadata.
+        ``movement`` dataset containing the pose tracks, confidence scores,
+        and associated metadata.
 
     Notes
     -----
@@ -212,7 +218,7 @@ def from_dlc_style_df(
 def from_sleap_file(
     file_path: Union[Path, str], fps: Optional[float] = None
 ) -> xr.Dataset:
-    """Load pose tracking data from a SLEAP file into an xarray Dataset.
+    """Create a ``movement`` dataset from a SLEAP file.
 
     Parameters
     ----------
@@ -227,7 +233,8 @@ def from_sleap_file(
     Returns
     -------
     xarray.Dataset
-        Dataset containing the pose tracks, confidence scores, and metadata.
+        ``movement`` dataset containing the pose tracks, confidence scores,
+        and associated metadata.
 
     Notes
     -----
@@ -287,12 +294,12 @@ def from_sleap_file(
 def from_lp_file(
     file_path: Union[Path, str], fps: Optional[float] = None
 ) -> xr.Dataset:
-    """Load pose tracking data from a LightningPose (LP) output file.
+    """Create a ``movement`` dataset from a LightningPose file.
 
     Parameters
     ----------
     file_path : pathlib.Path or str
-        Path to the file containing the LP predicted poses, in .csv format.
+        Path to the file containing the predicted poses, in .csv format.
     fps : float, optional
         The number of frames per second in the video. If None (default),
         the `time` coordinates will be in frame numbers.
@@ -300,7 +307,8 @@ def from_lp_file(
     Returns
     -------
     xarray.Dataset
-        Dataset containing the pose tracks, confidence scores, and metadata.
+        ``movement`` dataset containing the pose tracks, confidence scores,
+        and associated metadata.
 
     Examples
     --------
@@ -316,12 +324,12 @@ def from_lp_file(
 def from_dlc_file(
     file_path: Union[Path, str], fps: Optional[float] = None
 ) -> xr.Dataset:
-    """Load pose tracking data from a DeepLabCut (DLC) output file.
+    """Create a ``movement`` dataset from a DeepLabCut file.
 
     Parameters
     ----------
     file_path : pathlib.Path or str
-        Path to the file containing the DLC predicted poses, either in .h5
+        Path to the file containing the predicted poses, either in .h5
         or .csv format.
     fps : float, optional
         The number of frames per second in the video. If None (default),
@@ -330,7 +338,8 @@ def from_dlc_file(
     Returns
     -------
     xarray.Dataset
-        Dataset containing the pose tracks, confidence scores, and metadata.
+        ``movement`` dataset containing the pose tracks, confidence scores,
+        and associated metadata.
 
     See Also
     --------
@@ -352,12 +361,12 @@ def _from_lp_or_dlc_file(
     source_software: Literal["LightningPose", "DeepLabCut"],
     fps: Optional[float] = None,
 ) -> xr.Dataset:
-    """Load data from DeepLabCut (DLC) or LightningPose (LP) output files.
+    """Create a ``movement`` dataset from a LightningPose or DeepLabCut file.
 
     Parameters
     ----------
     file_path : pathlib.Path or str
-        Path to the file containing the DLC predicted poses, either in .h5
+        Path to the file containing the predicted poses, either in .h5
         or .csv format.
     source_software : {'LightningPose', 'DeepLabCut'}
         The source software of the file.
@@ -368,7 +377,8 @@ def _from_lp_or_dlc_file(
     Returns
     -------
     xarray.Dataset
-        Dataset containing the pose tracks, confidence scores, and metadata.
+        ``movement`` dataset containing the pose tracks, confidence scores,
+        and associated metadata.
 
     """
     expected_suffix = [".csv"]
@@ -379,7 +389,7 @@ def _from_lp_or_dlc_file(
         file_path, expected_permission="r", expected_suffix=expected_suffix
     )
 
-    # Load the DLC poses into a DataFrame
+    # Load the DeepLabCut poses into a DataFrame
     if file.path.suffix == ".csv":
         df = _df_from_dlc_csv(file.path)
     else:  # file.path.suffix == ".h5"
@@ -400,7 +410,7 @@ def _from_lp_or_dlc_file(
 def _ds_from_sleap_analysis_file(
     file_path: Path, fps: Optional[float]
 ) -> xr.Dataset:
-    """Validate and load data from a SLEAP analysis file.
+    """Create a ``movement`` dataset from a SLEAP analysis (.h5) file.
 
     Parameters
     ----------
@@ -413,7 +423,8 @@ def _ds_from_sleap_analysis_file(
     Returns
     -------
     xarray.Dataset
-        Dataset containing the pose tracks, confidence scores, and metadata.
+        ``movement`` dataset containing the pose tracks, confidence scores,
+        and associated metadata.
 
     """
     file = ValidHDF5(file_path, expected_datasets=["tracks"])
@@ -447,7 +458,7 @@ def _ds_from_sleap_analysis_file(
 def _ds_from_sleap_labels_file(
     file_path: Path, fps: Optional[float]
 ) -> xr.Dataset:
-    """Validate and load data from a SLEAP labels file.
+    """Create a ``movement`` dataset from a SLEAP labels (.slp) file.
 
     Parameters
     ----------
@@ -460,7 +471,8 @@ def _ds_from_sleap_labels_file(
     Returns
     -------
     xarray.Dataset
-        Dataset containing the pose tracks, confidence scores, and metadata.
+        ``movement`` dataset containing the pose tracks, confidence scores,
+        and associated metadata.
 
     """
     file = ValidHDF5(file_path, expected_datasets=["pred_points", "metadata"])
@@ -484,9 +496,9 @@ def _ds_from_sleap_labels_file(
 
 
 def _sleap_labels_to_numpy(labels: Labels) -> np.ndarray:
-    """Convert a SLEAP `Labels` object to a NumPy array.
+    """Convert a SLEAP ``Labels`` object to a NumPy array.
 
-    The output array contains pose tracks with point-wise confidence scores.
+    The output array contains pose tracks and point-wise confidence scores.
 
     Parameters
     ----------
@@ -552,17 +564,17 @@ def _sleap_labels_to_numpy(labels: Labels) -> np.ndarray:
 
 
 def _df_from_dlc_csv(file_path: Path) -> pd.DataFrame:
-    """Parse a DeepLabCut-style .csv file into a pandas DataFrame.
+    """Create a DeepLabCut-style DataFrame from a .csv file.
 
-    If poses are loaded from a DeepLabCut .csv file, the DataFrame
+    If poses are loaded from a DeepLabCut-style .csv file, the DataFrame
     lacks the multi-index columns that are present in the .h5 file. This
-    function parses the .csv file to a pandas DataFrame with multi-index
-    columns, i.e. the same format as in the .h5 file.
+    function parses the .csv file to DataFrame with multi-index columns,
+    i.e. the same format as in the .h5 file.
 
     Parameters
     ----------
     file_path : pathlib.Path
-        Path to the DeepLabCut-style .csv file.
+        Path to the DeepLabCut-style .csv file containing pose tracks.
 
     Returns
     -------
@@ -587,7 +599,7 @@ def _df_from_dlc_csv(file_path: Path) -> pd.DataFrame:
     column_tuples = list(zip(*[line[1:] for line in header_lines]))
     columns = pd.MultiIndex.from_tuples(column_tuples, names=level_names)
 
-    # Import the DLC poses as a DataFrame
+    # Import the DeepLabCut poses as a DataFrame
     df = pd.read_csv(
         file.path,
         skiprows=len(header_lines),
@@ -599,7 +611,7 @@ def _df_from_dlc_csv(file_path: Path) -> pd.DataFrame:
 
 
 def _df_from_dlc_h5(file_path: Path) -> pd.DataFrame:
-    """Load data from a DeepLabCut .h5 file into a pandas DataFrame.
+    """Create a DeepLabCut-style DataFrame from a .h5 file.
 
     Parameters
     ----------
@@ -609,7 +621,7 @@ def _df_from_dlc_h5(file_path: Path) -> pd.DataFrame:
     Returns
     -------
     pandas.DataFrame
-        DeepLabCut-style Dataframe.
+        DeepLabCut-style DataFrame with multi-index columns.
 
     """
     file = ValidHDF5(file_path, expected_datasets=["df_with_missing"])
@@ -620,7 +632,7 @@ def _df_from_dlc_h5(file_path: Path) -> pd.DataFrame:
 
 
 def _ds_from_valid_data(data: ValidPosesDataset) -> xr.Dataset:
-    """Convert already validated pose tracking data to an xarray Dataset.
+    """Create a ``movement`` dataset from validated pose tracking data.
 
     Parameters
     ----------
@@ -630,7 +642,8 @@ def _ds_from_valid_data(data: ValidPosesDataset) -> xr.Dataset:
     Returns
     -------
     xarray.Dataset
-        Dataset containing the pose tracks, confidence scores, and metadata.
+        ``movement`` dataset containing the pose tracks, confidence scores,
+        and associated metadata.
 
     """
     n_frames = data.position_array.shape[0]

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -23,6 +23,60 @@ from movement.logging import log_error, log_warning
 logger = logging.getLogger(__name__)
 
 
+def from_numpy(
+    position_array: np.ndarray,
+    confidence_array: np.ndarray,
+    individual_names: Optional[list[str]] = None,
+    keypoint_names: Optional[list[str]] = None,
+    fps: Optional[float] = None,
+    source_software: Optional[str] = None,
+) -> xr.Dataset:
+    """Create a ``movement`` dataset from NumPy arrays.
+
+    Parameters
+    ----------
+    position_array : np.ndarray
+        Array of shape (n_frames, n_individuals, n_keypoints, n_space)
+        containing the poses. It will be converted to a
+        :py:class:`xarray.DataArray` object named "position".
+    confidence_array : np.ndarray, optional
+        Array of shape (n_frames, n_individuals, n_keypoints) containing
+        the point-wise confidence scores. It will be converted to a
+        :py:class:`xarray.DataArray` object named "confidence".
+        If None (default), the scores will be set to an array of NaNs.
+    individual_names : list of str, optional
+        List of unique names for the individuals in the video. If None
+        (default), the individuals will be named "individual_0",
+        "individual_1", etc.
+    keypoint_names : list of str, optional
+        List of unique names for the keypoints in the skeleton. If None
+        (default), the keypoints will be named "keypoint_0", "keypoint_1",
+        etc.
+    fps : float, optional
+        Frames per second of the video. Defaults to None, in which case
+        the time coordinates will be in frame numbers.
+    source_software : str, optional
+        Name of the pose estimation software from which the data originate.
+        Defaults to None.
+
+    Returns
+    -------
+    xarray.Dataset
+        A ``movement`` dataset containing the pose tracks, confidence scores,
+        and associated metadata.
+
+    """
+    valid_data = ValidPosesDataset(
+        position_array=position_array,
+        confidence_array=confidence_array,
+        individual_names=individual_names,
+        keypoint_names=keypoint_names,
+        fps=fps,
+        source_software=source_software,
+    )
+    return _from_valid_data(valid_data)
+
+
 def from_file(
     file_path: Union[Path, str],
     source_software: Literal["DeepLabCut", "SLEAP", "LightningPose"],

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 def from_numpy(
     position_array: np.ndarray,
-    confidence_array: np.ndarray,
+    confidence_array: Optional[np.ndarray],
     individual_names: Optional[list[str]] = None,
     keypoint_names: Optional[list[str]] = None,
     fps: Optional[float] = None,

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -62,8 +62,26 @@ def from_numpy(
     Returns
     -------
     xarray.Dataset
-        A ``movement`` dataset containing the pose tracks, confidence scores,
+        Dataset containing the pose tracks, confidence scores,
         and associated metadata.
+
+    Examples
+    --------
+    Create random position data for two individuals, ``Alice`` and ``Bob``,
+    with three keypoints each: ``snout``, ``centre``, and ``tail_base``.
+    These are tracked in 2D space over 100 frames, at 30 fps.
+    The confidence scores are set to 1 for all points.
+
+    >>> import numpy as np
+    >>> from movement.io import load_poses
+    >>> ds = load_poses.from_numpy(
+    ...     position_array=np.random.rand((100, 2, 3, 2)),
+    ...     confidence_array=np.ones((100, 2, 3)),
+    ...     individual_names=["Alice", "Bob"],
+    ...     keypoint_names=["snout", "centre", "tail_base"],
+    ...     fps=30,
+    ...     source_software="DeepLabCut",
+    ... )
 
     """
     valid_data = ValidPosesDataset(

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -80,7 +80,6 @@ def from_numpy(
     ...     individual_names=["Alice", "Bob"],
     ...     keypoint_names=["snout", "centre", "tail_base"],
     ...     fps=30,
-    ...     source_software="DeepLabCut",
     ... )
 
     """

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -15,15 +15,18 @@ from movement.logging import log_error
 logger = logging.getLogger(__name__)
 
 
-def _xarray_to_dlc_df(ds: xr.Dataset, columns: pd.MultiIndex) -> pd.DataFrame:
-    """Convert an xarray dataset to DLC-style multi-index pandas DataFrame.
+def _ds_to_dlc_style_df(
+    ds: xr.Dataset, columns: pd.MultiIndex
+) -> pd.DataFrame:
+    """Convert a ``movement`` dataset to a DeepLabCut-style DataFrame.
 
     Parameters
     ----------
     ds : xarray.Dataset
-        Dataset containing pose tracks, confidence scores, and metadata.
+        ``movement`` dataset containing pose tracks, confidence scores,
+        and associated metadata.
     columns : pandas.MultiIndex
-        DLC-style multi-index columns
+        DeepLabCut-style multi-index columns
 
     Returns
     -------
@@ -57,7 +60,7 @@ def _auto_split_individuals(ds: xr.Dataset) -> bool:
 
 
 def _save_dlc_df(filepath: Path, df: pd.DataFrame) -> None:
-    """Given a filepath, will save the dataframe as either a .h5 or .csv.
+    """Save the dataframe as either a .h5 or .csv depending on the file path.
 
     Parameters
     ----------
@@ -74,20 +77,20 @@ def _save_dlc_df(filepath: Path, df: pd.DataFrame) -> None:
         df.to_hdf(filepath, key="df_with_missing")
 
 
-def to_dlc_df(
+def to_dlc_style_df(
     ds: xr.Dataset, split_individuals: bool = False
 ) -> Union[pd.DataFrame, dict[str, pd.DataFrame]]:
-    """Convert an xarray dataset to DeepLabCut-style pandas DataFrame(s).
+    """Convert a ``movement`` dataset to DeepLabCut-style DataFrame(s).
 
     Parameters
     ----------
     ds : xarray.Dataset
-        Dataset containing pose tracks, confidence scores, and metadata.
+        ``movement`` dataset containing pose tracks, confidence scores,
+        and associated metadata.
     split_individuals : bool, optional
-        If True, return a dictionary of pandas DataFrames per individual,
-        with individual names as keys and DataFrames as values.
-        If False, return a single pandas DataFrame for all individuals.
-        Default is False.
+        If True, return a dictionary of DataFrames per individual, with
+        individual names as keys. If False (default), return a single
+        DataFrame for all individuals (see Notes).
 
     Returns
     -------
@@ -107,8 +110,7 @@ def to_dlc_df(
 
     See Also
     --------
-    to_dlc_file : Save the xarray dataset containing pose tracks directly
-        to a DeepLabCut-style .h5 or .csv file.
+    to_dlc_file : Save dataset directly to a DeepLabCut-style .h5 or .csv file.
 
     """
     _validate_dataset(ds)
@@ -128,7 +130,7 @@ def to_dlc_df(
                 [scorer, bodyparts, coords], names=index_levels
             )
 
-            df = _xarray_to_dlc_df(individual_data, columns)
+            df = _ds_to_dlc_style_df(individual_data, columns)
             df_dict[individual] = df
 
         logger.info(
@@ -142,9 +144,9 @@ def to_dlc_df(
             [scorer, individuals, bodyparts, coords], names=index_levels
         )
 
-        df_all = _xarray_to_dlc_df(ds, columns)
+        df_all = _ds_to_dlc_style_df(ds, columns)
 
-        logger.info("Converted poses dataset to DLC-style DataFrame.")
+        logger.info("Converted poses dataset to DeepLabCut-style DataFrame.")
         return df_all
 
 
@@ -153,35 +155,35 @@ def to_dlc_file(
     file_path: Union[str, Path],
     split_individuals: Union[bool, Literal["auto"]] = "auto",
 ) -> None:
-    """Save the xarray dataset to a DeepLabCut-style .h5 or .csv file.
+    """Save a ``movement`` dataset to DeepLabCut file(s).
 
     Parameters
     ----------
     ds : xarray.Dataset
-        Dataset containing pose tracks, confidence scores, and metadata.
+        ``movement`` dataset containing pose tracks, confidence scores,
+        and associated metadata.
     file_path : pathlib.Path or str
-        Path to the file to save the DLC poses to. The file extension
+        Path to the file to save the poses to. The file extension
         must be either .h5 (recommended) or .csv.
     split_individuals : bool or "auto", optional
-        Whether to save individuals to separate files or to the same file.\n
-        If True, each individual will be saved to a separate file,
-        formatted as in a single-animal DeepLabCut project - i.e. without
-        the "individuals" column level. The individual's name will be appended
-        to the file path, just before the file extension, i.e.
-        "/path/to/filename_individual1.h5".\n
-        If False, all individuals will be saved to the same file,
-        formatted as in a multi-animal DeepLabCut project - i.e. the columns
-        will include the "individuals" level. The file path will not be
-        modified.\n
-        If "auto" the argument's value is determined based on the number of
-        individuals in the dataset: True if there is only one, and
-        False if there are more than one. This is the default.
+        Whether to save individuals to separate files or to the same file
+        (see Notes). Defaults to "auto".
+
+    Notes
+    -----
+    If ``split_individuals`` is True, each individual will be saved to a
+    separate file, formatted as in a single-animal DeepLabCut project
+    (without the "individuals" column level). The individual's name will be
+    appended to the file path, just before the file extension, e.g.
+    "/path/to/filename_individual1.h5". If False, all individuals will be
+    saved to the same file, formatted as in a multi-animal DeepLabCut project
+    (with the "individuals" column level). The file path will not be modified.
+    If "auto", the argument's value is determined based on the number of
+    individuals in the dataset: True if there is only one, False otherwise.
 
     See Also
     --------
-    to_dlc_df : Convert an xarray dataset containing pose tracks into a single
-        DeepLabCut-style pandas DataFrame or a dictionary of DataFrames
-        per individual.
+    to_dlc_style_df : Convert dataset to DeepLabCut-style DataFrame(s).
 
     Examples
     --------
@@ -205,7 +207,7 @@ def to_dlc_file(
 
     if split_individuals:
         # split the dataset into a dictionary of dataframes per individual
-        df_dict = to_dlc_df(ds, split_individuals=True)
+        df_dict = to_dlc_style_df(ds, split_individuals=True)
 
         for key, df in df_dict.items():
             # the key is the individual's name
@@ -215,7 +217,7 @@ def to_dlc_file(
             logger.info(f"Saved poses for individual {key} to {file.path}.")
     else:
         # convert the dataset to a single dataframe for all individuals
-        df_all = to_dlc_df(ds, split_individuals=False)
+        df_all = to_dlc_style_df(ds, split_individuals=False)
         if isinstance(df_all, pd.DataFrame):
             _save_dlc_df(file.path, df_all)
         logger.info(f"Saved poses dataset to {file.path}.")
@@ -225,28 +227,29 @@ def to_lp_file(
     ds: xr.Dataset,
     file_path: Union[str, Path],
 ) -> None:
-    """Save the xarray dataset to a LightningPose-style .csv file (see Notes).
+    """Save a ``movement`` dataset to a LightningPose file.
 
     Parameters
     ----------
     ds : xarray.Dataset
-        Dataset containing pose tracks, confidence scores, and metadata.
+        ``movement`` dataset containing pose tracks, confidence scores,
+        and associated metadata.
     file_path : pathlib.Path or str
-        Path to the .csv file to save the poses to.
+        Path to the file to save the poses to. File extension must be .csv.
 
     Notes
     -----
     LightningPose saves pose estimation outputs as .csv files, using the same
     format as single-animal DeepLabCut projects. Therefore, under the hood,
-    this function calls ``to_dlc_file`` with ``split_individuals=True``. This
-    setting means that each individual is saved to a separate file, with
-    the individual's name appended to the file path, just before the file
-    extension, i.e. "/path/to/filename_individual1.csv".
+    this function calls :py:func:`movement.io.save_poses.to_dlc_file`
+    with ``split_individuals=True``. This setting means that each individual
+    is saved to a separate file, with the individual's name appended to the
+    file path, just before the file extension,
+    i.e. "/path/to/filename_individual1.csv".
 
     See Also
     --------
-    to_dlc_file : Save the xarray dataset containing pose tracks to a
-        DeepLabCut-style .h5 or .csv file.
+    to_dlc_file : Save dataset to a DeepLabCut-style .h5 or .csv file.
 
     """
     file = _validate_file_path(file_path=file_path, expected_suffix=[".csv"])
@@ -257,14 +260,15 @@ def to_lp_file(
 def to_sleap_analysis_file(
     ds: xr.Dataset, file_path: Union[str, Path]
 ) -> None:
-    """Save the xarray dataset to a SLEAP-style .h5 analysis file.
+    """Save a ``movement`` dataset to a SLEAP analysis file.
 
     Parameters
     ----------
     ds : xarray.Dataset
-        Dataset containing pose tracks, confidence scores, and metadata.
+        ``movement`` dataset containing pose tracks, confidence scores,
+        and associated metadata.
     file_path : pathlib.Path or str
-        Path to the file to save the poses to. The file extension must be .h5.
+        Path to the file to save the poses to. File extension must be .h5.
 
     Notes
     -----
@@ -355,12 +359,13 @@ def to_sleap_analysis_file(
 
 
 def _remove_unoccupied_tracks(ds: xr.Dataset):
-    """Remove tracks that are completely unoccupied in the xarray dataset.
+    """Remove tracks that are completely unoccupied from the dataset.
 
     Parameters
     ----------
     ds : xarray.Dataset
-        Dataset containing pose tracks, confidence scores, and metadata.
+        ``movement`` dataset containing pose tracks, confidence scores,
+        and associated metadata.
 
     Returns
     -------
@@ -412,7 +417,7 @@ def _validate_file_path(
 
 
 def _validate_dataset(ds: xr.Dataset) -> None:
-    """Validate the input dataset is an xarray Dataset with valid poses.
+    """Validate the input as a proper ``movement`` dataset.
 
     Parameters
     ----------
@@ -422,7 +427,7 @@ def _validate_dataset(ds: xr.Dataset) -> None:
     Raises
     ------
     ValueError
-        If `ds` is not an xarray Dataset with valid poses.
+        If `ds` is not an a valid ``movement`` dataset.
 
     """
     if not isinstance(ds, xr.Dataset):

--- a/movement/io/validators.py
+++ b/movement/io/validators.py
@@ -20,11 +20,11 @@ class ValidFile:
     ----------
     path : str or pathlib.Path
         Path to the file.
-    expected_permission : {'r', 'w', 'rw'}
-        Expected access permission(s) for the file. If 'r', the file is
-        expected to be readable. If 'w', the file is expected to be writable.
-        If 'rw', the file is expected to be both readable and writable.
-        Default: 'r'.
+    expected_permission : {"r", "w", "rw"}
+        Expected access permission(s) for the file. If "r", the file is
+        expected to be readable. If "w", the file is expected to be writable.
+        If "rw", the file is expected to be both readable and writable.
+        Default: "r".
     expected_suffix : list of str
         Expected suffix(es) for the file. If an empty list (default), this
         check is skipped.
@@ -36,9 +36,9 @@ class ValidFile:
     PermissionError
         If the file does not have the expected access permission(s).
     FileNotFoundError
-        If the file does not exist when `expected_permission` is 'r' or 'rw'.
+        If the file does not exist when `expected_permission` is "r" or "rw".
     FileExistsError
-        If the file exists when `expected_permission` is 'w'.
+        If the file exists when `expected_permission` is "w".
     ValueError
         If the file does not have one of the expected suffix(es).
 
@@ -70,7 +70,7 @@ class ValidFile:
                 raise log_error(
                     FileNotFoundError, f"File {value} does not exist."
                 )
-        else:  # expected_permission is 'w'
+        else:  # expected_permission is "w"
             if value.exists():
                 raise log_error(
                     FileExistsError, f"File {value} already exists."
@@ -159,7 +159,7 @@ class ValidHDF5:
 
 @define
 class ValidDeepLabCutCSV:
-    """Class for validating DLC-style .csv files.
+    """Class for validating DeepLabCut-style .csv files.
 
     Parameters
     ----------
@@ -251,18 +251,16 @@ def _validate_list_length(
 
 @define(kw_only=True)
 class ValidPosesDataset:
-    """Class for validating pose tracking data imported from a file.
+    """Class for validating data intended for a ``movement`` dataset.
 
     Attributes
     ----------
     position_array : np.ndarray
         Array of shape (n_frames, n_individuals, n_keypoints, n_space)
-        containing the poses. It will be converted to a
-        `xarray.DataArray` object named "position".
+        containing the poses.
     confidence_array : np.ndarray, optional
         Array of shape (n_frames, n_individuals, n_keypoints) containing
-        the point-wise confidence scores. It will be converted to a
-        `xarray.DataArray` object named "confidence".
+        the point-wise confidence scores.
         If None (default), the scores will be set to an array of NaNs.
     individual_names : list of str, optional
         List of unique names for the individuals in the video. If None

--- a/tests/test_integration/test_io.py
+++ b/tests/test_integration/test_io.py
@@ -15,12 +15,12 @@ class TestPosesIO:
         """Return the output file path for a DLC .h5 or .csv file."""
         return tmp_path / request.param
 
-    def test_load_and_save_to_dlc_df(self, dlc_style_df):
+    def test_load_and_save_to_dlc_style_df(self, dlc_style_df):
         """Test that loading pose tracks from a DLC-style DataFrame and
         converting back to a DataFrame returns the same data values.
         """
         ds = load_poses.from_dlc_style_df(dlc_style_df)
-        df = save_poses.to_dlc_df(ds, split_individuals=False)
+        df = save_poses.to_dlc_style_df(ds, split_individuals=False)
         np.testing.assert_allclose(df.values, dlc_style_df.values)
 
     def test_save_and_load_dlc_file(

--- a/tests/test_integration/test_io.py
+++ b/tests/test_integration/test_io.py
@@ -19,7 +19,7 @@ class TestPosesIO:
         """Test that loading pose tracks from a DLC-style DataFrame and
         converting back to a DataFrame returns the same data values.
         """
-        ds = load_poses.from_dlc_df(dlc_style_df)
+        ds = load_poses.from_dlc_style_df(dlc_style_df)
         df = save_poses.to_dlc_df(ds, split_individuals=False)
         np.testing.assert_allclose(df.values, dlc_style_df.values)
 

--- a/tests/test_unit/test_load_poses.py
+++ b/tests/test_unit/test_load_poses.py
@@ -178,11 +178,11 @@ class TestLoadPoses:
     @pytest.mark.parametrize(
         "source_software", ["DeepLabCut", "LightningPose", None]
     )
-    def test_load_from_dlc_df(self, dlc_style_df, source_software):
+    def test_load_from_dlc_style_df(self, dlc_style_df, source_software):
         """Test that loading pose tracks from a valid DLC-style DataFrame
         returns a proper Dataset.
         """
-        ds = load_poses.from_dlc_df(
+        ds = load_poses.from_dlc_style_df(
             dlc_style_df, source_software=source_software
         )
         self.assert_dataset(ds, expected_source_software=source_software)

--- a/tests/test_unit/test_save_poses.py
+++ b/tests/test_unit/test_save_poses.py
@@ -98,12 +98,12 @@ class TestSavePoses:
             ),  # valid dataset
         ],
     )
-    def test_to_dlc_df(self, ds, expected_exception):
+    def test_to_dlc_style_df(self, ds, expected_exception):
         """Test that converting a valid/invalid xarray dataset to
         a DeepLabCut-style pandas DataFrame returns the expected result.
         """
         with expected_exception as e:
-            df = save_poses.to_dlc_df(ds, split_individuals=False)
+            df = save_poses.to_dlc_style_df(ds, split_individuals=False)
             if e is None:  # valid input
                 assert isinstance(df, pd.DataFrame)
                 assert isinstance(df.columns, pd.MultiIndex)
@@ -163,15 +163,15 @@ class TestSavePoses:
         ],
         indirect=["valid_poses_dataset"],
     )
-    def test_to_dlc_df_split_individuals(
+    def test_to_dlc_style_df_split_individuals(
         self,
         valid_poses_dataset,
         split_individuals,
     ):
         """Test that the `split_individuals` argument affects the behaviour
-        of the `to_dlc_df` function as expected.
+        of the `to_dlc_style_df` function as expected.
         """
-        df = save_poses.to_dlc_df(valid_poses_dataset, split_individuals)
+        df = save_poses.to_dlc_style_df(valid_poses_dataset, split_individuals)
         # Get the names of the individuals in the dataset
         ind_names = valid_poses_dataset.individuals.values
         if split_individuals is False:


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

The public functions in the `load_poses.py` module currently assume that users are always loading data from a file (or from a DeepLabCut-style pandas dataframe). However, there are some use-cases where the data are already in Python, in the form of numpy arrays, perhaps imported with custom loaders (this is not hypothetical, a potential user has already asked for it). There is a way to convert such data into a properly-formatted `movement` dataset, but this way is not easy to find and is not documented.

**What does this PR do?**

Adds a `from_numpy()` function that explicitly accepts `position` (+ optional `confidence`) data in the form of numpy arrays and returns a `movement` dataset. Under the hood it calls the `ValidPosesDataset` validator and the existing `_from_valid_data()` utility.

The addition of this function enabled me to slightly refactor the `load_poses.py` module such that `from_numpy()` is the single point-of-entry into a `movement` dataset - i.e. every other loading function first reads data into numpy arrays before calling the new function. This was already *de facto* the case, but it's much more explicit now. Moreover, this refactoring also enabled me to get read of a redundant validation call for `LightningPose` data.

Here's the schematic of the updated `load_poses.py` module. The previous version can be found [here](https://neuroinformatics.zulipchat.com/#narrow/stream/406001-Movement/topic/Developer.20guide.20for.20new.20I.2FO.20functions/near/439769897).

![updated_load_poses](https://github.com/neuroinformatics-unit/movement/assets/20923448/4053375f-a625-4029-a51d-359aac56af84)

## How has this PR been tested?

I added a simple unit test for the new function. The underlying `ValidPosesDataset` is already extensively tested, and so are all file loaders.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

The API index has been updated accordingly. The new function's docstring also includes example usage.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)

## EDIT 2024-05-31
Following @sfmig review, the scope of this PR expanded, resulting in a more thorough refactoring of IO-related modules: `load_poses.py`, `save_poses.py`, and `validators.py`. This mostly involved renaming functions and editing docstrings, to make the whole thing more logical and internally consistent. 

These are the names of the updated public functions:
![Screenshot 2024-05-31 at 15 49 18](https://github.com/neuroinformatics-unit/movement/assets/20923448/da81c943-cb52-4045-af6c-d371b215b1cb)

Note that we renamed `from_dlc_df` to `from_dlc_style_df` (and likewise for save), because LightningPose also uses "DeepLabCut-style" dataframes.

We also decided to rename private functions such that it's clear what is being converted to what, e.g.: `_ds_from_sleap_labels_file()` instead of `_load_from_sleap_labels.file()`. There is one remaining inconsistency, namely the fact that public functions start with `from_` while private functions start with `_ds_from_` or `_df_from_`. That's because the way public functions are actually invoked is the following:

```python
from movement.io import load_poses

ds = load_poses.from_file(`file/path')
```
and `load_poses.ds_from_file` would be redundant. Perhaps there is scope for renaming `load_poses` to `load_dataset` (and `save_poses` to `save_dataset` accordingly), such that the syntax would be `movement.io.load_dataset.from_file()`. That could make more sense now, because "poses" is a bit ambiguous, while we've [fully defined what a "dataset" is](https://movement.neuroinformatics.dev/getting_started/movement_dataset.html). I'll open an issue about that.

Here's the updated diagram for `movement`'s I/O functionalites.

![movement_io_updated](https://github.com/neuroinformatics-unit/movement/assets/20923448/afb2a643-c02c-4f80-b270-d8efc790d9d7)
