### PR TITLE
Suggestion to rename ValidPosesCSV to ValidDeepLabCutCSV

### DIFF
--- a/docs/source/api_index.rst
+++ b/docs/source/api_index.rst
@@ -31,7 +31,7 @@ Input/Output
 
     ValidFile
     ValidHDF5
-    ValidPosesCSV
+    ValidDeepLabCutCSV
     ValidPosesDataset
 
 Sample Data

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -13,9 +13,9 @@ from sleap_io.model.labels import Labels
 
 from movement import MovementDataset
 from movement.io.validators import (
+    ValidDeepLabCutCSV,
     ValidFile,
     ValidHDF5,
-    ValidPosesCSV,
     ValidPosesDataset,
 )
 from movement.logging import log_error, log_warning
@@ -503,7 +503,7 @@ def _load_df_from_dlc_csv(file_path: Path) -> pd.DataFrame:
         DeepLabCut-style DataFrame with multi-index columns.
 
     """
-    file = ValidPosesCSV(file_path)
+    file = ValidDeepLabCutCSV(file_path)
 
     possible_level_names = ["scorer", "individuals", "bodyparts", "coords"]
     with open(file.path) as f:

--- a/movement/io/validators.py
+++ b/movement/io/validators.py
@@ -158,7 +158,7 @@ class ValidHDF5:
 
 
 @define
-class ValidPosesCSV:
+class ValidDeepLabCutCSV:
     """Class for validating DLC-style .csv files.
 
     Parameters

--- a/tests/test_unit/test_validators.py
+++ b/tests/test_unit/test_validators.py
@@ -4,9 +4,9 @@ import numpy as np
 import pytest
 
 from movement.io.validators import (
+    ValidDeepLabCutCSV,
     ValidFile,
     ValidHDF5,
-    ValidPosesCSV,
     ValidPosesDataset,
 )
 
@@ -124,7 +124,7 @@ class TestValidators:
         """Test that invalid CSV files raise the appropriate errors."""
         file_path = request.getfixturevalue(invalid_input)
         with expected_exception:
-            ValidPosesCSV(file_path)
+            ValidDeepLabCutCSV(file_path)
 
     @pytest.mark.parametrize(
         "invalid_position_array",


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
The class defines a specific Deeplabcut csv format, rather than a common format in pose estimation more generally. This is clarified in the docstring but maybe it would be nice to make it more explicit with the class name.

**What does this PR do?**
Renames the validator class ValidPosesCSV to ValidDeepLabCutCSV.

Not sure about the high/lower case dance though, so happy to hear thoughts 👀 

## References

None.

## How has this PR been tested?

Tests pass locally and in CI.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [ n/a ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
