### PR TITLE
Update supported Python versions

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -28,16 +28,16 @@ jobs:
     strategy:
       matrix:
         # Run all supported Python versions on linux
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
         os: [ubuntu-latest]
         # Include 1 Intel macos (13) and 1 M1 macos (latest) and 1 Windows run
         include:
         - os: macos-13
-          python-version: "3.10"
+          python-version: "3.11"
         - os: macos-latest
-          python-version: "3.10"
+          python-version: "3.11"
         - os: windows-latest
-          python-version: "3.10"
+          python-version: "3.11"
 
     steps:
       - name: Cache Test Data

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Python Version](https://img.shields.io/pypi/pyversions/movement.svg)](https://pypi.org/project/movement)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-orange.svg)](https://opensource.org/licenses/BSD-3-Clause)
 ![CI](https://img.shields.io/github/actions/workflow/status/neuroinformatics-unit/movement/test_and_deploy.yml?label=CI)
 [![codecov](https://codecov.io/gh/neuroinformatics-unit/movement/branch/main/graph/badge.svg?token=P8CCH3TI8K)](https://codecov.io/gh/neuroinformatics-unit/movement)

--- a/docs/source/getting_started/installation.md
+++ b/docs/source/getting_started/installation.md
@@ -15,7 +15,7 @@ First, create and activate an environment with some prerequisites.
 You can call your environment whatever you like, we've used `movement-env`.
 
 ```sh
-conda create -n movement-env -c conda-forge python=3.10 pytables
+conda create -n movement-env -c conda-forge python=3.11 pytables
 conda activate movement-env
 ```
 

--- a/examples/compute_kinematics.py
+++ b/examples/compute_kinematics.py
@@ -52,7 +52,9 @@ position = ds.position
 # colouring them by individual.
 
 fig, ax = plt.subplots(1, 1)
-for mouse_name, col in zip(position.individuals.values, ["r", "g", "b"]):
+for mouse_name, col in zip(
+    position.individuals.values, ["r", "g", "b"], strict=False
+):
     ax.plot(
         position.sel(individuals=mouse_name, space="x"),
         position.sel(individuals=mouse_name, space="y"),
@@ -78,7 +80,7 @@ for mouse_name, col in zip(position.individuals.values, ["r", "g", "b"]):
 # %%
 # We can also color the data points based on their timestamps:
 fig, axes = plt.subplots(3, 1, sharey=True)
-for mouse_name, ax in zip(position.individuals.values, axes):
+for mouse_name, ax in zip(position.individuals.values, axes, strict=False):
     sc = ax.scatter(
         position.sel(individuals=mouse_name, space="x"),
         position.sel(individuals=mouse_name, space="y"),
@@ -297,7 +299,7 @@ plt.gcf().show()
 # %%
 # We can also visualise the speed, as the norm of the velocity vector:
 fig, axes = plt.subplots(3, 1, sharex=True, sharey=True)
-for mouse_name, ax in zip(velocity.individuals.values, axes):
+for mouse_name, ax in zip(velocity.individuals.values, axes, strict=False):
     # compute the norm of the velocity vector for one mouse
     speed_one_mouse = np.linalg.norm(
         velocity.sel(individuals=mouse_name, space=["x", "y"]).squeeze(),
@@ -357,7 +359,7 @@ accel = ds.move.compute_acceleration()
 # and plot of the components of the acceleration vector ``ax``, ``ay`` per
 # individual:
 fig, axes = plt.subplots(3, 1, sharex=True, sharey=True)
-for mouse_name, ax in zip(accel.individuals.values, axes):
+for mouse_name, ax in zip(accel.individuals.values, axes, strict=False):
     # plot x-component of acceleration vector
     ax.plot(
         accel.sel(individuals=mouse_name, space=["x"]).squeeze(),
@@ -379,7 +381,7 @@ fig.tight_layout()
 # acceleration.
 # We can also represent this for each individual.
 fig, axes = plt.subplots(3, 1, sharex=True, sharey=True)
-for mouse_name, ax in zip(accel.individuals.values, axes):
+for mouse_name, ax in zip(accel.individuals.values, axes, strict=False):
     # compute norm of the acceleration vector for one mouse
     accel_one_mouse = np.linalg.norm(
         accel.sel(individuals=mouse_name, space=["x", "y"]).squeeze(),

--- a/examples/smooth.py
+++ b/examples/smooth.py
@@ -67,7 +67,7 @@ def plot_raw_and_smooth_timeseries_and_psd(
     fig, ax = plt.subplots(2, 1, figsize=(10, 6))
 
     for ds, color, label in zip(
-        [ds_raw, ds_smooth], ["k", "r"], ["raw", "smooth"]
+        [ds_raw, ds_smooth], ["k", "r"], ["raw", "smooth"], strict=False
     ):
         # plot position time series
         pos = ds.position.sel(**selection)

--- a/movement/filtering.py
+++ b/movement/filtering.py
@@ -3,7 +3,6 @@
 import logging
 from datetime import datetime
 from functools import wraps
-from typing import Optional, Union
 
 import xarray as xr
 from scipy import signal
@@ -79,9 +78,9 @@ def report_nan_values(ds: xr.Dataset, ds_label: str = "dataset"):
 def interpolate_over_time(
     ds: xr.Dataset,
     method: str = "linear",
-    max_gap: Union[int, None] = None,
+    max_gap: int | None = None,
     print_report: bool = True,
-) -> Union[xr.Dataset, None]:
+) -> xr.Dataset | None:
     """Fill in NaN values by interpolating over the time dimension.
 
     Parameters
@@ -122,7 +121,7 @@ def filter_by_confidence(
     ds: xr.Dataset,
     threshold: float = 0.6,
     print_report: bool = True,
-) -> Union[xr.Dataset, None]:
+) -> xr.Dataset | None:
     """Drop all points below a certain confidence threshold.
 
     Position points with an associated confidence value below the threshold are
@@ -173,7 +172,7 @@ def filter_by_confidence(
 def median_filter(
     ds: xr.Dataset,
     window_length: int,
-    min_periods: Optional[int] = None,
+    min_periods: int | None = None,
     print_report: bool = True,
 ) -> xr.Dataset:
     """Smooth pose tracks by applying a median filter over time.

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -2,7 +2,7 @@
 
 import logging
 from pathlib import Path
-from typing import Literal, Optional, Union
+from typing import Literal
 
 import h5py
 import numpy as np
@@ -25,11 +25,11 @@ logger = logging.getLogger(__name__)
 
 def from_numpy(
     position_array: np.ndarray,
-    confidence_array: Optional[np.ndarray] = None,
-    individual_names: Optional[list[str]] = None,
-    keypoint_names: Optional[list[str]] = None,
-    fps: Optional[float] = None,
-    source_software: Optional[str] = None,
+    confidence_array: np.ndarray | None = None,
+    individual_names: list[str] | None = None,
+    keypoint_names: list[str] | None = None,
+    fps: float | None = None,
+    source_software: str | None = None,
 ) -> xr.Dataset:
     """Create a ``movement`` dataset from NumPy arrays.
 
@@ -95,9 +95,9 @@ def from_numpy(
 
 
 def from_file(
-    file_path: Union[Path, str],
+    file_path: Path | str,
     source_software: Literal["DeepLabCut", "SLEAP", "LightningPose"],
-    fps: Optional[float] = None,
+    fps: float | None = None,
 ) -> xr.Dataset:
     """Create a ``movement`` dataset from any supported file.
 
@@ -149,7 +149,7 @@ def from_file(
 
 def from_dlc_style_df(
     df: pd.DataFrame,
-    fps: Optional[float] = None,
+    fps: float | None = None,
     source_software: Literal["DeepLabCut", "LightningPose"] = "DeepLabCut",
 ) -> xr.Dataset:
     """Create a ``movement`` dataset from a DeepLabCut-style DataFrame.
@@ -216,7 +216,7 @@ def from_dlc_style_df(
 
 
 def from_sleap_file(
-    file_path: Union[Path, str], fps: Optional[float] = None
+    file_path: Path | str, fps: float | None = None
 ) -> xr.Dataset:
     """Create a ``movement`` dataset from a SLEAP file.
 
@@ -292,7 +292,7 @@ def from_sleap_file(
 
 
 def from_lp_file(
-    file_path: Union[Path, str], fps: Optional[float] = None
+    file_path: Path | str, fps: float | None = None
 ) -> xr.Dataset:
     """Create a ``movement`` dataset from a LightningPose file.
 
@@ -322,7 +322,7 @@ def from_lp_file(
 
 
 def from_dlc_file(
-    file_path: Union[Path, str], fps: Optional[float] = None
+    file_path: Path | str, fps: float | None = None
 ) -> xr.Dataset:
     """Create a ``movement`` dataset from a DeepLabCut file.
 
@@ -357,9 +357,9 @@ def from_dlc_file(
 
 
 def _ds_from_lp_or_dlc_file(
-    file_path: Union[Path, str],
+    file_path: Path | str,
     source_software: Literal["LightningPose", "DeepLabCut"],
-    fps: Optional[float] = None,
+    fps: float | None = None,
 ) -> xr.Dataset:
     """Create a ``movement`` dataset from a LightningPose or DeepLabCut file.
 
@@ -408,7 +408,7 @@ def _ds_from_lp_or_dlc_file(
 
 
 def _ds_from_sleap_analysis_file(
-    file_path: Path, fps: Optional[float]
+    file_path: Path, fps: float | None
 ) -> xr.Dataset:
     """Create a ``movement`` dataset from a SLEAP analysis (.h5) file.
 
@@ -456,7 +456,7 @@ def _ds_from_sleap_analysis_file(
 
 
 def _ds_from_sleap_labels_file(
-    file_path: Path, fps: Optional[float]
+    file_path: Path, fps: float | None
 ) -> xr.Dataset:
     """Create a ``movement`` dataset from a SLEAP labels (.slp) file.
 
@@ -596,7 +596,9 @@ def _df_from_dlc_csv(file_path: Path) -> pd.DataFrame:
 
     # Form multi-index column names from the header lines
     level_names = [line[0] for line in header_lines]
-    column_tuples = list(zip(*[line[1:] for line in header_lines]))
+    column_tuples = list(
+        zip(*[line[1:] for line in header_lines], strict=False)
+    )
     columns = pd.MultiIndex.from_tuples(column_tuples, names=level_names)
 
     # Import the DeepLabCut poses as a DataFrame

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -2,7 +2,7 @@
 
 import logging
 from pathlib import Path
-from typing import Literal, Union
+from typing import Literal
 
 import h5py
 import numpy as np
@@ -79,7 +79,7 @@ def _save_dlc_df(filepath: Path, df: pd.DataFrame) -> None:
 
 def to_dlc_style_df(
     ds: xr.Dataset, split_individuals: bool = False
-) -> Union[pd.DataFrame, dict[str, pd.DataFrame]]:
+) -> pd.DataFrame | dict[str, pd.DataFrame]:
     """Convert a ``movement`` dataset to DeepLabCut-style DataFrame(s).
 
     Parameters
@@ -152,8 +152,8 @@ def to_dlc_style_df(
 
 def to_dlc_file(
     ds: xr.Dataset,
-    file_path: Union[str, Path],
-    split_individuals: Union[bool, Literal["auto"]] = "auto",
+    file_path: str | Path,
+    split_individuals: bool | Literal["auto"] = "auto",
 ) -> None:
     """Save a ``movement`` dataset to DeepLabCut file(s).
 
@@ -225,7 +225,7 @@ def to_dlc_file(
 
 def to_lp_file(
     ds: xr.Dataset,
-    file_path: Union[str, Path],
+    file_path: str | Path,
 ) -> None:
     """Save a ``movement`` dataset to a LightningPose file.
 
@@ -257,9 +257,7 @@ def to_lp_file(
     to_dlc_file(ds, file.path, split_individuals=True)
 
 
-def to_sleap_analysis_file(
-    ds: xr.Dataset, file_path: Union[str, Path]
-) -> None:
+def to_sleap_analysis_file(ds: xr.Dataset, file_path: str | Path) -> None:
     """Save a ``movement`` dataset to a SLEAP analysis file.
 
     Parameters
@@ -378,7 +376,7 @@ def _remove_unoccupied_tracks(ds: xr.Dataset):
 
 
 def _validate_file_path(
-    file_path: Union[str, Path], expected_suffix: list[str]
+    file_path: str | Path, expected_suffix: list[str]
 ) -> ValidFile:
     """Validate the input file path.
 

--- a/movement/io/validators.py
+++ b/movement/io/validators.py
@@ -3,7 +3,7 @@
 import os
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Literal, Optional, Union
+from typing import Any, Literal
 
 import h5py
 import numpy as np
@@ -202,7 +202,7 @@ class ValidDeepLabCutCSV:
                 )
 
 
-def _list_of_str(value: Union[str, Iterable[Any]]) -> list[str]:
+def _list_of_str(value: str | Iterable[Any]) -> list[str]:
     """Try to coerce the value into a list of strings."""
     if isinstance(value, str):
         log_warning(
@@ -226,7 +226,7 @@ def _ensure_type_ndarray(value: Any) -> None:
         )
 
 
-def _set_fps_to_none_if_invalid(fps: Optional[float]) -> Optional[float]:
+def _set_fps_to_none_if_invalid(fps: float | None) -> float | None:
     """Set fps to None if a non-positive float is passed."""
     if fps is not None and fps <= 0:
         log_warning(
@@ -238,7 +238,7 @@ def _set_fps_to_none_if_invalid(fps: Optional[float]) -> Optional[float]:
 
 
 def _validate_list_length(
-    attribute: str, value: Optional[list], expected_length: int
+    attribute: str, value: list | None, expected_length: int
 ):
     """Raise a ValueError if the list does not have the expected length."""
     if (value is not None) and (len(value) != expected_length):
@@ -280,22 +280,22 @@ class ValidPosesDataset:
 
     # Define class attributes
     position_array: np.ndarray = field()
-    confidence_array: Optional[np.ndarray] = field(default=None)
-    individual_names: Optional[list[str]] = field(
+    confidence_array: np.ndarray | None = field(default=None)
+    individual_names: list[str] | None = field(
         default=None,
         converter=converters.optional(_list_of_str),
     )
-    keypoint_names: Optional[list[str]] = field(
+    keypoint_names: list[str] | None = field(
         default=None,
         converter=converters.optional(_list_of_str),
     )
-    fps: Optional[float] = field(
+    fps: float | None = field(
         default=None,
         converter=converters.pipe(  # type: ignore
             converters.optional(float), _set_fps_to_none_if_invalid
         ),
     )
-    source_software: Optional[str] = field(
+    source_software: str | None = field(
         default=None,
         validator=validators.optional(validators.instance_of(str)),
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "Analysis of body movement"
 readme = "README.md"
-requires-python = ">=3.9.0"
+requires-python = ">=3.10.0"
 dynamic = ["version"]
 
 license = { text = "BSD-3-Clause" }
@@ -27,9 +27,9 @@ classifiers = [
   "Development Status :: 3 - Alpha",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Operating System :: OS Independent",
   "License :: OSI Approved :: BSD License",
 ]
@@ -138,14 +138,14 @@ check-hidden = true
 legacy_tox_ini = """
 [tox]
 requires = tox-conda
-envlist = py{39,310,311}
+envlist = py{310,311,312}
 isolated_build = True
 
 [gh-actions]
 python =
-    3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [testenv]
 conda_deps =


### PR DESCRIPTION
Following [Scientific Python's SPEC-0](https://scientific-python.org/specs/spec-0000/), we are dropping support for `python v3.9` and adding support for `python v3.12`. 
In the installation instructions, the recommended python version for the conda environment was bumped from `3.10` to `3.11`, and consequently `3.11` is also the version we test across all OSes in CI.

One of the `ruff` linters (`pyupgrade`) automatically replaced all `Union` occurrences with the `|` syntax, because that was introduced in `3.10`.

I also added a badge to the README, which will automatically fetch supported Python version from PyPI and display them.