### PR TITLE
Adapt move accessor to bboxes datasets

### DIFF
--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -352,6 +352,7 @@ def _numpy_arrays_from_via_tracks_file(file_path: Path) -> dict:
 
     The extracted numpy arrays are returned in a dictionary with the following
     keys:
+
     - position_array (n_frames, n_individuals, n_space):
         contains the trajectories of the bounding boxes' centroids.
     - shape_array (n_frames, n_individuals, n_space):

--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -382,9 +382,9 @@ def _numpy_arrays_from_via_tracks_file(file_path: Path) -> dict:
     df = _df_from_via_tracks_file(file_path)
 
     # Compute indices of the rows where the IDs switch
-    bool_ID_diff_from_prev = df["ID"].ne(df["ID"].shift())  # pandas series
-    indices_ID_switch = (
-        bool_ID_diff_from_prev.loc[lambda x: x].index[1:].to_numpy()
+    bool_id_diff_from_prev = df["ID"].ne(df["ID"].shift())  # pandas series
+    indices_id_switch = (
+        bool_id_diff_from_prev.loc[lambda x: x].index[1:].to_numpy()
     )
 
     # Stack position, shape and confidence arrays along ID axis
@@ -397,7 +397,7 @@ def _numpy_arrays_from_via_tracks_file(file_path: Path) -> dict:
     for key in map_key_to_columns:
         list_arrays = np.split(
             df[map_key_to_columns[key]].to_numpy(),
-            indices_ID_switch,  # indices along axis=0
+            indices_id_switch,  # indices along axis=0
         )
 
         array_dict[key] = np.stack(list_arrays, axis=1).squeeze()

--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -623,7 +623,7 @@ def _ds_from_valid_data(data: ValidBboxesDataset) -> xr.Dataset:
 
     # Convert data to an xarray.Dataset
     # with dimensions ('time', 'individuals', 'space')
-    DIM_NAMES = tuple(a for a in MovementDataset.dim_names if a != "keypoints")
+    DIM_NAMES = MovementDataset.dim_names_per_ds_type["bboxes"]
     n_space = data.position_array.shape[-1]
     return xr.Dataset(
         data_vars={

--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -624,7 +624,7 @@ def _ds_from_valid_data(data: ValidBboxesDataset) -> xr.Dataset:
 
     # Convert data to an xarray.Dataset
     # with dimensions ('time', 'individuals', 'space')
-    DIM_NAMES = MovementDataset.dim_names_per_ds_type["bboxes"]
+    DIM_NAMES = MovementDataset.dim_names["bboxes"]
     n_space = data.position_array.shape[-1]
     return xr.Dataset(
         data_vars={

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -654,7 +654,7 @@ def _ds_from_valid_data(data: ValidPosesDataset) -> xr.Dataset:
         time_coords = time_coords / data.fps
         time_unit = "seconds"
 
-    DIM_NAMES = MovementDataset.dim_names
+    DIM_NAMES = MovementDataset.dim_names_per_ds_type["poses"]
     # Convert data to an xarray.Dataset
     return xr.Dataset(
         data_vars={

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -654,7 +654,7 @@ def _ds_from_valid_data(data: ValidPosesDataset) -> xr.Dataset:
         time_coords = time_coords / data.fps
         time_unit = "seconds"
 
-    DIM_NAMES = MovementDataset.dim_names_per_ds_type["poses"]
+    DIM_NAMES = MovementDataset.dim_names["poses"]
     # Convert data to an xarray.Dataset
     return xr.Dataset(
         data_vars={

--- a/movement/move_accessor.py
+++ b/movement/move_accessor.py
@@ -292,15 +292,11 @@ class MovementDataset:
     def _validate_dimensions(self) -> None:
         missing_dims = set(self.dim_names) - set(self._obj.dims)
         if missing_dims:
-            raise ValueError(
-                f"Missing required dimensions: {sorted(missing_dims)}"
-                # sort for deterministic error messages during testing
-            )
+            raise ValueError(f"Missing required dimensions: {missing_dims}")
 
     def _validate_data_vars(self) -> None:
         missing_vars = set(self.var_names) - set(self._obj.data_vars)
         if missing_vars:
             raise ValueError(
-                f"Missing required data variables: {sorted(missing_vars)}"
-                # sort for deterministic error messages during testing
+                f"Missing required data variables: {missing_vars}"
             )

--- a/movement/move_accessor.py
+++ b/movement/move_accessor.py
@@ -294,11 +294,13 @@ class MovementDataset:
     def _validate_dims(self) -> None:
         missing_dims = set(self.dim_names_instance) - set(self._obj.dims)
         if missing_dims:
-            raise ValueError(f"Missing required dimensions: {missing_dims}")
+            raise ValueError(
+                f"Missing required dimensions: {sorted(missing_dims)}"
+            )  # sort for a reproducible error message
 
     def _validate_data_vars(self) -> None:
         missing_vars = set(self.var_names_instance) - set(self._obj.data_vars)
         if missing_vars:
             raise ValueError(
-                f"Missing required data variables: {missing_vars}"
-            )
+                f"Missing required data variables: {sorted(missing_vars)}"
+            )  # sort for a reproducible error message

--- a/movement/move_accessor.py
+++ b/movement/move_accessor.py
@@ -31,10 +31,10 @@ class MovementDataset:
 
     Attributes
     ----------
-    dim_names_per_ds_type : dict
+    dim_names : dict
         A dictionary with the names of the expected dimensions in the dataset,
         for each dataset type (``"poses"`` or ``"bboxes"``).
-    var_names_per_ds_type : dict
+    var_names : dict
         A dictionary with the expected data variables in the dataset, for each
         dataset type (``"poses"`` or ``"bboxes"``).
 
@@ -57,7 +57,6 @@ class MovementDataset:
     def __init__(self, ds: xr.Dataset):
         """Initialize the MovementDataset."""
         self._obj = ds
-
         # Set instance attributes based on dataset type
         self.dim_names_instance = self.dim_names[self._obj.ds_type]
         self.var_names_instance = self.var_names[self._obj.ds_type]
@@ -258,7 +257,6 @@ class MovementDataset:
         try:
             self._validate_dims()
             self._validate_data_vars()
-
             if self._obj.ds_type == "poses":
                 ValidPosesDataset(
                     position_array=self._obj["position"].values,
@@ -274,7 +272,6 @@ class MovementDataset:
                 frame_array = self._obj.coords["time"].values.reshape(-1, 1)
                 if self._obj.attrs["time_unit"] == "seconds":
                     frame_array *= fps
-
                 ValidBboxesDataset(
                     position_array=self._obj["position"].values,
                     shape_array=self._obj["shape"].values,
@@ -286,8 +283,7 @@ class MovementDataset:
                 )
         except Exception as e:
             error_msg = (
-                f"The dataset does not contain valid {self._obj.ds_type}. "
-                + str(e)
+                f"The dataset does not contain valid {self._obj.ds_type}. {e}"
             )
             raise log_error(ValueError, error_msg) from e
 

--- a/movement/move_accessor.py
+++ b/movement/move_accessor.py
@@ -249,11 +249,11 @@ class MovementDataset:
             missing_vars = set(self.var_names) - set(self._obj.data_vars)
             if missing_dims:
                 raise ValueError(
-                    f"Missing required dimensions: {missing_dims}"
+                    f"Missing required dimensions: {sorted(missing_dims)}"
                 )
             if missing_vars:
                 raise ValueError(
-                    f"Missing required data variables: {missing_vars}"
+                    f"Missing required data variables: {sorted(missing_vars)}"
                 )
             ValidPosesDataset(
                 position_array=self._obj[self.var_names[0]].values,

--- a/movement/move_accessor.py
+++ b/movement/move_accessor.py
@@ -45,11 +45,11 @@ class MovementDataset:
     """
 
     # Set class attributes for expected dimensions and data variables
-    dim_names_per_ds_type: ClassVar[dict] = {
+    dim_names: ClassVar[dict] = {
         "poses": ("time", "individuals", "keypoints", "space"),
         "bboxes": ("time", "individuals", "space"),
     }
-    var_names_per_ds_type: ClassVar[dict] = {
+    var_names: ClassVar[dict] = {
         "poses": ("position", "confidence"),
         "bboxes": ("position", "shape", "confidence"),
     }
@@ -59,8 +59,8 @@ class MovementDataset:
         self._obj = ds
 
         # Set instance attributes based on dataset type
-        self.dim_names = self.dim_names_per_ds_type[self._obj.ds_type]
-        self.var_names = self.var_names_per_ds_type[self._obj.ds_type]
+        self.dim_names_instance = self.dim_names[self._obj.ds_type]
+        self.var_names_instance = self.var_names[self._obj.ds_type]
 
     def __getattr__(self, name: str) -> xr.DataArray:
         """Forward requested but undefined attributes to relevant modules.
@@ -290,12 +290,12 @@ class MovementDataset:
             raise log_error(ValueError, error_msg) from e
 
     def _validate_dimensions(self) -> None:
-        missing_dims = set(self.dim_names) - set(self._obj.dims)
+        missing_dims = set(self.dim_names_instance) - set(self._obj.dims)
         if missing_dims:
             raise ValueError(f"Missing required dimensions: {missing_dims}")
 
     def _validate_data_vars(self) -> None:
-        missing_vars = set(self.var_names) - set(self._obj.data_vars)
+        missing_vars = set(self.var_names_instance) - set(self._obj.data_vars)
         if missing_vars:
             raise ValueError(
                 f"Missing required data variables: {missing_vars}"

--- a/movement/move_accessor.py
+++ b/movement/move_accessor.py
@@ -31,10 +31,10 @@ class MovementDataset:
 
     Attributes
     ----------
-    dim_names : dict
+    dim_names_per_ds_type : dict
         A dictionary with the names of the expected dimensions in the dataset,
         for each dataset type ("poses" or "bboxes").
-    var_names : dict
+    var_names_per_ds_type : dict
         A dictionary with the expected data variables in the dataset, for each
         dataset type ("poses" or "bboxes").
 
@@ -254,10 +254,12 @@ class MovementDataset:
             if missing_dims:
                 raise ValueError(
                     f"Missing required dimensions: {sorted(missing_dims)}"
+                    # sorted required for deterministic error messages
                 )
             if missing_vars:
                 raise ValueError(
                     f"Missing required data variables: {sorted(missing_vars)}"
+                    # sorted required for deterministic error messages
                 )
             if self._obj.ds_type == "poses":
                 ValidPosesDataset(
@@ -269,8 +271,8 @@ class MovementDataset:
                     source_software=source_software,
                 )
             elif self._obj.ds_type == "bboxes":
-                # define frame_array
-                # convert time axis to frames if time_unit is seconds
+                # Define frame_array.
+                # Convert time axis to frames if time_unit is seconds
                 frame_array = self._obj.coords["time"].values.reshape(-1, 1)
                 if self._obj.attrs["time_unit"] == "seconds":
                     frame_array *= fps

--- a/movement/move_accessor.py
+++ b/movement/move_accessor.py
@@ -33,10 +33,10 @@ class MovementDataset:
     ----------
     dim_names_per_ds_type : dict
         A dictionary with the names of the expected dimensions in the dataset,
-        for each dataset type ("poses" or "bboxes").
+        for each dataset type (``"poses"`` or ``"bboxes"``).
     var_names_per_ds_type : dict
         A dictionary with the expected data variables in the dataset, for each
-        dataset type ("poses" or "bboxes").
+        dataset type (``"poses"`` or ``"bboxes"``).
 
     References
     ----------
@@ -254,12 +254,12 @@ class MovementDataset:
             if missing_dims:
                 raise ValueError(
                     f"Missing required dimensions: {sorted(missing_dims)}"
-                    # sorted required for deterministic error messages
+                    # sort for deterministic error messages during testing
                 )
             if missing_vars:
                 raise ValueError(
                     f"Missing required data variables: {sorted(missing_vars)}"
-                    # sorted required for deterministic error messages
+                    # sort for deterministic error messages during testing
                 )
             if self._obj.ds_type == "poses":
                 ValidPosesDataset(

--- a/movement/move_accessor.py
+++ b/movement/move_accessor.py
@@ -272,7 +272,7 @@ class MovementDataset:
                 )
             elif self._obj.ds_type == "bboxes":
                 # Define frame_array.
-                # Convert time axis to frames if time_unit is seconds
+                # Recover from time axis in seconds if necessary.
                 frame_array = self._obj.coords["time"].values.reshape(-1, 1)
                 if self._obj.attrs["time_unit"] == "seconds":
                     frame_array *= fps

--- a/movement/move_accessor.py
+++ b/movement/move_accessor.py
@@ -256,8 +256,9 @@ class MovementDataset:
         fps = self._obj.attrs.get("fps", None)
         source_software = self._obj.attrs.get("source_software", None)
         try:
-            self._validate_dimensions()
+            self._validate_dims()
             self._validate_data_vars()
+
             if self._obj.ds_type == "poses":
                 ValidPosesDataset(
                     position_array=self._obj["position"].values,
@@ -273,6 +274,7 @@ class MovementDataset:
                 frame_array = self._obj.coords["time"].values.reshape(-1, 1)
                 if self._obj.attrs["time_unit"] == "seconds":
                     frame_array *= fps
+
                 ValidBboxesDataset(
                     position_array=self._obj["position"].values,
                     shape_array=self._obj["shape"].values,
@@ -289,7 +291,7 @@ class MovementDataset:
             )
             raise log_error(ValueError, error_msg) from e
 
-    def _validate_dimensions(self) -> None:
+    def _validate_dims(self) -> None:
         missing_dims = set(self.dim_names_instance) - set(self._obj.dims)
         if missing_dims:
             raise ValueError(f"Missing required dimensions: {missing_dims}")

--- a/movement/move_accessor.py
+++ b/movement/move_accessor.py
@@ -294,11 +294,15 @@ class MovementDataset:
     def _validate_dims(self) -> None:
         missing_dims = set(self.dim_names_instance) - set(self._obj.dims)
         if missing_dims:
-            raise ValueError(f"Missing required dimensions: {missing_dims}")
+            raise ValueError(
+                f"Missing required dimensions: {sorted(missing_dims)}"
+                # sort for deterministic error messages during testing
+            )
 
     def _validate_data_vars(self) -> None:
         missing_vars = set(self.var_names_instance) - set(self._obj.data_vars)
         if missing_vars:
             raise ValueError(
-                f"Missing required data variables: {missing_vars}"
+                f"Missing required data variables: {sorted(missing_vars)}"
+                # sort for deterministic error messages during testing
             )

--- a/movement/move_accessor.py
+++ b/movement/move_accessor.py
@@ -294,15 +294,11 @@ class MovementDataset:
     def _validate_dims(self) -> None:
         missing_dims = set(self.dim_names_instance) - set(self._obj.dims)
         if missing_dims:
-            raise ValueError(
-                f"Missing required dimensions: {sorted(missing_dims)}"
-                # sort for deterministic error messages during testing
-            )
+            raise ValueError(f"Missing required dimensions: {missing_dims}")
 
     def _validate_data_vars(self) -> None:
         missing_vars = set(self.var_names_instance) - set(self._obj.data_vars)
         if missing_vars:
             raise ValueError(
-                f"Missing required data variables: {sorted(missing_vars)}"
-                # sort for deterministic error messages during testing
+                f"Missing required data variables: {missing_vars}"
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,28 +214,12 @@ def sleap_file(request):
 
 
 @pytest.fixture
-def valid_bboxes_arrays_all_zeros():  # used for validators
-    """Return a dictionary of valid zero arrays (in terms of shape) for a
-    ValidBboxesDataset.
-    """
-    # define the shape of the arrays
-    n_frames, n_individuals, n_space = (10, 2, 2)
-
-    # build a valid array for position or shape will all zeros
-    valid_bbox_array_all_zeros = np.zeros((n_frames, n_individuals, n_space))
-
-    # return as a dict
-    return {
-        "position": valid_bbox_array_all_zeros,
-        "shape": valid_bbox_array_all_zeros,
-        "individual_names": ["id_" + str(id) for id in range(n_individuals)],
-    }
-
-
-@pytest.fixture
-def valid_bboxes_array():  # used for filtering
+def valid_bboxes_array():
     """Return a dictionary of valid non-zero arrays for a
     ValidBboxesDataset.
+
+    Contains realistic data for 10 frames, 2 individuals, in 2D
+    with 5 low confidence bounding boxes.
     """
     # define the shape of the arrays
     n_frames, n_individuals, n_space = (10, 2, 2)
@@ -278,8 +262,8 @@ def valid_bboxes_array():  # used for filtering
 @pytest.fixture
 def valid_bboxes_dataset(
     valid_bboxes_array,
-):  # ---- with low confidence values!
-    """Return a valid bboxes' tracks dataset."""
+):
+    """Return a valid bboxes dataset with low confidence values."""
     dim_names = MovementDataset.dim_names_per_ds_type["bboxes"]
 
     position_array = valid_bboxes_array["position"]
@@ -294,10 +278,6 @@ def valid_bboxes_dataset(
             "shape": xr.DataArray(shape_array, dims=dim_names),
             "confidence": xr.DataArray(confidence_array, dims=dim_names[:-1]),
         },
-        # Ignoring type error because `time_coords`
-        # (which is a function of `data.frame_array`)
-        # cannot be None after
-        # ValidBboxesDataset.__attrs_post_init__()   # type: ignore
         coords={
             dim_names[0]: np.arange(n_frames),
             dim_names[1]: [f"id_{id}" for id in range(n_individuals)],
@@ -314,8 +294,8 @@ def valid_bboxes_dataset(
 
 
 @pytest.fixture
-def valid_bboxes_dataset_with_nan(valid_bboxes_dataset):  # in position
-    """Return a valid bboxes dataset with NaN values."""
+def valid_bboxes_dataset_with_nan(valid_bboxes_dataset):
+    """Return a valid bboxes dataset with NaN values in the position array."""
     # Set 3 NaN values in the position array for id_0
     valid_bboxes_dataset.position.loc[
         {"individuals": "id_0", "time": [3, 7, 8]}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -395,13 +395,13 @@ def valid_poses_dataset_with_nan(valid_poses_dataset):
 
 
 def rename_time_dimension_in_ds(valid_dataset):
-    invalid_dataset = valid_dataset.rename({"time": "tame"})
-    return invalid_dataset
+    """Return an invalid dataset with "tame" instead of "time" dimension."""
+    return valid_dataset.rename({"time": "tame"})
 
 
 def drop_position_var_in_ds(valid_dataset):
-    invalid_dataset = valid_dataset.drop_vars("position")
-    return invalid_dataset
+    """Return an invalid dataset without a "position" array."""
+    return valid_dataset.drop_vars("position")
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -265,7 +265,7 @@ def valid_bboxes_dataset(
     valid_bboxes_array,
 ):
     """Return a valid bboxes dataset with low confidence values."""
-    dim_names = MovementDataset.dim_names_per_ds_type["bboxes"]
+    dim_names = MovementDataset.dim_names["bboxes"]
 
     position_array = valid_bboxes_array["position"]
     shape_array = valid_bboxes_array["shape"]
@@ -350,7 +350,7 @@ def valid_position_array():
 @pytest.fixture
 def valid_poses_dataset(valid_position_array, request):
     """Return a valid pose tracks dataset."""
-    dim_names = MovementDataset.dim_names_per_ds_type["poses"]
+    dim_names = MovementDataset.dim_names["poses"]
     # create a multi_individual_array by default unless overridden via param
     try:
         array_format = request.param

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -390,14 +390,14 @@ def valid_poses_dataset_with_nan(valid_poses_dataset):
     return valid_poses_dataset
 
 
-def rename_time_dimension_in_ds(valid_dataset):
-    """Return an invalid dataset with "tame" instead of "time" dimension."""
-    return valid_dataset.rename({"time": "tame"})
+def rename_dimension_in_ds(valid_dataset, map_old_to_new):
+    """Return an invalid dataset with one dimension renamed."""
+    return valid_dataset.rename(map_old_to_new)
 
 
-def drop_position_var_in_ds(valid_dataset):
-    """Return an invalid dataset without a "position" array."""
-    return valid_dataset.drop_vars("position")
+def drop_position_var_in_ds(valid_dataset, var_name: str | list):
+    """Return an invalid dataset without one or more data variable arrays."""
+    return valid_dataset.drop_vars(var_name)
 
 
 @pytest.fixture
@@ -415,25 +415,45 @@ def empty_dataset():
 @pytest.fixture
 def missing_var_poses_dataset(valid_poses_dataset):
     """Return a poses dataset missing position variable."""
-    return drop_position_var_in_ds(valid_poses_dataset)
+    return drop_position_var_in_ds(valid_poses_dataset, var_name="position")
 
 
 @pytest.fixture
 def missing_var_bboxes_dataset(valid_bboxes_dataset):
     """Return a bboxes dataset missing position variable."""
-    return drop_position_var_in_ds(valid_bboxes_dataset)
+    return drop_position_var_in_ds(valid_bboxes_dataset, var_name="position")
+
+
+@pytest.fixture
+def missing_two_vars_bboxes_dataset(valid_bboxes_dataset):
+    """Return a bboxes dataset missing position and shape variables."""
+    return drop_position_var_in_ds(
+        valid_bboxes_dataset, var_name=["position", "shape"]
+    )
 
 
 @pytest.fixture
 def missing_dim_poses_dataset(valid_poses_dataset):
     """Return a poses dataset missing the time dimension."""
-    return rename_time_dimension_in_ds(valid_poses_dataset)
+    return rename_dimension_in_ds(
+        valid_poses_dataset, map_old_to_new={"time": "tame"}
+    )
 
 
 @pytest.fixture
 def missing_dim_bboxes_dataset(valid_bboxes_dataset):
     """Return a bboxes dataset missing the time dimension."""
-    return rename_time_dimension_in_ds(valid_bboxes_dataset)
+    return rename_dimension_in_ds(
+        valid_bboxes_dataset, map_old_to_new={"time": "tame"}
+    )
+
+
+@pytest.fixture
+def missing_two_dims_bboxes_dataset(valid_bboxes_dataset):
+    """Return a bboxes dataset missing the time and space dimensions."""
+    return rename_dimension_in_ds(
+        valid_bboxes_dataset, map_old_to_new={"time": "tame", "space": "spice"}
+    )
 
 
 @pytest.fixture(params=["displacement", "velocity", "acceleration"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -248,9 +248,10 @@ def valid_bboxes_array():
     confidence[idx_start : idx_start + 3, 0] = 0.1
     confidence[idx_start : idx_start + 2, 1] = 0.1
 
-    assert np.sum(confidence == 0.1) == 5
+    # assert that there are 5 confidence values
+    # below the default threshold
+    assert np.sum(confidence < 0.6) == 5
 
-    # return dict
     return {
         "position": position,
         "shape": shape,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -295,6 +295,21 @@ def valid_bboxes_dataset(
 
 
 @pytest.fixture
+def valid_bboxes_dataset_in_seconds(valid_bboxes_dataset):
+    """Return a valid bboxes dataset with time in seconds.
+
+    The origin of time is assumed to be time = frame 0 = 0 seconds.
+    """
+    assert valid_bboxes_dataset.attrs["time_unit"] == "frames"
+
+    fps = 60
+    valid_bboxes_dataset["time"] = valid_bboxes_dataset.time / fps
+    valid_bboxes_dataset.attrs["time_unit"] = "seconds"
+    valid_bboxes_dataset.attrs["fps"] = fps
+    return valid_bboxes_dataset
+
+
+@pytest.fixture
 def valid_bboxes_dataset_with_nan(valid_bboxes_dataset):
     """Return a valid bboxes dataset with NaN values in the position array."""
     # Set 3 NaN values in the position array for id_0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -248,10 +248,6 @@ def valid_bboxes_array():
     confidence[idx_start : idx_start + 3, 0] = 0.1
     confidence[idx_start : idx_start + 2, 1] = 0.1
 
-    # assert that there are 5 confidence values
-    # below the default threshold
-    assert np.sum(confidence < 0.6) == 5
-
     return {
         "position": position,
         "shape": shape,
@@ -264,7 +260,9 @@ def valid_bboxes_array():
 def valid_bboxes_dataset(
     valid_bboxes_array,
 ):
-    """Return a valid bboxes dataset with low confidence values."""
+    """Return a valid bboxes dataset with low confidence values and
+    time in frames.
+    """
     dim_names = MovementDataset.dim_names["bboxes"]
 
     position_array = valid_bboxes_array["position"]
@@ -300,8 +298,6 @@ def valid_bboxes_dataset_in_seconds(valid_bboxes_dataset):
 
     The origin of time is assumed to be time = frame 0 = 0 seconds.
     """
-    assert valid_bboxes_dataset.attrs["time_unit"] == "frames"
-
     fps = 60
     valid_bboxes_dataset["time"] = valid_bboxes_dataset.time / fps
     valid_bboxes_dataset.attrs["time_unit"] = "seconds"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -390,16 +390,6 @@ def valid_poses_dataset_with_nan(valid_poses_dataset):
     return valid_poses_dataset
 
 
-def rename_dimension_in_ds(valid_dataset, map_old_to_new):
-    """Return an invalid dataset with one dimension renamed."""
-    return valid_dataset.rename(map_old_to_new)
-
-
-def drop_position_var_in_ds(valid_dataset, var_name: str | list):
-    """Return an invalid dataset without one or more data variable arrays."""
-    return valid_dataset.drop_vars(var_name)
-
-
 @pytest.fixture
 def not_a_dataset():
     """Return data that is not a pose tracks dataset."""
@@ -415,45 +405,37 @@ def empty_dataset():
 @pytest.fixture
 def missing_var_poses_dataset(valid_poses_dataset):
     """Return a poses dataset missing position variable."""
-    return drop_position_var_in_ds(valid_poses_dataset, var_name="position")
+    return valid_poses_dataset.drop_vars("position")
 
 
 @pytest.fixture
 def missing_var_bboxes_dataset(valid_bboxes_dataset):
     """Return a bboxes dataset missing position variable."""
-    return drop_position_var_in_ds(valid_bboxes_dataset, var_name="position")
+    return valid_bboxes_dataset.drop_vars("position")
 
 
 @pytest.fixture
 def missing_two_vars_bboxes_dataset(valid_bboxes_dataset):
     """Return a bboxes dataset missing position and shape variables."""
-    return drop_position_var_in_ds(
-        valid_bboxes_dataset, var_name=["position", "shape"]
-    )
+    return valid_bboxes_dataset.drop_vars(["position", "shape"])
 
 
 @pytest.fixture
 def missing_dim_poses_dataset(valid_poses_dataset):
     """Return a poses dataset missing the time dimension."""
-    return rename_dimension_in_ds(
-        valid_poses_dataset, map_old_to_new={"time": "tame"}
-    )
+    return valid_poses_dataset.rename({"time": "tame"})
 
 
 @pytest.fixture
 def missing_dim_bboxes_dataset(valid_bboxes_dataset):
     """Return a bboxes dataset missing the time dimension."""
-    return rename_dimension_in_ds(
-        valid_bboxes_dataset, map_old_to_new={"time": "tame"}
-    )
+    return valid_bboxes_dataset.rename({"time": "tame"})
 
 
 @pytest.fixture
 def missing_two_dims_bboxes_dataset(valid_bboxes_dataset):
     """Return a bboxes dataset missing the time and space dimensions."""
-    return rename_dimension_in_ds(
-        valid_bboxes_dataset, map_old_to_new={"time": "tame", "space": "spice"}
-    )
+    return valid_bboxes_dataset.rename({"time": "tame", "space": "spice"})
 
 
 @pytest.fixture(params=["displacement", "velocity", "acceleration"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -213,9 +213,6 @@ def sleap_file(request):
     return pytest.DATA_PATHS.get(request.param)
 
 
-# ------------ Dataset validator fixtures ---------------------------------
-
-
 @pytest.fixture
 def valid_bboxes_arrays_all_zeros():  # used for validators
     """Return a dictionary of valid zero arrays (in terms of shape) for a
@@ -235,7 +232,6 @@ def valid_bboxes_arrays_all_zeros():  # used for validators
     }
 
 
-# --------------------- Bboxes dataset fixtures ----------------------------
 @pytest.fixture
 def valid_bboxes_array():  # used for filtering
     """Return a dictionary of valid non-zero arrays for a
@@ -327,9 +323,6 @@ def valid_bboxes_dataset_with_nan(valid_bboxes_dataset):  # in position
     return valid_bboxes_dataset
 
 
-#  --------------------- Poses dataset fixtures ----------------------------
-
-
 @pytest.fixture
 def valid_position_array():
     """Return a function that generates different kinds
@@ -405,7 +398,6 @@ def valid_poses_dataset_with_nan(valid_poses_dataset):
     return valid_poses_dataset
 
 
-# -------------------- Invalid datasets fixtures ------------------------------
 def rename_time_dimension_in_ds(valid_dataset):
     invalid_dataset = valid_dataset.rename({"time": "tame"})
     return invalid_dataset
@@ -450,9 +442,6 @@ def missing_dim_poses_dataset(valid_poses_dataset):
 def missing_dim_bboxes_dataset(valid_bboxes_dataset):
     """Return a bboxes dataset missing the time dimension."""
     return rename_time_dimension_in_ds(valid_bboxes_dataset)
-
-
-# --------------------------------------------------------------------------
 
 
 @pytest.fixture(params=["displacement", "velocity", "acceleration"])

--- a/tests/test_integration/test_kinematics_vector_transform.py
+++ b/tests/test_integration/test_kinematics_vector_transform.py
@@ -16,7 +16,7 @@ class TestKinematicsVectorTransform:
         [
             ("valid_poses_dataset", does_not_raise()),
             ("valid_poses_dataset_with_nan", does_not_raise()),
-            ("missing_dim_dataset", pytest.raises(RuntimeError)),
+            ("missing_dim_poses_dataset", pytest.raises(RuntimeError)),
         ],
     )
     def test_cart_and_pol_transform(

--- a/tests/test_unit/test_kinematics.py
+++ b/tests/test_unit/test_kinematics.py
@@ -53,7 +53,7 @@ class TestKinematics:
     kinematic_test_params = [
         ("valid_poses_dataset", does_not_raise()),
         ("valid_poses_dataset_with_nan", does_not_raise()),
-        ("missing_dim_dataset", pytest.raises(AttributeError)),
+        ("missing_dim_poses_dataset", pytest.raises(AttributeError)),
     ]
 
     @pytest.mark.parametrize("ds, expected_exception", kinematic_test_params)

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -127,7 +127,7 @@ def assert_dataset(
     assert dataset.confidence.shape == dataset.position.shape[:-1]
 
     # Check the dims and coords
-    DIM_NAMES = tuple(a for a in MovementDataset.dim_names if a != "keypoints")
+    DIM_NAMES = MovementDataset.dim_names_per_ds_type["bboxes"]
     assert all([i in dataset.dims for i in DIM_NAMES])
     for d, dim in enumerate(DIM_NAMES[1:]):
         assert dataset.sizes[dim] == dataset.position.shape[d + 1]

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -127,7 +127,7 @@ def assert_dataset(
     assert dataset.confidence.shape == dataset.position.shape[:-1]
 
     # Check the dims and coords
-    DIM_NAMES = MovementDataset.dim_names_per_ds_type["bboxes"]
+    DIM_NAMES = MovementDataset.dim_names["bboxes"]
     assert all([i in dataset.dims for i in DIM_NAMES])
     for d, dim in enumerate(DIM_NAMES[1:]):
         assert dataset.sizes[dim] == dataset.position.shape[d + 1]

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -209,7 +209,7 @@ def test_from_file(source_software, fps, use_frame_numbers_from_file):
 
 @pytest.mark.parametrize("fps", [None, 30, 60.0])
 @pytest.mark.parametrize("use_frame_numbers_from_file", [True, False])
-def test_from_VIA_tracks_file(
+def test_from_via_tracks_file(
     via_tracks_file, fps, use_frame_numbers_from_file
 ):
     """Test that loading tracked bounding box data from

--- a/tests/test_unit/test_load_poses.py
+++ b/tests/test_unit/test_load_poses.py
@@ -78,7 +78,7 @@ class TestLoadPoses:
         assert dataset.position.ndim == 4
         assert dataset.confidence.shape == dataset.position.shape[:-1]
         # Check the dims and coords
-        DIM_NAMES = MovementDataset.dim_names
+        DIM_NAMES = MovementDataset.dim_names_per_ds_type["poses"]
         assert all([i in dataset.dims for i in DIM_NAMES])
         for d, dim in enumerate(DIM_NAMES[1:]):
             assert dataset.sizes[dim] == dataset.position.shape[d + 1]

--- a/tests/test_unit/test_load_poses.py
+++ b/tests/test_unit/test_load_poses.py
@@ -78,7 +78,7 @@ class TestLoadPoses:
         assert dataset.position.ndim == 4
         assert dataset.confidence.shape == dataset.position.shape[:-1]
         # Check the dims and coords
-        DIM_NAMES = MovementDataset.dim_names_per_ds_type["poses"]
+        DIM_NAMES = MovementDataset.dim_names["poses"]
         assert all([i in dataset.dims for i in DIM_NAMES])
         for d, dim in enumerate(DIM_NAMES[1:]):
             assert dataset.sizes[dim] == dataset.position.shape[d + 1]

--- a/tests/test_unit/test_move_accessor.py
+++ b/tests/test_unit/test_move_accessor.py
@@ -77,6 +77,11 @@ def test_invalid_move_method_call(valid_dataset, method, request):
             "",
         ),
         (
+            "valid_bboxes_dataset_in_seconds",
+            does_not_raise(),
+            "",
+        ),
+        (
             "missing_dim_poses_dataset",
             pytest.raises(ValueError),
             "The dataset does not contain valid poses. "

--- a/tests/test_unit/test_move_accessor.py
+++ b/tests/test_unit/test_move_accessor.py
@@ -4,36 +4,50 @@ import pytest
 import xarray as xr
 
 
-class TestMovementDataset:
-    """Test suite for the MovementDataset class."""
+@pytest.mark.parametrize(
+    "valid_dataset", ("valid_poses_dataset", "valid_bboxes_dataset")
+)
+def test_compute_kinematics_with_valid_dataset(
+    valid_dataset, kinematic_property, request
+):
+    """Test that computing a kinematic property of a valid
+    poses or bounding boxes dataset via accessor methods returns
+    an instance of xr.DataArray.
+    """
+    valid_input_dataset = request.getfixturevalue(valid_dataset)
 
-    def test_compute_kinematics_with_valid_dataset(
-        self, valid_poses_dataset, kinematic_property
-    ):
-        """Test that computing a kinematic property of a valid
-        pose dataset via accessor methods returns an instance of
-        xr.DataArray.
-        """
-        result = getattr(
-            valid_poses_dataset.move, f"compute_{kinematic_property}"
-        )()
-        assert isinstance(result, xr.DataArray)
+    result = getattr(
+        valid_input_dataset.move, f"compute_{kinematic_property}"
+    )()
+    assert isinstance(result, xr.DataArray)
 
-    def test_compute_kinematics_with_invalid_dataset(
-        self, invalid_poses_dataset, kinematic_property
-    ):
-        """Test that computing a kinematic property of an invalid
-        poses dataset via accessor methods raises the appropriate error.
-        """
-        expected_exception = (
-            RuntimeError
-            if isinstance(invalid_poses_dataset, xr.Dataset)
-            else AttributeError
-        )
-        with pytest.raises(expected_exception):
-            getattr(
-                invalid_poses_dataset.move, f"compute_{kinematic_property}"
-            )()
+
+@pytest.mark.parametrize(
+    "invalid_dataset",
+    (
+        "not_a_dataset",
+        "empty_dataset",
+        "missing_var_poses_dataset",
+        "missing_var_bboxes_dataset",
+        "missing_dim_poses_dataset",
+        "missing_dim_bboxes_dataset",
+    ),
+)
+def test_compute_kinematics_with_invalid_dataset(
+    invalid_dataset, kinematic_property, request
+):
+    """Test that computing a kinematic property of an invalid
+    poses or bounding boxes dataset via accessor methods raises
+    the appropriate error.
+    """
+    invalid_dataset = request.getfixturevalue(invalid_dataset)
+    expected_exception = (
+        RuntimeError
+        if isinstance(invalid_dataset, xr.Dataset)
+        else AttributeError
+    )
+    with pytest.raises(expected_exception):
+        getattr(invalid_dataset.move, f"compute_{kinematic_property}")()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_unit/test_move_accessor.py
+++ b/tests/test_unit/test_move_accessor.py
@@ -33,10 +33,42 @@ class TestMovementDataset:
                 invalid_poses_dataset.move, f"compute_{kinematic_property}"
             )()
 
-    @pytest.mark.parametrize(
-        "method", ["compute_invalid_property", "do_something"]
-    )
-    def test_invalid_method_call(self, valid_poses_dataset, method):
-        """Test that invalid accessor method calls raise an AttributeError."""
-        with pytest.raises(AttributeError):
-            getattr(valid_poses_dataset.move, method)()
+
+@pytest.mark.parametrize(
+    "method", ["compute_invalid_property", "do_something"]
+)
+@pytest.mark.parametrize(
+    "valid_dataset", ("valid_poses_dataset", "valid_bboxes_dataset")
+)
+def test_invalid_move_method_call(valid_dataset, method, request):
+    """Test that invalid accessor method calls raise an AttributeError."""
+    valid_input_dataset = request.getfixturevalue(valid_dataset)
+    with pytest.raises(AttributeError):
+        getattr(valid_input_dataset.move, method)()
+
+
+@pytest.mark.parametrize(
+    "invalid_dataset, log_message",
+    (
+        (
+            "missing_var_poses_dataset",
+            "Missing required data variables: ['position']",
+        ),
+        (
+            "missing_var_bboxes_dataset",
+            "Missing required dimensions: ['keypoints']",
+        ),
+        ("missing_dim_poses_dataset", "Missing required dimensions: ['time']"),
+        (
+            "missing_dim_bboxes_dataset",
+            "Missing required dimensions: ['keypoints', 'time']",
+        ),
+    ),
+)
+def test_move_validate(invalid_dataset, log_message, request):
+    """Test the validate method returns the expected message."""
+    invalid_dataset = request.getfixturevalue(invalid_dataset)
+
+    with pytest.raises(ValueError) as excinfo:
+        invalid_dataset.move.validate()
+    assert log_message in str(excinfo.value)

--- a/tests/test_unit/test_move_accessor.py
+++ b/tests/test_unit/test_move_accessor.py
@@ -64,51 +64,47 @@ def test_invalid_move_method_call(valid_dataset, method, request):
 
 
 @pytest.mark.parametrize(
-    "input_dataset, expected_exception, log_message",
+    "input_dataset, expected_exception, expected_words_in_error_message",
     (
         (
             "valid_poses_dataset",
             does_not_raise(),
-            "",
+            [],
         ),
         (
             "valid_bboxes_dataset",
             does_not_raise(),
-            "",
+            [],
         ),
         (
             "valid_bboxes_dataset_in_seconds",
             does_not_raise(),
-            "",
+            [],
         ),
         (
             "missing_dim_poses_dataset",
             pytest.raises(ValueError),
-            "The dataset does not contain valid poses. "
-            "Missing required dimensions: ['time']",
+            ["Missing required dimensions:", "time"],
         ),
         (
             "missing_dim_bboxes_dataset",
             pytest.raises(ValueError),
-            "The dataset does not contain valid bboxes. "
-            "Missing required dimensions: ['time']",
+            ["Missing required dimensions:", "time"],
         ),
         (
             "missing_var_poses_dataset",
             pytest.raises(ValueError),
-            "The dataset does not contain valid poses. "
-            "Missing required data variables: ['position']",
+            ["Missing required data variables:", "position"],
         ),
         (
             "missing_var_bboxes_dataset",
             pytest.raises(ValueError),
-            "The dataset does not contain valid bboxes. "
-            "Missing required data variables: ['position']",
+            ["Missing required data variables:", "position"],
         ),
     ),
 )
 def test_move_validate(
-    input_dataset, expected_exception, log_message, request
+    input_dataset, expected_exception, expected_words_in_error_message, request
 ):
     """Test the validate method returns the expected message."""
     input_dataset = request.getfixturevalue(input_dataset)
@@ -116,5 +112,14 @@ def test_move_validate(
     with expected_exception as excinfo:
         input_dataset.move.validate()
 
-    if log_message:
-        assert str(excinfo.value) == log_message
+    if expected_words_in_error_message:
+        assert (
+            f"The dataset does not contain valid {input_dataset.ds_type}. "
+            in str(excinfo.value)
+        )
+        assert all(
+            [
+                word in str(excinfo.value)
+                for word in expected_words_in_error_message
+            ]
+        )

--- a/tests/test_unit/test_move_accessor.py
+++ b/tests/test_unit/test_move_accessor.py
@@ -64,47 +64,47 @@ def test_invalid_move_method_call(valid_dataset, method, request):
 
 
 @pytest.mark.parametrize(
-    "input_dataset, expected_exception, expected_words_in_error_message",
+    "input_dataset, expected_exception, expected_in_error_message",
     (
         (
             "valid_poses_dataset",
             does_not_raise(),
-            [],
+            "",
         ),
         (
             "valid_bboxes_dataset",
             does_not_raise(),
-            [],
+            "",
         ),
         (
             "valid_bboxes_dataset_in_seconds",
             does_not_raise(),
-            [],
+            "",
         ),
         (
             "missing_dim_poses_dataset",
             pytest.raises(ValueError),
-            ["Missing required dimensions:", "time"],
+            "Missing required dimensions: ['time']",
         ),
         (
             "missing_dim_bboxes_dataset",
             pytest.raises(ValueError),
-            ["Missing required dimensions:", "time"],
+            "Missing required dimensions: ['time']",
         ),
         (
             "missing_var_poses_dataset",
             pytest.raises(ValueError),
-            ["Missing required data variables:", "position"],
+            "Missing required data variables: ['position']",
         ),
         (
             "missing_var_bboxes_dataset",
             pytest.raises(ValueError),
-            ["Missing required data variables:", "position"],
+            "Missing required data variables: ['position']",
         ),
     ),
 )
 def test_move_validate(
-    input_dataset, expected_exception, expected_words_in_error_message, request
+    input_dataset, expected_exception, expected_in_error_message, request
 ):
     """Test the validate method returns the expected message."""
     input_dataset = request.getfixturevalue(input_dataset)
@@ -112,14 +112,9 @@ def test_move_validate(
     with expected_exception as excinfo:
         input_dataset.move.validate()
 
-    if expected_words_in_error_message:
+    if expected_in_error_message:
         assert (
             f"The dataset does not contain valid {input_dataset.ds_type}. "
             in str(excinfo.value)
         )
-        assert all(
-            [
-                word in str(excinfo.value)
-                for word in expected_words_in_error_message
-            ]
-        )
+        assert expected_in_error_message in str(excinfo.value)

--- a/tests/test_unit/test_save_poses.py
+++ b/tests/test_unit/test_save_poses.py
@@ -53,6 +53,13 @@ class TestSavePoses:
         },
     ]
 
+    invalid_poses_datasets_and_exceptions = [
+        ("not_a_dataset", ValueError),
+        ("empty_dataset", RuntimeError),
+        ("missing_var_poses_dataset", ValueError),
+        ("missing_dim_poses_dataset", ValueError),
+    ]
+
     @pytest.fixture(params=output_files)
     def output_file_params(self, request):
         """Return a dictionary containing parameters for testing saving
@@ -128,12 +135,7 @@ class TestSavePoses:
 
     @pytest.mark.parametrize(
         "invalid_poses_dataset, expected_exception",
-        (
-            ("not_a_dataset", ValueError),
-            ("empty_dataset", RuntimeError),
-            ("missing_var_poses_dataset", ValueError),
-            ("missing_dim_poses_dataset", ValueError),
-        ),
+        invalid_poses_datasets_and_exceptions,
     )
     def test_to_dlc_file_invalid_dataset(
         self, invalid_poses_dataset, expected_exception, tmp_path, request
@@ -263,12 +265,7 @@ class TestSavePoses:
 
     @pytest.mark.parametrize(
         "invalid_poses_dataset, expected_exception",
-        (
-            ("not_a_dataset", ValueError),
-            ("empty_dataset", RuntimeError),
-            ("missing_var_poses_dataset", ValueError),
-            ("missing_dim_poses_dataset", ValueError),
-        ),
+        invalid_poses_datasets_and_exceptions,
     )
     def test_to_lp_file_invalid_dataset(
         self, invalid_poses_dataset, expected_exception, tmp_path, request
@@ -296,12 +293,7 @@ class TestSavePoses:
 
     @pytest.mark.parametrize(
         "invalid_poses_dataset, expected_exception",
-        (
-            ("not_a_dataset", ValueError),
-            ("empty_dataset", RuntimeError),
-            ("missing_var_poses_dataset", ValueError),
-            ("missing_dim_poses_dataset", ValueError),
-        ),
+        invalid_poses_datasets_and_exceptions,
     )
     def test_to_sleap_analysis_file_invalid_dataset(
         self, invalid_poses_dataset, expected_exception, new_h5_file, request

--- a/tests/test_unit/test_save_poses.py
+++ b/tests/test_unit/test_save_poses.py
@@ -126,15 +126,24 @@ class TestSavePoses:
             file_path = val.get("file_path") if isinstance(val, dict) else val
             save_poses.to_dlc_file(valid_poses_dataset, file_path)
 
+    @pytest.mark.parametrize(
+        "invalid_poses_dataset, expected_exception",
+        (
+            ("not_a_dataset", ValueError),
+            ("empty_dataset", RuntimeError),
+            ("missing_var_poses_dataset", ValueError),
+            ("missing_dim_poses_dataset", ValueError),
+        ),
+    )
     def test_to_dlc_file_invalid_dataset(
-        self, invalid_poses_dataset, tmp_path
+        self, invalid_poses_dataset, expected_exception, tmp_path, request
     ):
         """Test that saving an invalid pose dataset to a valid
         DeepLabCut-style file returns the appropriate errors.
         """
-        with pytest.raises(ValueError):
+        with pytest.raises(expected_exception):
             save_poses.to_dlc_file(
-                invalid_poses_dataset,
+                request.getfixturevalue(invalid_poses_dataset),
                 tmp_path / "test.h5",
                 split_individuals=False,
             )
@@ -252,13 +261,24 @@ class TestSavePoses:
             file_path = val.get("file_path") if isinstance(val, dict) else val
             save_poses.to_lp_file(valid_poses_dataset, file_path)
 
-    def test_to_lp_file_invalid_dataset(self, invalid_poses_dataset, tmp_path):
+    @pytest.mark.parametrize(
+        "invalid_poses_dataset, expected_exception",
+        (
+            ("not_a_dataset", ValueError),
+            ("empty_dataset", RuntimeError),
+            ("missing_var_poses_dataset", ValueError),
+            ("missing_dim_poses_dataset", ValueError),
+        ),
+    )
+    def test_to_lp_file_invalid_dataset(
+        self, invalid_poses_dataset, expected_exception, tmp_path, request
+    ):
         """Test that saving an invalid pose dataset to a valid
         LightningPose-style file returns the appropriate errors.
         """
-        with pytest.raises(ValueError):
+        with pytest.raises(expected_exception):
             save_poses.to_lp_file(
-                invalid_poses_dataset,
+                request.getfixturevalue(invalid_poses_dataset),
                 tmp_path / "test.csv",
             )
 
@@ -274,15 +294,24 @@ class TestSavePoses:
             file_path = val.get("file_path") if isinstance(val, dict) else val
             save_poses.to_sleap_analysis_file(valid_poses_dataset, file_path)
 
+    @pytest.mark.parametrize(
+        "invalid_poses_dataset, expected_exception",
+        (
+            ("not_a_dataset", ValueError),
+            ("empty_dataset", RuntimeError),
+            ("missing_var_poses_dataset", ValueError),
+            ("missing_dim_poses_dataset", ValueError),
+        ),
+    )
     def test_to_sleap_analysis_file_invalid_dataset(
-        self, invalid_poses_dataset, new_h5_file
+        self, invalid_poses_dataset, expected_exception, new_h5_file, request
     ):
         """Test that saving an invalid pose dataset to a valid
         SLEAP-style file returns the appropriate errors.
         """
-        with pytest.raises(ValueError):
+        with pytest.raises(expected_exception):
             save_poses.to_sleap_analysis_file(
-                invalid_poses_dataset,
+                request.getfixturevalue(invalid_poses_dataset),
                 new_h5_file,
             )
 


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
This PR extends the `move.validate()` method to bounding boxes dataset.

**What does this PR do?**
- Extends the `validate` method of the `move` accessor to consider a bounding boxes dataset.
- Extends the current tests of the `move` accessor to cover the cases with bounding boxes dataset. To do so:
    - It adds fixtures for valid/invalid bounding boxes datasets.
	- It splits the `invalid_poses_dataset` fixture into separate fixtures. This allows us to reusue fixtures that are valid for both types of datasets (e.g., `empty_dataset`).
	- It parametrizes current tests, to extend them to valid and invalid bounding boxes datasets
	- It adds a test for the `move.validate()` method.
- Adapts other tests to the new fixtures for invalid datasets.

I am not sure I fully understand the move accessor so feel free to suggest better implementations!

## References
This came up while working on #246 - we missed the move accessor bits while implementing the bounding boxes dataset.

## How has this PR been tested?

Tests pass locally and in CI.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ n/a ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
