### PR TITLE
Small edits to ValidBboxesDataset (1/4)

### DIFF
--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -314,6 +314,6 @@ class ValidBboxesDataset:
                 -1, 1
             )
             log_warning(
-                "Confidence array was not provided."
-                "Setting to an array of NaNs."
+                "Frame numbers were not provided."
+                "Setting to an array of 0-based integers."
             )

--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -201,7 +201,10 @@ class ValidBboxesDataset:
         of the `position_array`. The names will be in the format of `id_<N>`,
         where <N>  is an integer from 1 to `position_array.shape[1]`.
     frame_array : np.ndarray, optional
-        ...
+        Array of shape (n_frames, 1) containing the frame numbers for which
+        bounding boxes are defined. If None (default), frame numbers will
+        be assigned based on the first dimension of the `position_array`,
+        starting from 0.
     fps : float, optional
         Frames per second defining the sampling rate of the data.
         Defaults to None.

--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -33,6 +33,16 @@ def _ensure_type_ndarray(value: Any) -> None:
         )
 
 
+def _ensure_shape(attribute, value: np.ndarray, expected_shape: tuple):
+    """Raise ValueError if the value does not have the expected shape."""
+    if value.shape != expected_shape:
+        raise log_error(
+            ValueError,
+            f"Expected '{attribute.name}' to have shape {expected_shape}, "
+            f"but got {value.shape}.",
+        )
+
+
 def _set_fps_to_none_if_invalid(fps: float | None) -> float | None:
     """Set fps to None if a non-positive float is passed."""
     if fps is not None and fps <= 0:
@@ -126,13 +136,10 @@ class ValidPosesDataset:
     def _validate_confidence_array(self, attribute, value):
         if value is not None:
             _ensure_type_ndarray(value)
-            expected_shape = self.position_array.shape[:-1]
-            if value.shape != expected_shape:
-                raise log_error(
-                    ValueError,
-                    f"Expected '{attribute.name}' to have shape "
-                    f"{expected_shape}, but got {value.shape}.",
-                )
+
+            _ensure_shape(
+                attribute, value, expected_shape=self.position_array.shape[:-1]
+            )
 
     @individual_names.validator
     def _validate_individual_names(self, attribute, value):
@@ -276,27 +283,24 @@ class ValidBboxesDataset:
         if value is not None:
             _ensure_type_ndarray(value)
 
-            expected_shape = self.position_array.shape[:-1]
-            if value.shape != expected_shape:
-                raise log_error(
-                    ValueError,
-                    f"Expected '{attribute.name}' to have shape "
-                    f"{expected_shape}, but got {value.shape}.",
-                )
+            _ensure_shape(
+                attribute, value, expected_shape=self.position_array.shape[:-1]
+            )
 
     @frame_array.validator
-    def _validate_frame_array(self, attribute, value):
+    def _validate_frame_array(
+        self, attribute, value
+    ):  # ---- ADD check for contiguous frames
         if value is not None:
             _ensure_type_ndarray(value)
 
             # should be a column vector (n_frames, 1)
-            expected_shape = (self.position_array.shape[0], 1)
-            if value.shape != expected_shape:
-                raise log_error(
-                    ValueError,
-                    f"Expected '{attribute.name}' to have shape "
-                    f"{expected_shape}, but got {value.shape}.",
-                )
+
+            _ensure_shape(
+                attribute,
+                value,
+                expected_shape=(self.position_array.shape[0], 1),
+            )
 
     # Define defaults
     def __attrs_post_init__(self):

--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -304,7 +304,7 @@ class ValidBboxesDataset:
 
         If no confidence_array is provided, set it to an array of NaNs.
         If no individual names are provided, assign them unique IDs per frame,
-        starting with 1 ("id_1")
+        starting with 0 ("id_0").
         """
         if self.confidence_array is None:
             self.confidence_array = np.full(
@@ -319,12 +319,12 @@ class ValidBboxesDataset:
 
         if self.individual_names is None:
             self.individual_names = [
-                f"id_{i+1}" for i in range(self.position_array.shape[1])
+                f"id_{i}" for i in range(self.position_array.shape[1])
             ]
             log_warning(
                 "Individual names for the bounding boxes "
                 "were not provided. "
-                "Setting to 1-based IDs that are unique per frame: \n"
+                "Setting to 0-based IDs that are unique per frame: \n"
                 f"{self.individual_names}.\n"
             )
 

--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -3,6 +3,7 @@
 from collections.abc import Iterable
 from typing import Any
 
+import attrs
 import numpy as np
 from attrs import converters, define, field, validators
 
@@ -44,7 +45,9 @@ def _validate_type_ndarray(value: Any) -> None:
         )
 
 
-def _validate_array_shape(attribute, value: np.ndarray, expected_shape: tuple):
+def _validate_array_shape(
+    attribute: attrs.Attribute, value: np.ndarray, expected_shape: tuple
+):
     """Raise ValueError if the value does not have the expected shape."""
     if value.shape != expected_shape:
         raise log_error(
@@ -54,7 +57,9 @@ def _validate_array_shape(attribute, value: np.ndarray, expected_shape: tuple):
         )
 
 
-def _validate_list_length(attribute, value: list | None, expected_length: int):
+def _validate_list_length(
+    attribute: attrs.Attribute, value: list | None, expected_length: int
+):
     """Raise a ValueError if the list does not have the expected length."""
     if (value is not None) and (len(value) != expected_length):
         raise log_error(

--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -221,6 +221,7 @@ class ValidBboxesDataset:
             _list_of_str
         ),  # force into list of strings if not
     )
+    frame_array: np.ndarray | None = field(default=None)
     fps: float | None = field(
         default=None,
         converter=converters.pipe(  # type: ignore
@@ -306,4 +307,13 @@ class ValidBboxesDataset:
                 "were not provided. "
                 "Setting to 1-based IDs that are unique per frame: \n"
                 f"{self.individual_names}.\n"
+            )
+
+        if self.frame_array is None:
+            self.frame_array = np.arange(self.position_array.shape[0]).reshape(
+                -1, 1
+            )
+            log_warning(
+                "Confidence array was not provided."
+                "Setting to an array of NaNs."
             )

--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -293,19 +293,23 @@ class ValidBboxesDataset:
             )
 
     @frame_array.validator
-    def _validate_frame_array(
-        self, attribute, value
-    ):  # ---- ADD check for contiguous frames
+    def _validate_frame_array(self, attribute, value):
         if value is not None:
             _validate_type_ndarray(value)
 
             # should be a column vector (n_frames, 1)
-
             _validate_array_shape(
                 attribute,
                 value,
                 expected_shape=(self.position_array.shape[0], 1),
             )
+
+            # check frames are continuous: exactly one frame number per row
+            if not np.all(np.diff(value, axis=0) == 1):
+                raise log_error(
+                    ValueError,
+                    f"Frame numbers in {attribute.name} are not continuous.",
+                )
 
     # Define defaults
     def __attrs_post_init__(self):

--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -313,7 +313,7 @@ class ValidBboxesDataset:
                 dtype="float32",
             )
             log_warning(
-                "Confidence array was not provided."
+                "Confidence array was not provided. "
                 "Setting to an array of NaNs."
             )
 
@@ -332,6 +332,6 @@ class ValidBboxesDataset:
             n_frames = self.position_array.shape[0]
             self.frame_array = np.arange(n_frames).reshape(-1, 1)
             log_warning(
-                "Frame numbers were not provided."
+                "Frame numbers were not provided. "
                 "Setting to an array of 0-based integers."
             )

--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -37,6 +37,17 @@ def _convert_fps_to_none_if_invalid(fps: float | None) -> float | None:
     return fps
 
 
+def _convert_to_column_vector(value: np.ndarray) -> np.ndarray:
+    """Convert an array of shape (n,) or (1, n) to an array of shape (n, 1)."""
+    # Validate the input is an np array
+    _validate_type_ndarray(value)
+
+    # Convert to column vector if necessary
+    if (value.ndim == 1) or (value.ndim == 2 and value.shape[1] != 1):
+        return value.reshape(-1, 1)
+    return value
+
+
 def _validate_type_ndarray(value: Any) -> None:
     """Raise ValueError the value is a not numpy array."""
     if not isinstance(value, np.ndarray):
@@ -213,9 +224,9 @@ class ValidBboxesDataset:
         of the `position_array`. The names will be in the format of `id_<N>`,
         where <N>  is an integer from 1 to `position_array.shape[1]`.
     frame_array : np.ndarray, optional
-        Array of shape (n_frames, 1) containing the frame numbers for which
-        bounding boxes are defined. If None (default), frame numbers will
-        be assigned based on the first dimension of the `position_array`,
+        One dimensional array of length n_frames containing the frame numbers
+        for which bounding boxes are defined. If None (default), frame numbers
+        will be assigned based on the first dimension of the `position_array`,
         starting from 0.
     fps : float, optional
         Frames per second defining the sampling rate of the data.
@@ -238,7 +249,12 @@ class ValidBboxesDataset:
             _convert_to_list_of_str
         ),  # force into list of strings if not
     )
-    frame_array: np.ndarray | None = field(default=None)
+    frame_array: np.ndarray | None = field(
+        default=None,
+        converter=converters.optional(
+            _convert_to_column_vector
+        ),  # force into column vector
+    )
     fps: float | None = field(
         default=None,
         converter=converters.pipe(  # type: ignore
@@ -294,22 +310,12 @@ class ValidBboxesDataset:
 
     @frame_array.validator
     def _validate_frame_array(self, attribute, value):
-        if value is not None:
-            _validate_type_ndarray(value)
-
-            # should be a column vector (n_frames, 1)
-            _validate_array_shape(
-                attribute,
-                value,
-                expected_shape=(self.position_array.shape[0], 1),
+        # check frames are continuous: exactly one frame number per row
+        if (value is not None) and (not np.all(np.diff(value, axis=0) == 1)):
+            raise log_error(
+                ValueError,
+                f"Frame numbers in {attribute.name} are not continuous.",
             )
-
-            # check frames are continuous: exactly one frame number per row
-            if not np.all(np.diff(value, axis=0) == 1):
-                raise log_error(
-                    ValueError,
-                    f"Frame numbers in {attribute.name} are not continuous.",
-                )
 
     # Define defaults
     def __attrs_post_init__(self):

--- a/tests/test_unit/test_sample_data.py
+++ b/tests/test_unit/test_sample_data.py
@@ -40,6 +40,7 @@ def validate_metadata(metadata: dict[str, dict]) -> None:
         "sha256sum",
         "type",
         "source_software",
+        "type",
         "fps",
         "species",
         "number_of_individuals",

--- a/tests/test_unit/test_validators/test_datasets_validators.py
+++ b/tests/test_unit/test_validators/test_datasets_validators.py
@@ -361,9 +361,9 @@ def test_bboxes_dataset_validator_confidence_array(
     [
         (
             np.arange(10).reshape(-1, 2),
-            pytest.raises(ValueError),
-            "Expected 'frame_array' to have shape (10, 1), " "but got (5, 2).",
-        ),  # frame_array should be a column vector
+            does_not_raise(),
+            "",
+        ),  # frame_array is coerced to a column vector
         (
             [1, 2, 3],
             pytest.raises(ValueError),
@@ -405,4 +405,5 @@ def test_bboxes_dataset_validator_frame_array(
         assert np.array_equal(ds.frame_array, default_frame_array)
         assert ds.frame_array.shape == (ds.position_array.shape[0], 1)
     else:
-        assert str(excinfo.value) == log_message
+        if log_message:
+            assert str(excinfo.value) == log_message

--- a/tests/test_unit/test_validators/test_datasets_validators.py
+++ b/tests/test_unit/test_validators/test_datasets_validators.py
@@ -370,6 +370,11 @@ def test_bboxes_dataset_validator_confidence_array(
             f"Expected a numpy array, but got {type(list())}.",
         ),  # not an ndarray, should raise ValueError
         (
+            np.array([1, 2, 3, 4, 6, 7, 8, 9, 10, 11]).reshape(-1, 1),
+            pytest.raises(ValueError),
+            "Frame numbers in frame_array are not continuous.",
+        ),  # frame numbers are not continuous
+        (
             None,
             does_not_raise(),
             "",

--- a/tests/test_unit/test_validators/test_datasets_validators.py
+++ b/tests/test_unit/test_validators/test_datasets_validators.py
@@ -361,9 +361,9 @@ def test_bboxes_dataset_validator_confidence_array(
     [
         (
             np.arange(10).reshape(-1, 2),
-            does_not_raise(),
-            "",
-        ),  # frame_array is coerced to a column vector
+            pytest.raises(ValueError),
+            "Expected 'frame_array' to have shape (10, 1), " "but got (5, 2).",
+        ),  # frame_array should be a column vector
         (
             [1, 2, 3],
             pytest.raises(ValueError),
@@ -405,5 +405,4 @@ def test_bboxes_dataset_validator_frame_array(
         assert np.array_equal(ds.frame_array, default_frame_array)
         assert ds.frame_array.shape == (ds.position_array.shape[0], 1)
     else:
-        if log_message:
-            assert str(excinfo.value) == log_message
+        assert str(excinfo.value) == log_message


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Two small edits are needed in `ValidBboxesDataset` to continue with the bboxes work:

1. Adding `frame_array` to `ValidBboxesDataset`.
	Usually running inference on a video using a detection model will output a file (often a csv) that links each detection (aka bounding box) to a frame in the video. As a result, specific frame numbers appear in the output file (see [here](https://motchallenge.net/instructions/) for a few examples). We would like to be able to pass these specific frame numbers to the bounding boxes dataset if they are defined.

2. Setting default track IDs to 1-based integers.
    This follows from the discussion at #217. 

**What does this PR do?**
1. Adds `frame_array` as an optional attribute to the `ValidBboxesDataset`.
	- If no frame numbers are provided, we assign numbers based on the first dimension of the position array, and starting from 0.
	- If frame numbers are provided, we only check that the `frame_numbers` value is a column vector (a numpy array of size (n,1) with n being the number of frames). 

2. Sets the default IDs for the `individual_names` to start with 0 ('id_0', 'id_1',...).

This PR also includes:
- a minor fix in the tests that renames a bboxes dataset from `poses` --->`ds`.
- two small fixes in the `test_sample_data` module to adapt to the new metadata.yaml file (which includes bbox data) that is now in the GIN repo. One fix is temporary (noted with a comment) to ensure the tests pass in this PR.

**Question**: We do not check that the frames are monotonically increasing (i.e. sorted) or that there are no gaps - should we? I think we shouldn't, but let me know thoughts.

## References

\

## How has this PR been tested?

Tests pass locally and in CI.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ n/a ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
