### PR TITLE
Accessor `compute_` to only validate required `position` data variable

### DIFF
--- a/movement/analysis/kinematics.py
+++ b/movement/analysis/kinematics.py
@@ -130,5 +130,5 @@ def _validate_time_dimension(data: xr.DataArray) -> None:
     """
     if "time" not in data.dims:
         raise log_error(
-            ValueError, "Input data must contain 'time' as a dimension."
+            AttributeError, "Input data must contain 'time' as a dimension."
         )

--- a/movement/analysis/kinematics.py
+++ b/movement/analysis/kinematics.py
@@ -124,7 +124,7 @@ def _validate_time_dimension(data: xr.DataArray) -> None:
 
     Raises
     ------
-    ValueError
+    AttributeError
         If the input data does not contain a ``time`` dimension.
 
     """

--- a/movement/move_accessor.py
+++ b/movement/move_accessor.py
@@ -82,7 +82,7 @@ class MovementDataset:
             ):
                 error_msg = (
                     f"'{self.__class__.__name__}' object has "
-                    "no attribute '{name}'"
+                    f"no attribute '{name}'"
                 )
                 raise log_error(AttributeError, error_msg)
             if not hasattr(self._obj, "position"):

--- a/movement/move_accessor.py
+++ b/movement/move_accessor.py
@@ -7,6 +7,7 @@ import xarray as xr
 
 from movement.analysis import kinematics
 from movement.io.validators import ValidPosesDataset
+from movement.logging import log_error
 
 logger = logging.getLogger(__name__)
 
@@ -76,14 +77,26 @@ class MovementDataset:
         """
 
         def method(*args, **kwargs):
-            if name.startswith("compute_") and hasattr(kinematics, name):
-                self.validate()
+            if not name.startswith("compute_") or not hasattr(
+                kinematics, name
+            ):
+                error_msg = (
+                    f"'{self.__class__.__name__}' object has "
+                    "no attribute '{name}'"
+                )
+                raise log_error(AttributeError, error_msg)
+            if not hasattr(self._obj, "position"):
+                raise log_error(
+                    AttributeError,
+                    "Missing required data variables: 'position'",
+                )
+            try:
                 return getattr(kinematics, name)(
                     self._obj.position, *args, **kwargs
                 )
-            raise AttributeError(
-                f"'{self.__class__.__name__}' object has no attribute '{name}'"
-            )
+            except Exception as e:
+                error_msg = f"Failed to evoke '{name}'. "
+                raise log_error(AttributeError, error_msg) from e
 
         return method
 
@@ -116,6 +129,5 @@ class MovementDataset:
                 source_software=source_software,
             )
         except Exception as e:
-            error_msg = "The dataset does not contain valid poses."
-            logger.error(error_msg)
-            raise ValueError(error_msg) from e
+            error_msg = "The dataset does not contain valid poses. " + str(e)
+            raise log_error(ValueError, error_msg) from e

--- a/tests/test_integration/test_kinematics_vector_transform.py
+++ b/tests/test_integration/test_kinematics_vector_transform.py
@@ -16,7 +16,7 @@ class TestKinematicsVectorTransform:
         [
             ("valid_poses_dataset", does_not_raise()),
             ("valid_poses_dataset_with_nan", does_not_raise()),
-            ("missing_dim_dataset", pytest.raises(ValueError)),
+            ("missing_dim_dataset", pytest.raises(AttributeError)),
         ],
     )
     def test_cart_and_pol_transform(

--- a/tests/test_unit/test_kinematics.py
+++ b/tests/test_unit/test_kinematics.py
@@ -53,7 +53,7 @@ class TestKinematics:
     kinematic_test_params = [
         ("valid_poses_dataset", does_not_raise()),
         ("valid_poses_dataset_with_nan", does_not_raise()),
-        ("missing_dim_dataset", pytest.raises(ValueError)),
+        ("missing_dim_dataset", pytest.raises(AttributeError)),
     ]
 
     @pytest.mark.parametrize("ds, expected_exception", kinematic_test_params)

--- a/tests/test_unit/test_move_accessor.py
+++ b/tests/test_unit/test_move_accessor.py
@@ -23,12 +23,7 @@ class TestMovementDataset:
         """Test that computing a kinematic property of an invalid
         pose dataset via accessor methods raises the appropriate error.
         """
-        expected_exception = (
-            ValueError
-            if isinstance(invalid_poses_dataset, xr.Dataset)
-            else AttributeError
-        )
-        with pytest.raises(expected_exception):
+        with pytest.raises(AttributeError):
             getattr(
                 invalid_poses_dataset.move, f"compute_{kinematic_property}"
             )()


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
This PR closes #203 

**What does this PR do?**
This PR removes the `self.validate()` step in `move_accessor` that validates the entire dataset, and validates only the required ``position`` data variable and leaves the ``time`` validation up to the `compute_` function evoked.
This PR also uses `log_error` that logs and raises an Error, in preference to `logger.error` + `raise` calls.
Incorrect error types raised are also corrected in this PR (ValueError &rarr; AttributeError). 

## References
#203 

## How has this PR been tested?
Affected tests have been updated accordingly and rerun. 

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
