### PR TITLE
Add utilities for vector magnitude and normalisation

### DIFF
--- a/examples/compute_kinematics.py
+++ b/examples/compute_kinematics.py
@@ -16,7 +16,7 @@ visualise the results.
 from matplotlib import pyplot as plt
 
 from movement import sample_data
-from movement.utils.vector import magnitude
+from movement.utils.vector import compute_norm
 
 # %%
 # Load sample dataset
@@ -254,7 +254,7 @@ fig.colorbar(sc, ax=ax, label="time (s)")
 # mouse along its trajectory.
 
 # length of each displacement vector
-displacement_vectors_lengths = magnitude(
+displacement_vectors_lengths = compute_norm(
     displacement.sel(individuals=mouse_name)
 )
 
@@ -302,7 +302,7 @@ plt.gcf().show()
 fig, axes = plt.subplots(3, 1, sharex=True, sharey=True)
 for mouse_name, ax in zip(velocity.individuals.values, axes, strict=False):
     # compute the magnitude of the velocity vector for one mouse
-    speed_one_mouse = magnitude(velocity.sel(individuals=mouse_name))
+    speed_one_mouse = compute_norm(velocity.sel(individuals=mouse_name))
     # plot speed against time
     ax.plot(speed_one_mouse)
     ax.set_title(mouse_name)
@@ -380,7 +380,7 @@ fig.tight_layout()
 fig, axes = plt.subplots(3, 1, sharex=True, sharey=True)
 for mouse_name, ax in zip(accel.individuals.values, axes, strict=False):
     # compute magnitude of the acceleration vector for one mouse
-    accel_one_mouse = magnitude(accel.sel(individuals=mouse_name))
+    accel_one_mouse = compute_norm(accel.sel(individuals=mouse_name))
 
     # plot acceleration against time
     ax.plot(accel_one_mouse)

--- a/examples/compute_kinematics.py
+++ b/examples/compute_kinematics.py
@@ -10,14 +10,13 @@ visualise the results.
 # Imports
 # -------
 
-import numpy as np
-
 # For interactive plots: install ipympl with `pip install ipympl` and uncomment
 # the following line in your notebook
 # %matplotlib widget
 from matplotlib import pyplot as plt
 
 from movement import sample_data
+from movement.utils.vector import magnitude
 
 # %%
 # Load sample dataset
@@ -255,13 +254,12 @@ fig.colorbar(sc, ax=ax, label="time (s)")
 # mouse along its trajectory.
 
 # length of each displacement vector
-displacement_vectors_lengths = np.linalg.norm(
-    displacement.sel(individuals=mouse_name, space=["x", "y"]).squeeze(),
-    axis=1,
+displacement_vectors_lengths = magnitude(
+    displacement.sel(individuals=mouse_name)
 )
 
-# sum of all displacement vectors
-total_displacement = np.sum(displacement_vectors_lengths, axis=0)  # in pixels
+# sum of all displacement vectors lengths (in pixels)
+total_displacement = displacement_vectors_lengths.sum(dim="time").values[0]
 
 print(
     f"The mouse {mouse_name}'s trajectory is {total_displacement:.2f} "
@@ -299,14 +297,12 @@ plt.gcf().show()
 # uses second order central differences.
 
 # %%
-# We can also visualise the speed, as the norm of the velocity vector:
+# We can also visualise the speed, as the magnitude (norm)
+# of the velocity vector:
 fig, axes = plt.subplots(3, 1, sharex=True, sharey=True)
 for mouse_name, ax in zip(velocity.individuals.values, axes, strict=False):
-    # compute the norm of the velocity vector for one mouse
-    speed_one_mouse = np.linalg.norm(
-        velocity.sel(individuals=mouse_name, space=["x", "y"]).squeeze(),
-        axis=1,
-    )
+    # compute the magnitude of the velocity vector for one mouse
+    speed_one_mouse = magnitude(velocity.sel(individuals=mouse_name))
     # plot speed against time
     ax.plot(speed_one_mouse)
     ax.set_title(mouse_name)
@@ -379,16 +375,12 @@ for mouse_name, ax in zip(accel.individuals.values, axes, strict=False):
 fig.tight_layout()
 
 # %%
-# The norm of the acceleration vector is the magnitude of the
-# acceleration.
-# We can also represent this for each individual.
+# The can also represent the magnitude (norm) of the acceleration vector
+# for each individual:
 fig, axes = plt.subplots(3, 1, sharex=True, sharey=True)
 for mouse_name, ax in zip(accel.individuals.values, axes, strict=False):
-    # compute norm of the acceleration vector for one mouse
-    accel_one_mouse = np.linalg.norm(
-        accel.sel(individuals=mouse_name, space=["x", "y"]).squeeze(),
-        axis=1,
-    )
+    # compute magnitude of the acceleration vector for one mouse
+    accel_one_mouse = magnitude(accel.sel(individuals=mouse_name))
 
     # plot acceleration against time
     ax.plot(accel_one_mouse)

--- a/examples/compute_kinematics.py
+++ b/examples/compute_kinematics.py
@@ -258,7 +258,7 @@ displacement_vectors_lengths = compute_norm(
     displacement.sel(individuals=mouse_name)
 )
 
-# sum of all displacement vectors lengths (in pixels)
+# sum the lengths of all displacement vectors (in pixels)
 total_displacement = displacement_vectors_lengths.sum(dim="time").values[0]
 
 print(

--- a/movement/utils/vector.py
+++ b/movement/utils/vector.py
@@ -57,7 +57,7 @@ def compute_norm(data: xr.DataArray) -> xr.DataArray:
         )
 
 
-def normalize(data: xr.DataArray) -> xr.DataArray:
+def convert_to_unit(data: xr.DataArray) -> xr.DataArray:
     """Convert the vectors along the spatial dimension into unit vectors.
 
     A unit vector is a vector pointing in the same direction as the original

--- a/movement/utils/vector.py
+++ b/movement/utils/vector.py
@@ -82,6 +82,47 @@ def pol2cart(data: xr.DataArray) -> xr.DataArray:
     ).transpose(*dims)
 
 
+def magnitude(data: xr.DataArray) -> xr.DataArray:
+    """Compute the magnitude in space.
+
+    The magnitude is computed as the Euclidean norm of a vector
+    with spatial components ``x`` and ``y`` in Cartesian coordinates.
+    If the input data contains polar coordinates, the magnitude
+    is the same as the radial distance ``rho``.
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        The input data containing either ``space`` or ``space_pol``
+        as a dimension.
+
+    Returns
+    -------
+    xarray.DataArray
+        An xarray DataArray representing the magnitude of the vector
+        in space. The output has no spatial dimension.
+
+
+    """
+    if "space" in data.dims:
+        _validate_dimension_coordinates(data, {"space": ["x", "y"]})
+        return xr.apply_ufunc(
+            np.linalg.norm,
+            data,
+            input_core_dims=[["space"]],
+            kwargs={"axis": -1},
+        )
+    elif "space_pol" in data.dims:
+        _validate_dimension_coordinates(data, {"space_pol": ["rho", "phi"]})
+        return data.sel(space_pol="rho", drop=True)
+    else:
+        raise log_error(
+            ValueError,
+            "Input data must contain either 'space' or 'space_pol' "
+            "as dimensions.",
+        )
+
+
 def _validate_dimension_coordinates(
     data: xr.DataArray, required_dim_coords: dict
 ) -> None:

--- a/movement/utils/vector.py
+++ b/movement/utils/vector.py
@@ -25,12 +25,7 @@ def cart2pol(data: xr.DataArray) -> xr.DataArray:
 
     """
     _validate_dimension_coordinates(data, {"space": ["x", "y"]})
-    rho = xr.apply_ufunc(
-        np.linalg.norm,
-        data,
-        input_core_dims=[["space"]],
-        kwargs={"axis": -1},
-    )
+    rho = magnitude(data)
     phi = xr.apply_ufunc(
         np.arctan2,
         data.sel(space="y"),

--- a/movement/utils/vector.py
+++ b/movement/utils/vector.py
@@ -123,6 +123,31 @@ def magnitude(data: xr.DataArray) -> xr.DataArray:
         )
 
 
+def normalize(data: xr.DataArray) -> xr.DataArray:
+    """Normalize data by the magnitude in space.
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        The input data containing ``space`` as a dimension,
+        with ``x`` and ``y`` in the dimension coordinate.
+
+    Returns
+    -------
+    xarray.DataArray
+        An xarray DataArray representing the normalized data,
+        having the same dimensions as the input data.
+
+    Notes
+    -----
+    Where the input values are 0 for both ``x`` and ``y``, the normalized
+    values will be NaN, because of zero-division.
+
+    """
+    _validate_dimension_coordinates(data, {"space": ["x", "y"]})
+    return data / magnitude(data)
+
+
 def _validate_dimension_coordinates(
     data: xr.DataArray, required_dim_coords: dict
 ) -> None:

--- a/movement/utils/vector.py
+++ b/movement/utils/vector.py
@@ -50,11 +50,7 @@ def compute_norm(data: xr.DataArray) -> xr.DataArray:
         _validate_dimension_coordinates(data, {"space_pol": ["rho", "phi"]})
         return data.sel(space_pol="rho", drop=True)
     else:
-        raise log_error(
-            ValueError,
-            "Input data must contain either 'space' or 'space_pol' "
-            "as dimensions.",
-        )
+        _raise_error_for_missing_spatial_dim()
 
 
 def convert_to_unit(data: xr.DataArray) -> xr.DataArray:
@@ -93,11 +89,8 @@ def convert_to_unit(data: xr.DataArray) -> xr.DataArray:
             new_data.sel(space_pol="rho").isnull(), np.nan, 1
         )
         return new_data
-    raise log_error(
-        ValueError,
-        "Input data must contain either 'space' or 'space_pol' "
-        "as dimensions.",
-    )
+    else:
+        _raise_error_for_missing_spatial_dim()
 
 
 def cart2pol(data: xr.DataArray) -> xr.DataArray:
@@ -211,3 +204,11 @@ def _validate_dimension_coordinates(
             )
     if error_message:
         raise log_error(ValueError, error_message)
+
+
+def _raise_error_for_missing_spatial_dim() -> None:
+    raise log_error(
+        ValueError,
+        "Input data array must contain either 'space' or 'space_pol' "
+        "as dimensions.",
+    )

--- a/movement/utils/vector.py
+++ b/movement/utils/vector.py
@@ -6,25 +6,35 @@ import xarray as xr
 from movement.utils.logging import log_error
 
 
-def magnitude(data: xr.DataArray) -> xr.DataArray:
-    """Compute the magnitude in space.
+def compute_norm(data: xr.DataArray) -> xr.DataArray:
+    """Compute the norm of the vectors along the spatial dimension.
 
-    The magnitude is computed as the Euclidean norm of a vector
-    with spatial components ``x`` and ``y`` in Cartesian coordinates.
-    If the input data contains polar coordinates, the magnitude
-    is the same as the radial distance ``rho``.
+    The norm of a vector is its magnitude, also called Euclidean norm, 2-norm
+    or Euclidean length. Note that if the input data is expressed in polar
+    coordinates, the magnitude of a vector is the same as its radial coordinate
+    ``rho``.
 
     Parameters
     ----------
     data : xarray.DataArray
-        The input data containing either ``space`` or ``space_pol``
+        The input data array containing either ``space`` or ``space_pol``
         as a dimension.
 
     Returns
     -------
     xarray.DataArray
-        An xarray DataArray representing the magnitude of the vector
-        in space. The output has no spatial dimension.
+         A data array holding the norm of the input vectors.
+         Note that this output array has no spatial dimension but preserves
+         all other dimensions of the input data array (see Notes).
+
+    Notes
+    -----
+    If the input data array is a ``position`` array, this function will compute
+    the magnitude of the position vectors, for every individual and keypoint,
+    at every timestep. If the input data array is a ``shape`` array of a
+    bounding boxes dataset, it will compute the magnitude of the shape
+    vectors (i.e., the diagonal of the bounding box),
+    for every individual and at every timestep.
 
 
     """
@@ -69,7 +79,7 @@ def normalize(data: xr.DataArray) -> xr.DataArray:
 
     """
     _validate_dimension_coordinates(data, {"space": ["x", "y"]})
-    return data / magnitude(data)
+    return data / compute_norm(data)
 
 
 def cart2pol(data: xr.DataArray) -> xr.DataArray:
@@ -91,7 +101,7 @@ def cart2pol(data: xr.DataArray) -> xr.DataArray:
 
     """
     _validate_dimension_coordinates(data, {"space": ["x", "y"]})
-    rho = magnitude(data)
+    rho = compute_norm(data)
     phi = xr.apply_ufunc(
         np.arctan2,
         data.sel(space="y"),

--- a/tests/test_unit/test_vector.py
+++ b/tests/test_unit/test_vector.py
@@ -134,17 +134,17 @@ class TestVector:
             ),
         ],
     )
-    def test_magnitude(self, ds, expected_exception, request):
-        """Test vector magnitude with known values."""
+    def test_compute_norm(self, ds, expected_exception, request):
+        """Test vector norm computation with known values."""
         ds = request.getfixturevalue(ds)
         with expected_exception:
-            result = vector.magnitude(ds.cart)
+            result = vector.compute_norm(ds.cart)
             expected = np.sqrt(
                 ds.cart.sel(space="x") ** 2 + ds.cart.sel(space="y") ** 2
             )
             xr.testing.assert_allclose(result, expected)
             # result should be the same from Cartesian and polar coordinates
-            xr.testing.assert_allclose(result, vector.magnitude(ds.pol))
+            xr.testing.assert_allclose(result, vector.compute_norm(ds.pol))
             # The result should only contain the time dimension.
             assert result.dims == ("time",)
 
@@ -168,7 +168,7 @@ class TestVector:
             assert normalized.sel(time=0).isnull().all()
             # the magnitude of the normalized vector should be 1 for all
             # time points except for the expected NaNs.
-            normalized_mag = vector.magnitude(normalized).values
+            normalized_mag = vector.compute_norm(normalized).values
             expected_mag = np.ones_like(normalized_mag)
             expected_mag[normalized.isnull().any("space")] = np.nan
             np.testing.assert_allclose(normalized_mag, expected_mag)

--- a/tests/test_unit/test_vector.py
+++ b/tests/test_unit/test_vector.py
@@ -121,3 +121,29 @@ class TestVector:
         with expected_exception:
             result = vector.pol2cart(ds.pol)
             xr.testing.assert_allclose(result, ds.cart)
+
+    @pytest.mark.parametrize(
+        "ds, expected_exception",
+        [
+            ("cart_pol_dataset", does_not_raise()),
+            ("cart_pol_dataset_with_nan", does_not_raise()),
+            ("cart_pol_dataset_missing_cart_dim", pytest.raises(ValueError)),
+            (
+                "cart_pol_dataset_missing_cart_coords",
+                pytest.raises(ValueError),
+            ),
+        ],
+    )
+    def test_magnitude(self, ds, expected_exception, request):
+        """Test vector magnitude with known values."""
+        ds = request.getfixturevalue(ds)
+        with expected_exception:
+            result = vector.magnitude(ds.cart)
+            expected = np.sqrt(
+                ds.cart.sel(space="x") ** 2 + ds.cart.sel(space="y") ** 2
+            )
+            xr.testing.assert_allclose(result, expected)
+            # result should be the same from Cartesian and polar coordinates
+            xr.testing.assert_allclose(result, vector.magnitude(ds.pol))
+            # The result should only contain the time dimension.
+            assert result.dims == ("time",)

--- a/tests/test_unit/test_vector.py
+++ b/tests/test_unit/test_vector.py
@@ -172,3 +172,15 @@ class TestVector:
             expected_mag = np.ones_like(normalized_mag)
             expected_mag[normalized.isnull().any("space")] = np.nan
             np.testing.assert_allclose(normalized_mag, expected_mag)
+            # Normalising the polar data should yield the same result
+            # as converting the normalised Cartesian data to polar.
+            xr.testing.assert_allclose(
+                vector.normalize(ds.pol),
+                vector.cart2pol(vector.normalize(ds.cart)),
+            )
+            # Normalising the Cartesian data should yield the same result
+            # as converting the normalised polar data to Cartesian.
+            xr.testing.assert_allclose(
+                vector.normalize(ds.cart),
+                vector.pol2cart(vector.normalize(ds.pol)),
+            )


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
We often need to compute the magnitude (norm, length) of a vector, and would be nice to have a convenient xarray-native way of doing so. Currently we can only do that by either:
- use `cart2pol` to convert to poral coordinates, and take the `rho` value
- convert to numpy array and use `np.linalg.norm`

**What does this PR do?**
Adds two new functions in  the`utils/vector.py` module.
1. `magnitude`: this does the obvious thing. If an array in cartesian space is passed, we return the euclidean norm. If a user passes an array in polar coordinates, we just return the `rho`.
2. `normalize`: added for convenience. This function only works for arrays in cartesian coordinates, and returns the same array divided by its magnitude. For (0,0) values (exactly at the origin), the output is NaN (because of zero-division). If the input array is passed with polar coordinates, I raise an error. In principle, I could just make all `rho` values equal to 	1, but I don't see much value in that (feel free to push back if you have a better idea on what to do in this case).

## References

Closes #190.
Facilitates #147 , #239 , #228, #238 and others.

## How has this PR been tested?

Unit tests have been added for both functions.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

I updated a few places in the examples where `np.linalg.norm` was used. Now they use `magnitude`.
The API index should automatically pick up the new functions.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)

## PS
@sfmig I'm aware this was on your to-do list, but I had to do this anyway now, because we could benefit from this feature in https://github.com/neuroinformatics-unit/In2Research-2024.

## EDIT: 2024-08-14
Following @sfmig's review, the following changes were made:
- we renamed `magnitude()` to `compute_norm()` and updated the docstring accordingly
- we renamed `normalize()` to `convert_to_unit()` and updated the docstring accordingly
- we made `convert_to_unit()` also work in polar coordianates, where it makes all `rho` values 1 and preserves `phi` angles.
