### PR TITLE
Added ruff rule to check for numpy2.0 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,14 +106,15 @@ ignore = [
   "D213", # multi-line-summary second line
 ]
 select = [
-  "E",   # pycodestyle errors
-  "F",   # Pyflakes
-  "UP",  # pyupgrade
-  "I",   # isort
-  "B",   # flake8 bugbear
-  "SIM", # flake8 simplify
-  "C90", # McCabe complexity
-  "D",   # pydocstyle
+  "E",      # pycodestyle errors
+  "F",      # Pyflakes
+  "UP",     # pyupgrade
+  "I",      # isort
+  "B",      # flake8 bugbear
+  "SIM",    # flake8 simplify
+  "C90",    # McCabe complexity
+  "D",      # pydocstyle
+  "NPY201", # checks for syntax that was deprecated in numpy2.0
 ]
 per-file-ignores = { "tests/*" = [
   "D100", # missing docstring in public module


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Numpy 2.0 was released yesterday, containing some breaking API changes (syntax deprecations).

The Numpy devs have written a [migration guide](https://numpy.org/devdocs/numpy_2_0_migration_guide.html), and have even provided a ruff linting rule - [NPY201](https://docs.astral.sh/ruff/rules/numpy2-deprecation/)  - that "Checks for uses of NumPy functions and constants that were removed from the main namespace in NumPy 2.0".

**What does this PR do?**

It add NPY201 to the ruff lint config. 

I also run `pre-commit run -a` and thankfully nothing came up. Nevertheless I'll leave this rule in, so that no deprecated syntax creeps in.

## References

n/a

## How has this PR been tested?

Existing tests pass locally and in CI.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [/] Tests have been added to cover all new functionality
- [/] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
