### PR TITLE
Pin pandas version for Py3.12 tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ license = { text = "BSD-3-Clause" }
 
 dependencies = [
   "numpy",
+  "pandas<2.2.2;python_version>='3.12'",
   "pandas",
   "h5py",
   "attrs",


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Tests are failing because with Python 3.12, a `numpy` install >=2.0.0 will conflict with the latest `pandas`.

See [here](https://github.com/numpy/numpy/issues/26710) for more details.

**What does this PR do?**
Pins `pandas` to < 2.2.2 if the Python version > 3.12 as a temporary fix.

This results in an environment with `pandas=2.2.1` and `numpy=1.26.4` .

**Questions**
- Is it clearer to pin numpy?
- Is there a better temporary fix?
- Why did this start to cause issues today?

## References

The issue in [numpy](https://github.com/numpy/numpy/issues/26710) - although it seems that the problem should have been fixed in [pandas 2.2.2](https://pandas.pydata.org/docs/whatsnew/v2.2.2.html#pandas-2-2-2-is-now-compatible-with-numpy-2-0)

## How has this PR been tested?

Tests pass locally and in CI.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?
No.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
