### PR TITLE
Refactor names and fix docs formatting in `validators`

### DIFF
--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -207,7 +207,7 @@ class ValidDeepLabCutCSV:
 class ValidVIATracksCSV:
     """Class for validating VIA tracks .csv files.
 
-    Parameters
+    Attributes
     ----------
     path : pathlib.Path or str
         Path to the VIA tracks .csv file.

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -17,6 +17,14 @@ from movement.utils.logging import log_error
 class ValidFile:
     """Class for validating file paths.
 
+    The validator ensures that the file:
+
+    - is not a directory,
+    - exists if it is meant to be read,
+    - does not exist if it is meant to be written,
+    - has the expected access permission(s), and
+    - has one of the expected suffix(es).
+
     Attributes
     ----------
     path : str or pathlib.Path
@@ -113,6 +121,11 @@ class ValidFile:
 class ValidHDF5:
     """Class for validating HDF5 files.
 
+    The validator ensures that the file:
+
+    - is in HDF5 format, and
+    - contains the expected datasets.
+
     Attributes
     ----------
     path : pathlib.Path
@@ -162,6 +175,9 @@ class ValidHDF5:
 class ValidDeepLabCutCSV:
     """Class for validating DeepLabCut-style .csv files.
 
+    The validator ensures that the file contains the
+    expected index column levels.
+
     Attributes
     ----------
     path : pathlib.Path
@@ -206,6 +222,13 @@ class ValidDeepLabCutCSV:
 @define
 class ValidVIATracksCSV:
     """Class for validating VIA tracks .csv files.
+
+    The validator ensures that the file:
+
+    - contains the expected header,
+    - contains valid frame numbers,
+    - contains tracked bounding boxes, and
+    - defines bounding boxes whose IDs are unique per image file.
 
     Attributes
     ----------

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -222,7 +222,7 @@ class ValidVIATracksCSV:
     path: Path = field(validator=validators.instance_of(Path))
 
     @path.validator
-    def csv_file_contains_valid_header(self, attribute, value):
+    def _csv_file_contains_valid_header(self, attribute, value):
         """Ensure the VIA tracks .csv file contains the expected header."""
         expected_header = [
             "filename",
@@ -246,7 +246,7 @@ class ValidVIATracksCSV:
                 )
 
     @path.validator
-    def csv_file_contains_valid_frame_numbers(self, attribute, value):
+    def _csv_file_contains_valid_frame_numbers(self, attribute, value):
         """Ensure that the VIA tracks .csv file contains valid frame numbers.
 
         This involves:
@@ -317,7 +317,7 @@ class ValidVIATracksCSV:
             )
 
     @path.validator
-    def csv_file_contains_tracked_bboxes(self, attribute, value):
+    def _csv_file_contains_tracked_bboxes(self, attribute, value):
         """Ensure that the VIA tracks .csv contains tracked bounding boxes.
 
         This involves:
@@ -384,7 +384,7 @@ class ValidVIATracksCSV:
                 ) from e
 
     @path.validator
-    def csv_file_contains_unique_track_IDs_per_filename(
+    def _csv_file_contains_unique_track_IDs_per_filename(
         self, attribute, value
     ):
         """Ensure the VIA tracks .csv contains unique track IDs per filename.

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -194,7 +194,7 @@ class ValidDeepLabCutCSV:
     path: Path = field(validator=validators.instance_of(Path))
 
     @path.validator
-    def _csv_file_contains_expected_levels(self, attribute, value):
+    def _file_contains_expected_levels(self, attribute, value):
         """Ensure that the .csv file contains the expected index column levels.
 
         These are to be found among the top 4 rows of the file.
@@ -245,7 +245,7 @@ class ValidVIATracksCSV:
     path: Path = field(validator=validators.instance_of(Path))
 
     @path.validator
-    def _csv_file_contains_valid_header(self, attribute, value):
+    def _file_contains_valid_header(self, attribute, value):
         """Ensure the VIA tracks .csv file contains the expected header."""
         expected_header = [
             "filename",
@@ -269,7 +269,7 @@ class ValidVIATracksCSV:
                 )
 
     @path.validator
-    def _csv_file_contains_valid_frame_numbers(self, attribute, value):
+    def _file_contains_valid_frame_numbers(self, attribute, value):
         """Ensure that the VIA tracks .csv file contains valid frame numbers.
 
         This involves:
@@ -340,7 +340,7 @@ class ValidVIATracksCSV:
             )
 
     @path.validator
-    def _csv_file_contains_tracked_bboxes(self, attribute, value):
+    def _file_contains_tracked_bboxes(self, attribute, value):
         """Ensure that the VIA tracks .csv contains tracked bounding boxes.
 
         This involves:
@@ -407,9 +407,7 @@ class ValidVIATracksCSV:
                 ) from e
 
     @path.validator
-    def _csv_file_contains_unique_track_IDs_per_filename(
-        self, attribute, value
-    ):
+    def _file_contains_unique_track_ids_per_filename(self, attribute, value):
         """Ensure the VIA tracks .csv contains unique track IDs per filename.
 
         It checks that bounding boxes IDs are defined once per image file.

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -255,7 +255,7 @@ class ValidVIATracksCSV:
           encoded in the image file ``filename``.
         - Checking the frame number can be cast as an integer.
         - Checking that there are as many unique frame numbers as unique image
-        files.
+          files.
 
         If the frame number is included as part of the image file name, it is
         expected as an integer led by at least one zero, between "_" and ".",

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -250,6 +250,7 @@ class ValidVIATracksCSV:
         """Ensure that the VIA tracks .csv file contains valid frame numbers.
 
         This involves:
+
         - Checking that frame numbers are included in `file_attributes` or
         encoded in the image file `filename`.
         - Checking the frame number can be cast as an integer.
@@ -319,6 +320,7 @@ class ValidVIATracksCSV:
         """Ensure that the VIA tracks .csv contains tracked bounding boxes.
 
         This involves:
+
         - Checking that the bounding boxes are defined as rectangles.
         - Checking that the bounding boxes have all geometric parameters
         (["x", "y", "width", "height"]).

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -209,7 +209,7 @@ class ValidVIATracksCSV:
 
     Attributes
     ----------
-    path : pathlib.Path or str
+    path : pathlib.Path
         Path to the VIA tracks .csv file.
 
     Raises

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -418,13 +418,13 @@ class ValidVIATracksCSV:
         for file in list_unique_filenames:
             df_one_filename = df.loc[df["filename"] == file]
 
-            list_track_IDs_one_filename = [
+            list_track_ids_one_filename = [
                 int(ast.literal_eval(row.region_attributes)["track"])
                 for row in df_one_filename.itertuples()
             ]
 
-            if len(set(list_track_IDs_one_filename)) != len(
-                list_track_IDs_one_filename
+            if len(set(list_track_ids_one_filename)) != len(
+                list_track_ids_one_filename
             ):
                 raise log_error(
                     ValueError,

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -37,9 +37,9 @@ class ValidFile:
     PermissionError
         If the file does not have the expected access permission(s).
     FileNotFoundError
-        If the file does not exist when `expected_permission` is "r" or "rw".
+        If the file does not exist when ``expected_permission`` is "r" or "rw".
     FileExistsError
-        If the file exists when `expected_permission` is "w".
+        If the file exists when ``expected_permission`` is "w".
     ValueError
         If the file does not have one of the expected suffix(es).
 
@@ -251,8 +251,8 @@ class ValidVIATracksCSV:
 
         This involves:
 
-        - Checking that frame numbers are included in `file_attributes` or
-        encoded in the image file `filename`.
+        - Checking that frame numbers are included in ``file_attributes`` or
+          encoded in the image file ``filename``.
         - Checking the frame number can be cast as an integer.
         - Checking that there are as many unique frame numbers as unique image
         files.
@@ -323,7 +323,7 @@ class ValidVIATracksCSV:
 
         - Checking that the bounding boxes are defined as rectangles.
         - Checking that the bounding boxes have all geometric parameters
-        (["x", "y", "width", "height"]).
+          (``["x", "y", "width", "height"]``).
         - Checking that the bounding boxes have a track ID defined.
         - Checking that the track ID can be cast as an integer.
         """


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Closes #252 

**What does this PR do?**
- Adds the missing blank lines after block quote
- Adds missing double backticks 
- Hides `ValidVIATracksCSV` attrs validator functions in the API docs
- Describes validation checks at validator class-level
- Shortens validator function names `_csv_file_contains...` &rarr; `_file_contains...`
- Change `ID` in function and variable names to lowercase ([consistency issues](https://sonarcloud.io/project/issues?id=neuroinformatics-unit_movement&pullRequest=219&issueStatuses=OPEN,CONFIRMED&sinceLeakPeriod=true))

## References
#252 

## How has this PR been tested?
Docs built locally and via CI

## TODO
- [x] One remaining concern is that in #213, I [hid all attrs validator functions in the API docs](https://github.com/neuroinformatics-unit/movement/pull/213#pullrequestreview-2154266895), thinking it is much cleaner, since we only have brief descriptions. Should we
  1. do the same for `ValidVIATracksCSV`, or
  2. unhide all attrs validator functions?

  If we go for 1., i.e. showing only the class definition, maybe we should mention what kinds of validations are done in the class-level docs?

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
