### PR TITLE
Fix `tox requires` section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,9 @@ check-hidden = true
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-requires = tox-conda
+requires =
+    tox-conda
+    tox-gh-actions  # See https://github.com/ymyzk/tox-gh-actions#tox-requires
 envlist = py{310,311,312}
 isolated_build = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ legacy_tox_ini = """
 [tox]
 requires =
     tox-conda
-    tox-gh-actions  # See https://github.com/ymyzk/tox-gh-actions#tox-requires
+    tox-gh-actions
 envlist = py{310,311,312}
 isolated_build = True
 


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
On CI, the tests are run on all platforms, using all Python environments.

This is because the `tox-gh-actions` plugin is not mapping correctly tox environments to Python versions specified in the CI jobs.

**What does this PR do?**
After checking the docs of `tox-gh-actions`, it seems the issue was the addition of the `tox-requires` section.

If we use this section, we need to add the `tox-gh-actions` plugin to that section too - see https://github.com/ymyzk/tox-gh-actions#tox-requires.

Note that the jobs running tests on Python 3.12 will fail unless the fix in PR #259 is implemented.

## References

Fixes #260.

## How has this PR been tested?

If the fix in PR #259 is implemented, tests pass in CI and are not repeated per platform.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [ n/a ] Tests have been added to cover all new functionality
- [ n/a ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
