### PR TITLE
Add citation information

### DIFF
--- a/CITATION.CFF
+++ b/CITATION.CFF
@@ -1,0 +1,32 @@
+cff-version: 1.2.0
+title: movement
+message: >-
+  If you use movement in your work, please cite the following Zenodo DOI
+type: software
+authors:
+  - given-names: Nikoloz
+    family-names: Sirmpilatze
+  - given-names: Chang Huan
+    family-names: Lo
+  - given-names: Sofia
+    family-names: Miñano
+  - given-names: Dhruv
+    family-names: Sharma
+  - given-names: Brandon D.
+    family-names: Peri
+  - given-names: Laura
+    family-names: Porta
+  - given-names: Iván
+    family-names: Varela
+  - given-names: Adam L.
+    family-names: Tyson
+    email: code@adamltyson.com
+repository-code: >-
+  https://github.com/neuroinformatics-unit/movement
+url: 'https://movement.neuroinformatics.dev/'
+abstract: >-
+   Python tools for analysing body movements across space and time.
+license: BSD-3-Clause
+date-released: '2024-007-17'
+doi: 10.5281/zenodo.12755724
+year: 2024

--- a/CITATION.CFF
+++ b/CITATION.CFF
@@ -10,12 +10,12 @@ authors:
     email: niko.sirbiladze@gmail.com
   - given-names: Chang Huan
     family-names: Lo
-  - given-names: Sofia
+  - given-names: Sofía
     family-names: Miñano
-  - given-names: Dhruv
-    family-names: Sharma
   - given-names: Brandon D.
     family-names: Peri
+  - given-names: Dhruv
+    family-names: Sharma
   - given-names: Laura
     family-names: Porta
   - given-names: Iván

--- a/CITATION.CFF
+++ b/CITATION.CFF
@@ -1,11 +1,13 @@
 cff-version: 1.2.0
 title: movement
 message: >-
-  If you use movement in your work, please cite the following Zenodo DOI
+  If you use movement in your work, please cite the following Zenodo DOI.
 type: software
 authors:
   - given-names: Nikoloz
     family-names: Sirmpilatze
+    orcid: 'https://orcid.org/0000-0003-1778-2427'
+    email: niko.sirbiladze@gmail.com
   - given-names: Chang Huan
     family-names: Lo
   - given-names: Sofia
@@ -21,12 +23,21 @@ authors:
   - given-names: Adam L.
     family-names: Tyson
     email: code@adamltyson.com
-repository-code: >-
-  https://github.com/neuroinformatics-unit/movement
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.12755724
+    description: 'A collection of archived snapshots of movement on Zenodo.'
+repository-code: 'https://github.com/neuroinformatics-unit/movement'
 url: 'https://movement.neuroinformatics.dev/'
 abstract: >-
-   Python tools for analysing body movements across space and time.
+  Python tools for analysing body movements across space and time.
+keywords:
+  - behavior
+  - behaviour
+  - kinematics
+  - neuroscience
+  - animal
+  - motion
+  - tracking
+  - pose
 license: BSD-3-Clause
-date-released: '2024-007-17'
-doi: 10.5281/zenodo.12755724
-year: 2024

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include *.md
+include CITATION.CFF
 exclude .pre-commit-config.yaml
 exclude .cruft.json
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Code style: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/format.json)](https://github.com/astral-sh/ruff)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![project chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://neuroinformatics.zulipchat.com/#narrow/stream/406001-Movement/topic/Welcome!)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.12755724.svg)](https://zenodo.org/doi/10.5281/zenodo.12755724)
 
 # movement
 
@@ -48,6 +49,12 @@ Contributions to movement are absolutely encouraged, whether to fix a bug, devel
 To help you get started, we have prepared a detailed [contributing guide](https://movement.neuroinformatics.dev/community/contributing.html).
 
 You are welcome to chat with the team on [zulip](https://neuroinformatics.zulipchat.com/#narrow/stream/406001-Movement). You can also [open an issue](https://github.com/neuroinformatics-unit/movement/issues) to report a bug or request a new feature.
+
+## Citation
+
+If you use `movement` in your work, please cite the following Zenodo DOI:
+
+>Niko Sirmpilatze, Chang Huan Lo, Sofia Miñano, Dhruv Sharma, Brandon D. Peri, Laura Porta, Iván Varela & Adam L. Tyson (2024). neuroinformatics-unit/movement: (2024). Zenodo. https://zenodo.org/doi/10.5281/zenodo.12755724
 
 ## License
 ⚖️ [BSD 3-Clause](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You are welcome to chat with the team on [zulip](https://neuroinformatics.zulipc
 
 If you use `movement` in your work, please cite the following Zenodo DOI:
 
-> Nikoloz Sirmpilatze, Chang Huan Lo, Sofia Miñano, Dhruv Sharma, Brandon D. Peri, Laura Porta, Iván Varela & Adam L. Tyson (2024). neuroinformatics-unit/movement. Zenodo. https://zenodo.org/doi/10.5281/zenodo.12755724
+> Nikoloz Sirmpilatze, Chang Huan Lo, Sofía Miñano, Brandon D. Peri, Dhruv Sharma, Laura Porta, Iván Varela & Adam L. Tyson (2024). neuroinformatics-unit/movement. Zenodo. https://zenodo.org/doi/10.5281/zenodo.12755724
 
 ## License
 ⚖️ [BSD 3-Clause](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You are welcome to chat with the team on [zulip](https://neuroinformatics.zulipc
 
 If you use `movement` in your work, please cite the following Zenodo DOI:
 
->Nikoloz Sirmpilatze, Chang Huan Lo, Sofia Miñano, Dhruv Sharma, Brandon D. Peri, Laura Porta, Iván Varela & Adam L. Tyson (2024). neuroinformatics-unit/movement: (2024). Zenodo. https://zenodo.org/doi/10.5281/zenodo.12755724
+> Nikoloz Sirmpilatze, Chang Huan Lo, Sofia Miñano, Dhruv Sharma, Brandon D. Peri, Laura Porta, Iván Varela & Adam L. Tyson (2024). neuroinformatics-unit/movement. Zenodo. https://zenodo.org/doi/10.5281/zenodo.12755724
 
 ## License
 ⚖️ [BSD 3-Clause](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You are welcome to chat with the team on [zulip](https://neuroinformatics.zulipc
 
 If you use `movement` in your work, please cite the following Zenodo DOI:
 
->Niko Sirmpilatze, Chang Huan Lo, Sofia Miñano, Dhruv Sharma, Brandon D. Peri, Laura Porta, Iván Varela & Adam L. Tyson (2024). neuroinformatics-unit/movement: (2024). Zenodo. https://zenodo.org/doi/10.5281/zenodo.12755724
+>Nikoloz Sirmpilatze, Chang Huan Lo, Sofia Miñano, Dhruv Sharma, Brandon D. Peri, Laura Porta, Iván Varela & Adam L. Tyson (2024). neuroinformatics-unit/movement: (2024). Zenodo. https://zenodo.org/doi/10.5281/zenodo.12755724
 
 ## License
 ⚖️ [BSD 3-Clause](./LICENSE)

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -42,6 +42,13 @@ Find out more on our [mission and scope](target-mission) statement and our [road
 ```{include} /snippets/status-warning.md
 ```
 
+## Citation
+
+If you use `movement` in your work, please cite the following Zenodo DOI:
+
+>Nikoloz Sirmpilatze, Chang Huan Lo, Sofia Miñano, Dhruv Sharma, Brandon D. Peri, Laura Porta, Iván Varela & Adam L. Tyson (2024). neuroinformatics-unit/movement: (2024). Zenodo. https://zenodo.org/doi/10.5281/zenodo.12755724
+
+
 ```{toctree}
 :maxdepth: 2
 :hidden:

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -46,7 +46,7 @@ Find out more on our [mission and scope](target-mission) statement and our [road
 
 If you use `movement` in your work, please cite the following Zenodo DOI:
 
->Nikoloz Sirmpilatze, Chang Huan Lo, Sofia Miñano, Dhruv Sharma, Brandon D. Peri, Laura Porta, Iván Varela & Adam L. Tyson (2024). neuroinformatics-unit/movement: (2024). Zenodo. https://zenodo.org/doi/10.5281/zenodo.12755724
+> Nikoloz Sirmpilatze, Chang Huan Lo, Sofia Miñano, Dhruv Sharma, Brandon D. Peri, Laura Porta, Iván Varela & Adam L. Tyson (2024). neuroinformatics-unit/movement. Zenodo. https://zenodo.org/doi/10.5281/zenodo.12755724
 
 
 ```{toctree}

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -43,11 +43,10 @@ Find out more on our [mission and scope](target-mission) statement and our [road
 ```
 
 ## Citation
-
-If you use `movement` in your work, please cite the following Zenodo DOI:
-
-> Nikoloz Sirmpilatze, Chang Huan Lo, Sofia Miñano, Dhruv Sharma, Brandon D. Peri, Laura Porta, Iván Varela & Adam L. Tyson (2024). neuroinformatics-unit/movement. Zenodo. https://zenodo.org/doi/10.5281/zenodo.12755724
-
+```{include} ../../README.md
+:start-after: '## Citation'
+:end-before: '## License'
+```
 
 ```{toctree}
 :maxdepth: 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "movement"
 authors = [
   { name = "Niko Sirmpilatze", email = "niko.sirbiladze@gmail.com" },
   { name = "Chang Huan Lo", email = "changhuan.lo@ucl.ac.uk" },
+  { name = "Sofía Miñano", email = "s.minano@ucl.ac.uk" },
 ]
 description = "Analysis of body movement"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "movement"
 authors = [
-  { name = "Niko Sirmpilatze", email = "niko.sirbiladze@gmail.com" },
+  { name = "Nikoloz Sirmpilatze", email = "niko.sirbiladze@gmail.com" },
   { name = "Chang Huan Lo", email = "changhuan.lo@ucl.ac.uk" },
   { name = "Sofía Miñano", email = "s.minano@ucl.ac.uk" },
 ]


### PR DESCRIPTION
This PR:
- Adds a citation CFF file
- Adds a citation section to the readme
- Adds a DOI badge
- Adds citation sentence to website

I've tried to make this as simple as maintain as possible. The DOI is the "general" one that represents all versions, and will resolve to the latest one. I've also kept version numbers out of it.

In terms of authors, I just used everyone who had contributed to the software, in the order suggested by Zenodo. The final publication may be different to this, but it seemed a good place to start. I suggest we don't try to hyper-optimise this, and just include everyone. The only maintenance needed will be to add new authors to this list as and when needed. Unfortunately this is in three places, but not sure if that's an issue?

I plonked the citation info on the index page of the website. It could go under "community", but I think we want it to be a bit more obvious than that?

Closes https://github.com/neuroinformatics-unit/movement/issues/232