### PR TITLE
Getting started docs update for bboxes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -314,7 +314,7 @@ The relevant functionality is implemented in the `movement.sample_data.py` modul
 The most important parts of this module are:
 
 1. The `SAMPLE_DATA` download manager object.
-2. The `list_datasets()` function, which returns a list of the available pose datasets (file names of the pose data files).
+2. The `list_datasets()` function, which returns a list of the available poses datasets (file names of the pose data files).
 3. The `fetch_dataset_paths()` function, which returns a dictionary containing local paths to the files associated with a particular sample dataset: `poses`, `frame`, `video`. If the relevant files are not already cached locally, they will be downloaded.
 4. The `fetch_dataset()` function, which downloads the files associated with a given sample dataset (same as `fetch_dataset_paths()`) and additionally loads the pose data into `movement`, returning an `xarray.Dataset` object. The local paths to the associated video and frame files are stored as dataset attributes, with names `video_path` and `frame_path`, respectively.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -296,12 +296,12 @@ GIN has a GitHub-like interface and git-like
 [CLI](gin:G-Node/Info/wiki/GIN+CLI+Setup#quickstart) functionalities.
 
 Currently, the data repository contains sample pose estimation data files
-stored in the `poses` folder. For some of these files, we also host
+stored in the `poses` folder, and tracked bounding boxes data files under the `bboxes` folder. For some of these files, we also host
 the associated video file (in the `videos` folder) and/or a single
 video frame (in the `frames`) folder. These can be used to develop and
-test visualisations, e.g. overlaying pose data on video frames.
+test visualisations, e.g. to overlay the data on video frames.
 The `metadata.yaml` file holds metadata for each sample dataset,
-including information on data provenance as well as the mapping between pose data files and related
+including information on data provenance as well as the mapping between data files and related
 video/frame files.
 
 ### Fetching data
@@ -314,9 +314,9 @@ The relevant functionality is implemented in the `movement.sample_data.py` modul
 The most important parts of this module are:
 
 1. The `SAMPLE_DATA` download manager object.
-2. The `list_datasets()` function, which returns a list of the available poses datasets (file names of the pose data files).
-3. The `fetch_dataset_paths()` function, which returns a dictionary containing local paths to the files associated with a particular sample dataset: `poses`, `frame`, `video`. If the relevant files are not already cached locally, they will be downloaded.
-4. The `fetch_dataset()` function, which downloads the files associated with a given sample dataset (same as `fetch_dataset_paths()`) and additionally loads the pose data into `movement`, returning an `xarray.Dataset` object. The local paths to the associated video and frame files are stored as dataset attributes, with names `video_path` and `frame_path`, respectively.
+2. The `list_datasets()` function, which returns a list of the available poses and bounding boxes datasets (file names of the data files).
+3. The `fetch_dataset_paths()` function, which returns a dictionary containing local paths to the files associated with a particular sample dataset: `poses` or `bboxes`, `frame`, `video`. If the relevant files are not already cached locally, they will be downloaded.
+4. The `fetch_dataset()` function, which downloads the files associated with a given sample dataset (same as `fetch_dataset_paths()`) and additionally loads the pose or bounding box data into `movement`, returning an `xarray.Dataset` object. If available, the local paths to the associated video and frame files are stored as dataset attributes, with names `video_path` and `frame_path`, respectively.
 
 By default, the downloaded files are stored in the `~/.movement/data` folder.
 This can be changed by setting the `DATA_DIR` variable in the `movement.sample_data.py` module.
@@ -329,7 +329,7 @@ To add a new file, you will need to:
 2. Ask to be added as a collaborator on the [movement data repository](gin:neuroinformatics/movement-test-data) (if not already)
 3. Download the [GIN CLI](gin:G-Node/Info/wiki/GIN+CLI+Setup#quickstart) and set it up with your GIN credentials, by running `gin login` in a terminal.
 4. Clone the movement data repository to your local machine, by running `gin get neuroinformatics/movement-test-data` in a terminal.
-5. Add your new files to the `poses`, `videos`, `frames`, and/or `bboxes` folders as appropriate. Follow the existing file naming conventions as closely as possible.
+5. Add your new files to the `poses`, `bboxes`, `videos` and/or `frames` folders as appropriate. Follow the existing file naming conventions as closely as possible.
 6. Determine the sha256 checksum hash of each new file. You can do this in a terminal by running:
     ::::{tab-set}
 
@@ -351,7 +351,7 @@ To add a new file, you will need to:
     ```
     :::
     ::::
-    For convenience, we've included a `get_sha256_hashes.py` script in the [movement data repository](gin:neuroinformatics/movement-test-data). If you run this from the root of the data repository, within a Python environment with `movement` installed, it will calculate the sha256 hashes for all files in the `poses`, `videos`, `frames`, and `bboxes` folders and write them to files named `poses_hashes.txt`, `videos_hashes.txt`, `frames_hashes.txt`, and `bboxes_hashes.txt`, respectively.
+    For convenience, we've included a `get_sha256_hashes.py` script in the [movement data repository](gin:neuroinformatics/movement-test-data). If you run this from the root of the data repository, within a Python environment with `movement` installed, it will calculate the sha256 hashes for all files in the `poses`, `bboxes`, `videos` and `frames` folders and write them to files named `poses_hashes.txt`, `bboxes_hashes.txt`, `videos_hashes.txt`, and `frames_hashes.txt` respectively.
 
 7. Add metadata for your new files to `metadata.yaml`, including their sha256 hashes you've calculated. See the example entry below for guidance.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -194,4 +194,5 @@ myst_url_schemes = {
     "sphinx-gallery": "https://sphinx-gallery.github.io/stable/{{path}}",
     "xarray": "https://docs.xarray.dev/en/stable/{{path}}#{{fragment}}",
     "lp": "https://lightning-pose.readthedocs.io/en/stable/{{path}}#{{fragment}}",
+    "via": "https://www.robots.ox.ac.uk/~vgg/software/via/{{path}}#{{fragment}}",
 }

--- a/docs/source/getting_started/index.md
+++ b/docs/source/getting_started/index.md
@@ -2,7 +2,7 @@
 
 Start by [installing the package](installation.md).
 
-After that try [loading some of your own predicted poses](target-loading),
+After that, try [loading some of your own tracked poses](target-loading-pose-tracks) or [bounding boxes' trajectories](target-loading-bbox-tracks),
 from one of the [supported formats](target-formats).
 Alternatively, you can use the [sample data](target-sample-data)
 provided with the package.

--- a/docs/source/getting_started/input_output.md
+++ b/docs/source/getting_started/input_output.md
@@ -6,8 +6,7 @@
 (target-supported-formats)=
 `movement` supports the analysis of trajectories of keypoints (_pose tracks_) and of bounding boxes' centroids (_bounding boxes' tracks_).
 
-To analyse pose tracks, `movement` supports loading data from various pose estimation frameworks.
-Currently, these include:
+To analyse pose tracks, `movement` supports loading data from various frameworks:
 - [DeepLabCut](dlc:) (DLC)
 - [SLEAP](sleap:) (SLEAP)
 - [LightingPose](lp:) (LP)
@@ -15,20 +14,24 @@ Currently, these include:
 To analyse bounding boxes' tracks, `movement` currently supports the [VGG Image Annotator](via:) (VIA) format for [tracks annotation](via:docs/face_track_annotation.html#:~:text=A%20snippet%20of%20this%20csv%20file%20is%20shown%20below)
 
 :::{note}
-At the moment `movement` only deals with tracked data: either keypoints or bounding boxes whose identities are known from one frame to the next, for a consecutive set of frames. For the pose estimation case, this means it only deals with the predictions output by the software packages mentioned above. It currently does not support loading manually labelled data, since this is most often defined over a non-continuous set of frames.
+At the moment `movement` only deals with tracked data: either keypoints or bounding boxes whose identities are known from one frame to the next, for a consecutive set of frames. For the pose estimation case, this means it only deals with the predictions output by the software packages above. It currently does not support loading manually labelled data (since this is most often defined over a non-continuous set of frames).
 :::
+
+Below we explain how you can load pose tracks and bounding boxes' tracks into `movement`, and how you can export a `movement` poses dataset to different file formats. You can also try `movement` out on some [sample data](target-sample-data)
+included with the package.
+
 
 (target-loading-pose-tracks)=
 ## Loading pose tracks
 
-The pose track loading functionalities are provided by the
+The pose tracks loading functionalities are provided by the
 {mod}`movement.io.load_poses` module, which can be imported as follows:
 
 ```python
 from movement.io import load_poses
 ```
 
-Depending on the source software, one of the following functions can be used.
+To read a pose tracks file into a [movement poses dataset](target-poses-and-bboxes-dataset), we provide specific functions for each of the supported formats.
 
 ::::{tab-set}
 
@@ -83,18 +86,50 @@ ds = load_poses.from_file(
 
 ::::
 
-The loaded data include the predicted trajectories for each individual and
+The resulting poses data structure `ds` will include the predicted trajectories for each individual and
 keypoint, as well as the associated point-wise confidence values reported by
 the pose estimation software.
 
-For more information on data structure, see the [movement dataset](target-dataset) page.
+For more information on the poses data structure, see the [movement poses dataset](target-poses-and-bboxes-dataset) page.
 
-You can also try `movement` out on some [sample data](target-sample-data)
-included with the package.
+
+(target-loading-bbox-tracks)=
+## Loading bounding boxes' tracks
+To load bounding boxes' tracks into a [movement bounding boxes dataset](target-poses-and-bboxes-dataset), we need the functions from the
+{mod}`movement.io.load_bboxes` module. This module can be imported as:
+
+```python
+from movement.io import load_bboxes
+```
+
+We currently support loading bounding boxes' tracks in the VGG Image Annotator (VIA) format only.
+
+::::{tab-set}
+:::{tab-item} VGG Image Annotator
+
+To load a VIA tracks .csv file:
+```python
+ds = load_bboxes.from_via_tracks_file("path/to/file.csv", fps=30)
+
+# or equivalently
+ds = load_bboxes.from_file(
+    "path/to/file.csv",
+    source_software="VIA-tracks",
+    fps=30,
+)
+```
+:::
+
+::::
+
+The resulting data structure `ds` will include the centroid trajectories for each tracked bounding box, the boxes' widths and heights, and their associated confidence values if provided.
+
+For more information on the bounding boxes data structure, see the [movement bounding boxes dataset](target-poses-and-bboxes-dataset) page.
+
 
 (target-saving-pose-tracks)=
 ## Saving pose tracks
-[movement datasets](target-dataset) can be saved in a variety of
+[movement poses datasets](target-poses-and-bboxes-dataset) can be saved in a variety of
 formats, including DeepLabCut-style files (.h5 or .csv) and
 [SLEAP-style analysis files](sleap:tutorials/analysis) (.h5).
 
@@ -157,3 +192,9 @@ save_poses.to_dlc_file(ds, "/path/to/file.csv", split_individuals=True)
 
 ::::
 :::::
+
+
+(target-saving-bboxes-tracks)=
+## Saving bounding boxes tracks
+
+We currently do not provide explicit methods to export a movement bounding boxes dataset in a specific format. However, you can easily save the bounding boxes' trajectories to a .csv file using the standard Python library `csv`.

--- a/docs/source/getting_started/input_output.md
+++ b/docs/source/getting_started/input_output.md
@@ -11,7 +11,7 @@ To analyse pose tracks, `movement` supports loading data from various frameworks
 - [SLEAP](sleap:) (SLEAP)
 - [LightingPose](lp:) (LP)
 
-To analyse bounding boxes' tracks, `movement` currently supports the [VGG Image Annotator](via:) (VIA) format for [tracks annotation](via:docs/face_track_annotation.html)
+To analyse bounding boxes' tracks, `movement` currently supports the [VGG Image Annotator](via:) (VIA) format for [tracks annotation](via:docs/face_track_annotation.html).
 
 :::{note}
 At the moment `movement` only deals with tracked data: either keypoints or bounding boxes whose identities are known from one frame to the next, for a consecutive set of frames. For the pose estimation case, this means it only deals with the predictions output by the software packages above. It currently does not support loading manually labelled data (since this is most often defined over a non-continuous set of frames).

--- a/docs/source/getting_started/input_output.md
+++ b/docs/source/getting_started/input_output.md
@@ -256,3 +256,4 @@ with open(filepath, mode="w", newline="") as file:
             writer.writerow([frame, individual, x, y, width, height, confidence])
 
 ```
+Alternatively, we can convert the `movement` bounding boxes' dataset to a pandas DataFrame with the {func}`.xarray.DataArray.to_dataframe()` method, wrangle the dataframe as required, and then apply the {func}`.pandas.DataFrame.to_csv()` method to save the data as a .csv file.

--- a/docs/source/getting_started/input_output.md
+++ b/docs/source/getting_started/input_output.md
@@ -4,35 +4,37 @@
 (target-formats)=
 ## Supported formats
 (target-supported-formats)=
-`movement` can load pose tracks from various pose estimation frameworks.
+`movement` supports the analysis of trajectories of keypoints (_pose tracks_) and of bounding boxes' centroids (_bounding boxes' tracks_).
+
+To analyse pose tracks, `movement` supports loading data from various pose estimation frameworks.
 Currently, these include:
 - [DeepLabCut](dlc:) (DLC)
 - [SLEAP](sleap:) (SLEAP)
 - [LightingPose](lp:) (LP)
 
-:::{warning}
-`movement` only deals with the predicted pose tracks output by these
-software packages. It does not support the training or labelling of the data.
+To analyse bounding boxes' tracks, `movement` currently supports the [VGG Image Annotator](via:) (VIA) format for [tracks annotation](via:docs/face_track_annotation.html#:~:text=A%20snippet%20of%20this%20csv%20file%20is%20shown%20below)
+
+:::{note}
+At the moment `movement` only deals with tracked data: either keypoints or bounding boxes whose identities are known from one frame to the next, for a consecutive set of frames. For the pose estimation case, this means it only deals with the predictions output by the software packages mentioned above. It currently does not support loading manually labelled data, since this is most often defined over a non-continuous set of frames.
 :::
 
-(target-loading)=
+(target-loading-pose-tracks)=
 ## Loading pose tracks
 
-The loading functionalities are provided by the
+The pose track loading functionalities are provided by the
 {mod}`movement.io.load_poses` module, which can be imported as follows:
 
 ```python
 from movement.io import load_poses
 ```
 
-Depending on the source sofrware, one of the following functions can be used.
+Depending on the source software, one of the following functions can be used.
 
 ::::{tab-set}
 
 :::{tab-item} SLEAP
 
-Load from [SLEAP analysis files](sleap:tutorials/analysis) (.h5, recommended),
-or from .slp files (experimental):
+To load [SLEAP analysis files](sleap:tutorials/analysis) in .h5 format (recommended):
 ```python
 ds = load_poses.from_sleap_file("/path/to/file.analysis.h5", fps=30)
 
@@ -41,9 +43,7 @@ ds = load_poses.from_file(
     "/path/to/file.analysis.h5", source_software="SLEAP", fps=30
 )
 ```
-
-You can also load from SLEAP .slp files in the same way, but there are caveats
-to that approach (see notes in {func}`movement.io.load_poses.from_sleap_file`).
+To load [SLEAP analysis files](sleap:tutorials/analysis) in .slp format (experimental, see notes in {func}`movement.io.load_poses.from_sleap_file`):
 
 ```python
 ds = load_poses.from_sleap_file("/path/to/file.predictions.slp", fps=30)
@@ -52,7 +52,7 @@ ds = load_poses.from_sleap_file("/path/to/file.predictions.slp", fps=30)
 
 :::{tab-item} DeepLabCut
 
-Load from DeepLabCut files (.h5):
+To load DeepLabCut files in .h5 format:
 ```python
 ds = load_poses.from_dlc_file("/path/to/file.h5", fps=30)
 
@@ -62,8 +62,7 @@ ds = load_poses.from_file(
 )
 ```
 
-You may also load .csv files
-(assuming they are formatted as DeepLabCut expects them):
+To load DeepLabCut files in .csv format:
 ```python
 ds = load_poses.from_dlc_file("/path/to/file.csv", fps=30)
 ```
@@ -71,7 +70,7 @@ ds = load_poses.from_dlc_file("/path/to/file.csv", fps=30)
 
 :::{tab-item} LightningPose
 
-Load from LightningPose files (.csv):
+To load LightningPose files in .csv format:
 ```python
 ds = load_poses.from_lp_file("/path/to/file.analysis.csv", fps=30)
 
@@ -84,21 +83,22 @@ ds = load_poses.from_file(
 
 ::::
 
-The loaded data include the predicted positions for each individual and
-keypoint as well as the associated point-wise confidence values, as reported by
-the pose estimation software. See the [movement dataset](target-dataset) page
-for more information on data structure.
+The loaded data include the predicted trajectories for each individual and
+keypoint, as well as the associated point-wise confidence values reported by
+the pose estimation software.
+
+For more information on data structure, see the [movement dataset](target-dataset) page.
 
 You can also try `movement` out on some [sample data](target-sample-data)
 included with the package.
 
-(target-saving)=
+(target-saving-pose-tracks)=
 ## Saving pose tracks
-[movement datasets](target-dataset) can be saved as a variety of
+[movement datasets](target-dataset) can be saved in a variety of
 formats, including DeepLabCut-style files (.h5 or .csv) and
 [SLEAP-style analysis files](sleap:tutorials/analysis) (.h5).
 
-First import the {mod}`movement.io.save_poses` module:
+To export pose tracks from `movement`, first import the {mod}`movement.io.save_poses` module:
 
 ```python
 from movement.io import save_poses
@@ -110,7 +110,7 @@ Then, depending on the desired format, use one of the following functions:
 
 ::::{tab-item} SLEAP
 
-Save to SLEAP-style analysis files (.h5):
+To save as a SLEAP analysis file in .h5 format:
 ```python
 save_poses.to_sleap_analysis_file(ds, "/path/to/file.h5")
 ```
@@ -129,7 +129,7 @@ each attribute and data variable represents, see the
 
 ::::{tab-item} DeepLabCut
 
-Save to DeepLabCut-style files (.h5 or .csv):
+To save as a DeepLabCut file, in .h5 or .csv format:
 ```python
 save_poses.to_dlc_file(ds, "/path/to/file.h5")  # preferred format
 save_poses.to_dlc_file(ds, "/path/to/file.csv")
@@ -143,13 +143,13 @@ save the data as separate single-animal DeepLabCut-style files.
 
 ::::{tab-item} LightningPose
 
-Save to LightningPose files (.csv).
+To save as a LightningPose file in .csv format:
 ```python
 save_poses.to_lp_file(ds, "/path/to/file.csv")
 ```
 :::{note}
-Because LightningPose saves pose estimation outputs in the same format as single-animal
-DeepLabCut projects, the above command is equivalent to:
+Because LightningPose follows the single-animal
+DeepLabCut .csv format, the above command is equivalent to:
 ```python
 save_poses.to_dlc_file(ds, "/path/to/file.csv", split_individuals=True)
 ```

--- a/docs/source/getting_started/input_output.md
+++ b/docs/source/getting_started/input_output.md
@@ -11,7 +11,7 @@ To analyse pose tracks, `movement` supports loading data from various frameworks
 - [SLEAP](sleap:) (SLEAP)
 - [LightingPose](lp:) (LP)
 
-To analyse bounding boxes' tracks, `movement` currently supports the [VGG Image Annotator](via:) (VIA) format for [tracks annotation](via:docs/face_track_annotation.html#:~:text=A%20snippet%20of%20this%20csv%20file%20is%20shown%20below)
+To analyse bounding boxes' tracks, `movement` currently supports the [VGG Image Annotator](via:) (VIA) format for [tracks annotation](via:docs/face_track_annotation.html)
 
 :::{note}
 At the moment `movement` only deals with tracked data: either keypoints or bounding boxes whose identities are known from one frame to the next, for a consecutive set of frames. For the pose estimation case, this means it only deals with the predictions output by the software packages above. It currently does not support loading manually labelled data (since this is most often defined over a non-continuous set of frames).
@@ -230,27 +230,29 @@ save_poses.to_dlc_file(ds, "/path/to/file.csv", split_individuals=True)
 
 
 (target-saving-bboxes-tracks)=
-## Saving bounding boxes tracks
+## Saving bounding boxes' tracks
 
 We currently do not provide explicit methods to export a movement bounding boxes dataset in a specific format. However, you can easily save the bounding boxes' trajectories to a .csv file using the standard Python library `csv`.
 
 Here is an example of how you can save a bounding boxes dataset to a .csv file:
 
 ```python
-import csv
+# define name for output csv file
+file = 'tracking_output.csv"
 
-# Open the file in write mode
-with open("path/to/file.csv", mode="w", newline="") as file:
+# open the csv file in write mode
+with open(filepath, mode="w", newline="") as file:
     writer = csv.writer(file)
 
-    # Write the header
-    writer.writerow(["frame", "individual", "x", "y", "width", "height", "confidence"])
+    # write the header
+    writer.writerow(["frame_idx", "bbox_ID", "x", "y", "width", "height", "confidence"])
 
-    # Write the data
-    for frame in ds.frames:
-        for individual in ds.individuals:
-            for i, (x, y) in enumerate(ds.positions[frame, individual]):
-                width, height = ds.shapes[frame, individual][i]
-                confidence = ds.confidence[frame, individual][i]
-                writer.writerow([frame, individual, x, y, width, height, confidence])
+    # write the data
+    for individual in ds.individuals.data:
+        for frame in ds.time.data:
+            x, y = ds.position.sel(time=frame, individuals=individual).data
+            width, height = ds.shape.sel(time=frame, individuals=individual).data
+            confidence = ds.confidence.sel(time=frame, individuals=individual).data
+            writer.writerow([frame, individual, x, y, width, height, confidence])
+
 ```

--- a/docs/source/getting_started/movement_dataset.md
+++ b/docs/source/getting_started/movement_dataset.md
@@ -1,19 +1,18 @@
-(target-dataset)=
-# The movement dataset
+(target-poses-and-bboxes-dataset)=
+# The movement datasets
 
-When you load predicted pose tracks into `movement`, they are represented
-as an {class}`xarray.Dataset` object, which is a container for multiple data
-arrays. Each array is in turn represented as an {class}`xarray.DataArray`
-object, which you can think of as a multi-dimensional {class}`numpy.ndarray`
+In `movement`, poses or bounding boxes' tracks are represented
+as an {class}`xarray.Dataset` object.
+
+An {class}`xarray.Dataset` object is a container for multiple arrays. Each array is an {class}`xarray.DataArray` object holding different aspects of the collected data (position, time, confidence scores...). You can think of a {class}`xarray.DataArray` object as a multi-dimensional {class}`numpy.ndarray`
 with pandas-style indexing and labelling.
 
-So, a `movement` dataset is simply an {class}`xarray.Dataset` with a specific
-structure to represent pose tracks, associated confidence scores and relevant
-metadata. Each dataset consists of **data variables**, **dimensions**,
-**coordinates** and **attributes**.
+So a `movement` dataset is simply an {class}`xarray.Dataset` with a specific
+structure to represent pose tracks or bounding boxes tracks. Because pose data and bounding boxes data are somewhat different, `movement` provides two types of datasets: `poses` datasets and `bboxes` datasets.
 
-In the next section, we will describe the
-structure of a `movement` dataset in some detail.
+To discuss the specifics of both types of `movement` datasets, it is useful to clarify some concepts such as **data variables**, **dimensions**,
+**coordinates** and **attributes**. In the next section, we will describe these concepts and the `movement` datasets' structure in some detail.
+
 To learn more about `xarray` data structures in general, see the relevant
 [documentation](xarray:user-guide/data-structures.html).
 
@@ -22,71 +21,148 @@ To learn more about `xarray` data structures in general, see the relevant
 
 ![](../_static/dataset_structure.png)
 
-You can always inspect the structure of a `movement` dataset `ds` by simply
-printing it:
+The structure of a `movement` dataset `ds` can be easily inspected by simply
+printing it. For example, for one of the sample poses dataset, we can run:
 ```python
-ds = load_poses.from_dlc_file("/path/to/file.h5", fps=30)
+from movement import sample_data
+
+ds = sample_data.fetch_dataset(
+    "SLEAP_three-mice_Aeon_proofread.analysis.h5",
+)
 print(ds)
 ```
-If you are working in a Jupyter notebook, you can also view an interactive
-representation of the dataset by typing its name - e.g. `ds` - in a cell.
+
+and we would obtain an output such as:
+```
+<xarray.Dataset> Size: 27kB
+Dimensions:      (time: 601, individuals: 3, keypoints: 1, space: 2)
+Coordinates:
+  * time         (time) float64 5kB 0.0 0.02 0.04 0.06 ... 11.96 11.98 12.0
+  * individuals  (individuals) <U10 120B 'AEON3B_NTP' 'AEON3B_TP1' 'AEON3B_TP2'
+  * keypoints    (keypoints) <U8 32B 'centroid'
+  * space        (space) <U1 8B 'x' 'y'
+Data variables:
+    position     (time, individuals, keypoints, space) float32 14kB 770.3 ......
+    confidence   (time, individuals, keypoints) float32 7kB nan nan ... nan nan
+Attributes:
+    fps:              50.0
+    time_unit:        seconds
+    source_software:  SLEAP
+    source_file:      /home/user/.movement/data/poses/SLEAP_three-mice_Aeon...
+    ds_type:          poses
+    frame_path:       /home/user/.movement/data/frames/three-mice_Aeon_fram...
+    video_path:       None
+```
+If you are working in a Jupyter notebook, you can view an interactive
+representation of the dataset by typing its variable name - e.g. `ds` - in a cell.
+
+Similarly, for a sample bounding boxes dataset we can have:
+```python
+from movement import sample_data
+
+ds = sample_data.fetch_dataset(
+    "VIA_multiple-crabs_5-frames_labels.csv",
+)
+print(ds)
+```
+
+and the last command would print out:
+```
+<xarray.Dataset> Size: 19kB
+Dimensions:      (time: 5, individuals: 86, space: 2)
+Coordinates:
+  * time         (time) int64 40B 0 1 2 3 4
+  * individuals  (individuals) <U5 2kB 'id_1' 'id_2' 'id_3' ... 'id_89' 'id_90'
+  * space        (space) <U1 8B 'x' 'y'
+Data variables:
+    position     (time, individuals, space) float64 7kB 871.8 ... 905.3
+    shape        (time, individuals, space) float64 7kB 60.0 53.0 ... 51.0 36.0
+    confidence   (time, individuals) float64 3kB nan nan nan nan ... nan nan nan
+Attributes:
+    fps:              None
+    time_unit:        frames
+    source_software:  VIA-tracks
+    source_file:      /home/user/.movement/data/bboxes/VIA_multiple-crabs_5...
+    ds_type:          bboxes
+    frame_path:       None
+    video_path:       None
+```
+
+In both cases, we can see that the description of the dataset structure refers to **dimensions**, **coordinates**, **data variables**, and **attributes**.
 
 ### Dimensions and coordinates
 In `xarray` [terminology](xarray:user-guide/terminology.html),
-each axis is called a **dimension** (`dim`), while
+each axis of the dataset is called a **dimension** (`dim`), while
 the labelled "ticks" along each axis are called **coordinates** (`coords`).
 
-A `movement` dataset has the following **dimensions**:
-- `time`, with size equal to the number of frames in the video
-- `individuals`, with size equal to the number of tracked individuals/instances
-- `keypoints`, with size equal to the number of tracked keypoints per individual
-- `space`: the number of spatial dimensions, either two (2D) or three (3D)
+A `movement` poses dataset has the following **dimensions**:
+- `time`, with size equal to the number of frames in the video.
+- `individuals`, with size equal to the number of tracked individuals/instances.
+- `keypoints`, with size equal to the number of tracked keypoints per individual.
+- `space`, which is the number of spatial dimensions, either two (2D) or three (3D).
 
-Appropriate **coordinates** are assigned to each **dimension**.
-- `individuals` are labelled with a list of unique names, e.g. `mouse1`, `mouse2`, etc.
-- `keypoints` are likewise labelled with a list of unique body part names, e.g. `snout`, `right_ear`, etc.
-- `space` is labelled with either `x`, `y` (2D) or `x`, `y`, `z` (3D).
+A `movement` bounding boxes dataset has the same **dimensions**, except for the `keypoints` dimension. It has:
+- `time`, with size equal to the number of frames in the video.
+- `individuals`, with size equal to the number of tracked bounding boxes (i.e., individuals/instances).
+- `space`, which is the number of spatial dimensions. Currently, we support only 2D bounding boxes data.
+
+In both cases, appropriate **coordinates** are assigned to each **dimension**.
+- `individuals` are labelled with a list of unique names (e.g. `mouse1`, `mouse2`, etc. or `id_0`, `id_1`, etc.).
+- `keypoints` are likewise labelled with a list of unique body part names, e.g. `snout`, `right_ear`, etc. Note that this dimension only exists in the poses dataset.
+- `space` is labelled with either `x`, `y` (2D) or `x`, `y`, `z` (3D). Note that bounding boxes datasets are restricted to 2D space.
 - `time` is labelled in seconds if `fps` is provided, otherwise the **coordinates** are expressed in frames (ascending 0-indexed integers).
 
 ### Data variables
+The data variables in a `movement` dataset are the arrays that hold the actual data. The specific data variables stored are slightly different between a `movement` poses dataset and a `movement` bounding boxes dataset.
 
-A `movement` dataset contains two **data variables** stored as {class}`xarray.DataArray` objects:
+A `movement` poses dataset contains two **data variables** stored as {class}`xarray.DataArray` objects:
 - `position`: the 2D or 3D locations of the keypoints over time, with shape (`time`, `individuals`, `keypoints`, `space`).
-- `confidence`: the point-wise confidence scores associated with each predicted keypoint (as reported by the pose estimation model), with shape (`time`, `individuals`, `keypoints`).
+- `confidence`: the confidence scores associated with each predicted keypoint (as reported by the pose estimation model), with shape (`time`, `individuals`, `keypoints`).
+
+A `movement` bounding boxes dataset contains three **data variables** stored as {class}`xarray.DataArray` objects:
+- `position`: the 2D locations of the bounding boxes' centroids over time, with shape (`time`, `individuals`, `space`).
+- `shape`: the width and height of the bounding boxes over time, with shape (`time`, `individuals`, `space`).
+- `confidence`: the confidence scores associated with each predicted bounding box, with shape (`time`, `individuals`).
 
 Grouping **data variables** together in a single dataset makes it easier to
 keep track of the relationships between them, and makes sense when they
-share some common **dimensions** (as is the case here).
+share some common **dimensions**.
 
 ### Attributes
 
-Related metadata that do not constitute arrays but instead take the form
-of key-value pairs can be stored as **attributes** - i.e. inside the specially
-designated `attrs` dictionary. Right after loading a `movement` dataset,
-the following **attributes** are stored:
-- `fps`: the number of frames per second in the video
-- `time_unit`: the unit of the `time` **coordinates**, frames or seconds
-- `source_software`: the software from which the poses were output
-- `source_file`: the path to the file from which the poses were loaded
+Both poses and bounding boxes datasets in `movement` have associated metadata. These can be stored as dataset **attributes** (i.e. inside the specially designated `attrs` dictionary) in the form of key-value pairs.
+
+Right after loading a `movement` dataset, the following **attributes** are created:
+- `fps`: the number of frames per second in the video. If not provided, it is set to `None`.
+- `time_unit`: the unit of the `time` **coordinates** (either `frames` or `seconds`).
+- `source_software`: the software that produced the pose or bounding boxes tracks.
+- `source_file`: the path to the file from which the data were loaded.
 
 Some of the [sample datasets](target-sample-data) provided with
-the `movement` package may also possess additional **attributes**, such as:
-- `video_path`: the path to the video file corresponding to the pose tracks
-- `frame_path`: the path to a single still frame from the video
+the `movement` package have additional **attributes**, such as:
+- `ds_type`: the type of dataset loaded (either `poses` or `bboxes`).
+- `video_path`: the path to the video file corresponding to the pose tracks.
+- `frame_path`: the path to a single still frame from the video.
+
+You can also add your own custom **attributes** to the dataset. For example, if you would like to record the frame of the full video at which the loaded tracking data starts, you could add a `frame_offset` attribute:
+```
+ds = ds.assign_attrs(frame_offset=142)
+```
 
 ## Working with movement datasets
 
 ### Using xarray's built-in functionality
 
-Since a `movement` dataset is an {class}`xarray.Dataset` consisting of
-{class}`xarray.DataArray` objects, you can use all of `xarray`'s intuitive interface
+Since a `movement` dataset is an {class}`xarray.Dataset`, you can use all of `xarray`'s intuitive interface
 and rich built-in functionalities for data manipulation and analysis.
-For example, you can access the **data variables** and **attributes** of
-a dataset `ds` using 'dot' notation (e.g. `ds.position`, `ds.fps`),
-[index and select data](xarray:user-guide/indexing.html) by **coordinate** label
-(`ds.sel()`) or position (`ds.isel()`), use **dimension** names for intelligent
-[data aggregation and broadcasting](xarray:user-guide/computation.html),
-and use the built-in [plotting methods](xarray:user-guide/plotting.html).
+
+For example, you can:
+- access the **data variables** and **attributes** of a dataset `ds` using dot notation (e.g. `ds.position`, `ds.fps`),
+- [index and select data](xarray:user-guide/indexing.html) by **coordinate** label
+(e.g. `ds.sel(individuals=["individual1", "individual2"])`) or by integer index (e.g. `ds.isel(time=slice(0,50))`),
+- use **dimension** names for
+[data aggregation and broadcasting](xarray:user-guide/computation.html), and
+- use `xarray`'s built-in [plotting methods](xarray:user-guide/plotting.html).
 
 As an example, here's how you can use the `sel` method to select subsets of
 data:
@@ -106,54 +182,65 @@ ds_sel = ds.sel(
     keypoints="snout"
 )
 ```
-Such selections can also be applied to the **data variables**,
-returning an {class}`xarray.DataArray` rather than an {class}`xarray.Dataset`:
+The same selections can be applied to the **data variables** inside a dataset. In that case the selection operations will
+return an {class}`xarray.DataArray` rather than an {class}`xarray.Dataset`:
 
 ```python
-position = ds.position.sel(individuals="individual1", keypoints="snout")
+position = ds.position.sel(
+    individuals="individual1",
+    keypoints="snout"
+)  # the output is a data array
 ```
 
 ### Accessing movement-specific functionality
 
 `movement` extends `xarray`'s functionality with a number of convenience
-methods that are specific to the structure of a `movement` dataset, as
-described above. The additional functionality is implemented in the
-{class}`movement.move_accessor.MovementDataset` class, which is an accessor to the
-underlying {class}`xarray.Dataset` object. To avoid conflicts with `xarray`'s
-built-in methods, `movement`-specific methods are accessed using the
-`move` keyword, for example:
+methods that are specific to `movement` datasets. These `movement`-specific methods are accessed using the
+`move` keyword.
+
+For example, to compute the velocity and acceleration vectors for all individuals and keypoints across time, we provide the `move.compute_velocity` and `move.compute_acceleration` methods:
 
 ```python
-# compute position derivatives for all individuals and keypoints across time
 velocity = ds.move.compute_velocity()
 acceleration = ds.move.compute_acceleration()
 ```
 
+The `movement`-specific functionalities are implemented in the
+{class}`movement.move_accessor.MovementDataset` class, which is an [accessor](https://docs.xarray.dev/en/stable/internals/extending-xarray.html) to the
+underlying {class}`xarray.Dataset` object. Defining a custom accessor is convenient
+to avoid conflicts with `xarray`'s built-in methods.
+
 ### Modifying movement datasets
 
-The `velocity` and `acceleration` produced in the above example are also
-{class}`xarray.DataArray` objects, with the same **dimensions** as the
-original `position` **data variable**. In some cases, you may wish to
+The `velocity` and `acceleration` produced in the above example are {class}`xarray.DataArray` objects, with the same **dimensions** as the
+original `position` **data variable**.
+
+In some cases, you may wish to
 add these or other new **data variables** to the `movement` dataset for
-convenience, which can be done by simply assigning them to the dataset
+convenience. This can be done by simply assigning them to the dataset
 with an appropriate name:
 
 ```python
 ds["velocity"] = velocity
 ds["acceleration"] = acceleration
-# henceforth accessible as ds.velocity and ds.acceleration
+
+# we can now access these using dot notation on the dataset
+ds.velocity
+ds.acceleration
 ```
 
 Custom **attributes** can also be added to the dataset:
 
 ```python
 ds.attrs["my_custom_attribute"] = "my_custom_value"
-# henceforth accessible as ds.my_custom_attribute
+
+# we can now access this value using dot notation on the dataset
+ds.my_custom_attribute
 ```
 
-To update existing **data variables** in-place, e.g. `position`
-and `velocity`:
+We can also update existing **data variables** in-place, using the `update()` method. For example, if we wanted to update the `position`
+and `velocity` arrays in our dataset, we could do:
 
 ```python
-ds.update({"position": position, "velocity": velocity_filtered})
+ds.update({"position": position_filtered, "velocity": velocity_filtered})
 ```

--- a/docs/source/getting_started/movement_dataset.md
+++ b/docs/source/getting_started/movement_dataset.md
@@ -139,15 +139,15 @@ The specific data variables stored are slightly different between a `movement` p
 ::::{tab-set}
 :::{tab-item} Poses dataset
 A `movement` poses dataset contains two **data variables**:
-- `position`: the 2D or 3D locations of the keypoints over time, with `shape=(time, individuals, keypoints, space)`.
-- `confidence`: the confidence scores associated with each predicted keypoint (as reported by the pose estimation model), with `shape=(time, individuals, keypoints)`
+- `position`: the 2D or 3D locations of the keypoints over time, with shape (`time`, `individuals`, `keypoints`, `space`).
+- `confidence`: the confidence scores associated with each predicted keypoint (as reported by the pose estimation model), with shape (`time`, `individuals`, `keypoints`).
 :::
 
 :::{tab-item} Bounding boxes' dataset
 A `movement` bounding boxes dataset contains three **data variables**:
-- `position`: the 2D locations of the bounding boxes' centroids over time, with `shape=(time, individuals, space)`.
-- `shape`: the width and height of the bounding boxes over time, with `shape=(time, individuals, space)`.
-- `confidence`: the confidence scores associated with each predicted bounding box, with `shape=(time, individuals)`.
+- `position`: the 2D locations of the bounding boxes' centroids over time, with shape (`time`, `individuals`, `space`).
+- `shape`: the width and height of the bounding boxes over time, with shape (`time`, `individuals`, `space`).
+- `confidence`: the confidence scores associated with each predicted bounding box, with shape (`time`, `individuals`).
 :::
 ::::
 

--- a/docs/source/getting_started/movement_dataset.md
+++ b/docs/source/getting_started/movement_dataset.md
@@ -171,9 +171,9 @@ the `movement` package have additional **attributes**, such as:
 - `video_path`: the path to the video file corresponding to the pose tracks.
 - `frame_path`: the path to a single still frame from the video.
 
-You can also add your own custom **attributes** to the dataset. For example, if you would like to record the frame of the full video at which the loaded tracking data starts, you could add a `frame_offset` attribute:
+You can also add your own custom **attributes** to the dataset. For example, if you would like to record the frame of the full video at which the loaded tracking data starts, you could add a `frame_offset` variable to the attributes of the dataset:
 ```
-ds = ds.assign_attrs(frame_offset=142)
+ds.attrs["frame_offset"] = 142
 ```
 
 ## Working with movement datasets

--- a/docs/source/getting_started/movement_dataset.md
+++ b/docs/source/getting_started/movement_dataset.md
@@ -22,7 +22,12 @@ To learn more about `xarray` data structures in general, see the relevant
 ![](../_static/dataset_structure.png)
 
 The structure of a `movement` dataset `ds` can be easily inspected by simply
-printing it. For example, for one of the sample poses dataset, we can run:
+printing it.
+
+::::{tab-set}
+
+:::{tab-item} Poses dataset
+To inspect a sample poses dataset, we can run:
 ```python
 from movement import sample_data
 
@@ -53,10 +58,11 @@ Attributes:
     frame_path:       /home/user/.movement/data/frames/three-mice_Aeon_fram...
     video_path:       None
 ```
-If you are working in a Jupyter notebook, you can view an interactive
-representation of the dataset by typing its variable name - e.g. `ds` - in a cell.
 
-Similarly, for a sample bounding boxes dataset we can have:
+:::
+
+:::{tab-item} Bounding boxes' dataset
+To inspect a sample bounding boxes' dataset, we can run:
 ```python
 from movement import sample_data
 
@@ -87,24 +93,37 @@ Attributes:
     frame_path:       None
     video_path:       None
 ```
+:::
+
+::::
 
 In both cases, we can see that the description of the dataset structure refers to **dimensions**, **coordinates**, **data variables**, and **attributes**.
+
+If you are working in a Jupyter notebook, you can view an interactive
+representation of the dataset by typing its variable name - e.g. `ds` - in a cell.
 
 ### Dimensions and coordinates
 In `xarray` [terminology](xarray:user-guide/terminology.html),
 each axis of the dataset is called a **dimension** (`dim`), while
 the labelled "ticks" along each axis are called **coordinates** (`coords`).
 
+::::{tab-set}
+:::{tab-item} Poses dataset
 A `movement` poses dataset has the following **dimensions**:
 - `time`, with size equal to the number of frames in the video.
 - `individuals`, with size equal to the number of tracked individuals/instances.
 - `keypoints`, with size equal to the number of tracked keypoints per individual.
 - `space`, which is the number of spatial dimensions. Currently, we support only 2D poses.
+:::
 
-A `movement` bounding boxes dataset has the same **dimensions**, except for the `keypoints` dimension. It has:
+:::{tab-item} Bounding boxes' dataset
+A `movement` bounding boxes dataset has the following **dimensions**s:
 - `time`, with size equal to the number of frames in the video.
-- `individuals`, with size equal to the number of tracked bounding boxes (i.e., individuals/instances).
+- `individuals`, with size equal to the number of tracked individuals/instances.
 - `space`, which is the number of spatial dimensions. Currently, we support only 2D bounding boxes data.
+Notice that these are the same dimensions as for a poses dataset, except for the `keypoints` dimension.
+:::
+::::
 
 In both cases, appropriate **coordinates** are assigned to each **dimension**.
 - `individuals` are labelled with a list of unique names (e.g. `mouse1`, `mouse2`, etc. or `id_0`, `id_1`, etc.).
@@ -113,16 +132,24 @@ In both cases, appropriate **coordinates** are assigned to each **dimension**.
 - `time` is labelled in seconds if `fps` is provided, otherwise the **coordinates** are expressed in frames (ascending 0-indexed integers).
 
 ### Data variables
-The data variables in a `movement` dataset are the arrays that hold the actual data. The specific data variables stored are slightly different between a `movement` poses dataset and a `movement` bounding boxes dataset.
+The data variables in a `movement` dataset are the arrays that hold the actual data, as {class}`xarray.DataArray` objects.
 
-A `movement` poses dataset contains two **data variables** stored as {class}`xarray.DataArray` objects:
-- `position`: the 2D or 3D locations of the keypoints over time, with shape (`time`, `individuals`, `keypoints`, `space`).
-- `confidence`: the confidence scores associated with each predicted keypoint (as reported by the pose estimation model), with shape (`time`, `individuals`, `keypoints`).
+The specific data variables stored are slightly different between a `movement` poses dataset and a `movement` bounding boxes dataset.
 
-A `movement` bounding boxes dataset contains three **data variables** stored as {class}`xarray.DataArray` objects:
-- `position`: the 2D locations of the bounding boxes' centroids over time, with shape (`time`, `individuals`, `space`).
-- `shape`: the width and height of the bounding boxes over time, with shape (`time`, `individuals`, `space`).
-- `confidence`: the confidence scores associated with each predicted bounding box, with shape (`time`, `individuals`).
+::::{tab-set}
+:::{tab-item} Poses dataset
+A `movement` poses dataset contains two **data variables**:
+- `position`: the 2D or 3D locations of the keypoints over time, with `shape=(time, individuals, keypoints, space)`.
+- `confidence`: the confidence scores associated with each predicted keypoint (as reported by the pose estimation model), with `shape=(time, individuals, keypoints)`
+:::
+
+:::{tab-item} Bounding boxes' dataset
+A `movement` bounding boxes dataset contains three **data variables**:
+- `position`: the 2D locations of the bounding boxes' centroids over time, with `shape=(time, individuals, space)`.
+- `shape`: the width and height of the bounding boxes over time, with `shape=(time, individuals, space)`.
+- `confidence`: the confidence scores associated with each predicted bounding box, with `shape=(time, individuals)`.
+:::
+::::
 
 Grouping **data variables** together in a single dataset makes it easier to
 keep track of the relationships between them, and makes sense when they

--- a/docs/source/getting_started/movement_dataset.md
+++ b/docs/source/getting_started/movement_dataset.md
@@ -164,10 +164,10 @@ Right after loading a `movement` dataset, the following **attributes** are creat
 - `time_unit`: the unit of the `time` **coordinates** (either `frames` or `seconds`).
 - `source_software`: the software that produced the pose or bounding boxes tracks.
 - `source_file`: the path to the file from which the data were loaded.
+- `ds_type`: the type of dataset loaded (either `poses` or `bboxes`).
 
 Some of the [sample datasets](target-sample-data) provided with
 the `movement` package have additional **attributes**, such as:
-- `ds_type`: the type of dataset loaded (either `poses` or `bboxes`).
 - `video_path`: the path to the video file corresponding to the pose tracks.
 - `frame_path`: the path to a single still frame from the video.
 

--- a/docs/source/getting_started/movement_dataset.md
+++ b/docs/source/getting_started/movement_dataset.md
@@ -99,7 +99,7 @@ A `movement` poses dataset has the following **dimensions**:
 - `time`, with size equal to the number of frames in the video.
 - `individuals`, with size equal to the number of tracked individuals/instances.
 - `keypoints`, with size equal to the number of tracked keypoints per individual.
-- `space`, which is the number of spatial dimensions, either two (2D) or three (3D).
+- `space`, which is the number of spatial dimensions. Currently, we support only 2D poses.
 
 A `movement` bounding boxes dataset has the same **dimensions**, except for the `keypoints` dimension. It has:
 - `time`, with size equal to the number of frames in the video.

--- a/docs/source/getting_started/movement_dataset.md
+++ b/docs/source/getting_started/movement_dataset.md
@@ -8,7 +8,7 @@ An {class}`xarray.Dataset` object is a container for multiple arrays. Each array
 with pandas-style indexing and labelling.
 
 So a `movement` dataset is simply an {class}`xarray.Dataset` with a specific
-structure to represent pose tracks or bounding boxes tracks. Because pose data and bounding boxes data are somewhat different, `movement` provides two types of datasets: `poses` datasets and `bboxes` datasets.
+structure to represent pose tracks or bounding boxes' tracks. Because pose data and bounding boxes data are somewhat different, `movement` provides two types of datasets: `poses` datasets and `bboxes` datasets.
 
 To discuss the specifics of both types of `movement` datasets, it is useful to clarify some concepts such as **data variables**, **dimensions**,
 **coordinates** and **attributes**. In the next section, we will describe these concepts and the `movement` datasets' structure in some detail.

--- a/docs/source/getting_started/sample_data.md
+++ b/docs/source/getting_started/sample_data.md
@@ -46,7 +46,9 @@ and its path is stored in the `frame_path` attribute
 (i.e., `ds.frame_path`). If no frame file is available for the dataset,
  `ds.frame_path=None`.
 
-:::{note}
+:::{dropdown} Under the hood
+:color: info
+:icon: info
 When you import the `sample_data` module with `from movement import sample_data`,
 `movement` downloads a small metadata file to your local machine with information about the latest sample datasets available. Then, the first time you call the `fetch_dataset()` function, `movement` downloads the requested file to your machine and caches it in the `~/.movement/data` directory. On subsequent calls, the data are directly loaded from this local cache.
 :::

--- a/docs/source/getting_started/sample_data.md
+++ b/docs/source/getting_started/sample_data.md
@@ -2,7 +2,7 @@
 # Sample data
 
 `movement` includes some sample data files that you can use to
-try out the package. These files contain predicted pose tracks from
+try the package out. These files contain pose and bounding boxes' tracks from
 various [supported formats](target-supported-formats).
 
 You can list the available sample data files using:
@@ -11,15 +11,14 @@ You can list the available sample data files using:
 from movement import sample_data
 
 file_names = sample_data.list_datasets()
-print(file_names)
+print(*file_names, sep='\n')  # print each sample file in a separate line
 ```
 
-This prints a list of file names containing sample pose data.
-Each file is prefixed with the name of the pose estimation software package
-that was used to generate it - either "DLC", "SLEAP", or "LP".
+Each sample file is prefixed with the name of the software package
+that was used to generate it.
 
-To load one of the sample datasets as a
-[movement dataset](target-dataset), use the
+To load one of the sample files as a
+[movement dataset](target-poses-and-bboxes-dataset), use the
 {func}`movement.sample_data.fetch_dataset()` function:
 
 ```python
@@ -27,8 +26,8 @@ filename = "SLEAP_three-mice_Aeon_proofread.analysis.h5"
 ds = sample_data.fetch_dataset(filename)
 ```
 Some sample datasets also have an associated video file
-(the video from which the poses were predicted),
-which you can request by setting `with_video=True`:
+(the video for which the data was predicted). You can request
+to download the sample video by setting `with_video=True`:
 
 ```python
 ds = sample_data.fetch_dataset(filename, with_video=True)
@@ -37,20 +36,17 @@ ds = sample_data.fetch_dataset(filename, with_video=True)
 If available, the video file is downloaded and its path is stored
 in the `video_path` attribute of the dataset (i.e., `ds.video_path`).
 The value of this attribute is `None` if no video file is
-available for this dataset or if you did not request it
-(`with_video=False`, which is the default).
+available for this dataset, or if you did not request it.
 
-Some datasets also have an associated frame file, which is a single
+Some datasets also include a sample frame file, which is a single
 still frame extracted from the video. This can be useful for visualisation
 (e.g., as a background image for plotting trajectories). If available,
 this file is always downloaded when fetching the dataset,
 and its path is stored in the `frame_path` attribute
 (i.e., `ds.frame_path`). If no frame file is available for the dataset,
-this attribute's value is `None`.
+ `ds.frame_path=None`.
 
 :::{note}
-Under the hood, the first time you call the `fetch_dataset()` function,
-it downloads the corresponding files to your local machine and caches them
-in the `~/.movement/data` directory. On subsequent calls, the data are directly
-loaded from this local cache.
+When you import the `sample_data` module with `from movement import sample_data`,
+`movement` downloads a small metadata file to your local machine with information about the latest sample datasets available. Then, the first time you call the `fetch_dataset()` function, `movement` downloads the requested file to your machine and caches it in the `~/.movement/data` directory. On subsequent calls, the data are directly loaded from this local cache.
 :::

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -27,7 +27,7 @@ def from_numpy(
     fps: float | None = None,
     source_software: str | None = None,
 ) -> xr.Dataset:
-    """Create a ``movement`` dataset from NumPy arrays.
+    """Create a ``movement`` poses dataset from NumPy arrays.
 
     Parameters
     ----------
@@ -95,7 +95,7 @@ def from_file(
     source_software: Literal["DeepLabCut", "SLEAP", "LightningPose"],
     fps: float | None = None,
 ) -> xr.Dataset:
-    """Create a ``movement`` dataset from any supported file.
+    """Create a ``movement`` poses dataset from any supported file.
 
     Parameters
     ----------
@@ -148,7 +148,7 @@ def from_dlc_style_df(
     fps: float | None = None,
     source_software: Literal["DeepLabCut", "LightningPose"] = "DeepLabCut",
 ) -> xr.Dataset:
-    """Create a ``movement`` dataset from a DeepLabCut-style DataFrame.
+    """Create a ``movement`` poses dataset from a DeepLabCut-style DataFrame.
 
     Parameters
     ----------
@@ -214,7 +214,7 @@ def from_dlc_style_df(
 def from_sleap_file(
     file_path: Path | str, fps: float | None = None
 ) -> xr.Dataset:
-    """Create a ``movement`` dataset from a SLEAP file.
+    """Create a ``movement`` poses dataset from a SLEAP file.
 
     Parameters
     ----------
@@ -290,7 +290,7 @@ def from_sleap_file(
 def from_lp_file(
     file_path: Path | str, fps: float | None = None
 ) -> xr.Dataset:
-    """Create a ``movement`` dataset from a LightningPose file.
+    """Create a ``movement`` poses dataset from a LightningPose file.
 
     Parameters
     ----------
@@ -320,7 +320,7 @@ def from_lp_file(
 def from_dlc_file(
     file_path: Path | str, fps: float | None = None
 ) -> xr.Dataset:
-    """Create a ``movement`` dataset from a DeepLabCut file.
+    """Create a ``movement`` poses dataset from a DeepLabCut file.
 
     Parameters
     ----------
@@ -357,7 +357,7 @@ def _ds_from_lp_or_dlc_file(
     source_software: Literal["LightningPose", "DeepLabCut"],
     fps: float | None = None,
 ) -> xr.Dataset:
-    """Create a ``movement`` dataset from a LightningPose or DeepLabCut file.
+    """Create a ``movement`` poses dataset from a LightningPose or DLC file.
 
     Parameters
     ----------
@@ -406,7 +406,7 @@ def _ds_from_lp_or_dlc_file(
 def _ds_from_sleap_analysis_file(
     file_path: Path, fps: float | None
 ) -> xr.Dataset:
-    """Create a ``movement`` dataset from a SLEAP analysis (.h5) file.
+    """Create a ``movement`` poses dataset from a SLEAP analysis (.h5) file.
 
     Parameters
     ----------
@@ -454,7 +454,7 @@ def _ds_from_sleap_analysis_file(
 def _ds_from_sleap_labels_file(
     file_path: Path, fps: float | None
 ) -> xr.Dataset:
-    """Create a ``movement`` dataset from a SLEAP labels (.slp) file.
+    """Create a ``movement`` poses dataset from a SLEAP labels (.slp) file.
 
     Parameters
     ----------
@@ -630,7 +630,7 @@ def _df_from_dlc_h5(file_path: Path) -> pd.DataFrame:
 
 
 def _ds_from_valid_data(data: ValidPosesDataset) -> xr.Dataset:
-    """Create a ``movement`` dataset from validated pose tracking data.
+    """Create a ``movement`` poses dataset from validated pose tracking data.
 
     Parameters
     ----------

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -251,10 +251,10 @@ class ValidVIATracksCSV:
 
         This involves:
         - Checking that frame numbers are included in `file_attributes` or
-          encoded in the image file `filename`.
+        encoded in the image file `filename`.
         - Checking the frame number can be cast as an integer.
         - Checking that there are as many unique frame numbers as unique image
-          files.
+        files.
 
         If the frame number is included as part of the image file name, it is
         expected as an integer led by at least one zero, between "_" and ".",
@@ -321,7 +321,7 @@ class ValidVIATracksCSV:
         This involves:
         - Checking that the bounding boxes are defined as rectangles.
         - Checking that the bounding boxes have all geometric parameters
-          (["x", "y", "width", "height"]).
+        (["x", "y", "width", "height"]).
         - Checking that the bounding boxes have a track ID defined.
         - Checking that the track ID can be cast as an integer.
         """


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

To update the Getting started docs re the new bounding box data loading functionalities.

**What does this PR do?**
- Edits the text in the Getting started sections to reference to the bounding boxes functionalities
- Adds the `from_numpy` methods to the input/output guide (closes #244)
- Small edits to make all sections more consistent. 
- Edits docstrings for pose loaders so that they explicitly refer to poses datasets in the API reference

## References

Fixes #244

Follows up from feedback received in PR #229 

## How has this PR been tested?

Docs build locally and in CI.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

It is an update itself.

## Checklist:

- [x] The code has been tested locally
- [ n/a ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
