### PR TITLE
Update python version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A Python toolbox for analysing body movements across space and time, to aid the 
 
 First, create and activate a conda environment with the required dependencies:
 ```
-conda create -n movement-env -c conda-forge python=3.10 pytables
+conda create -n movement-env -c conda-forge python=3.11 pytables
 conda activate movement-env
 ```
 


### PR DESCRIPTION
Since [PR208](https://github.com/neuroinformatics-unit/movement/pull/208), python v3.11 is the main version we test across OSes and it's the one we recommend in the installation guide. But I'd forgotten to update the python version in the quick install section of the README. This PR rectifies that.