### PR TITLE
Remove monospace formatting from 'movement' on website

### DIFF
--- a/docs/source/getting_started/input_output.md
+++ b/docs/source/getting_started/input_output.md
@@ -4,20 +4,20 @@
 (target-formats)=
 ## Supported formats
 (target-supported-formats)=
-`movement` supports the analysis of trajectories of keypoints (_pose tracks_) and of bounding boxes' centroids (_bounding boxes' tracks_).
+movement supports the analysis of trajectories of keypoints (_pose tracks_) and of bounding boxes' centroids (_bounding boxes' tracks_).
 
-To analyse pose tracks, `movement` supports loading data from various frameworks:
+To analyse pose tracks, movement supports loading data from various frameworks:
 - [DeepLabCut](dlc:) (DLC)
 - [SLEAP](sleap:) (SLEAP)
 - [LightingPose](lp:) (LP)
 
-To analyse bounding boxes' tracks, `movement` currently supports the [VGG Image Annotator](via:) (VIA) format for [tracks annotation](via:docs/face_track_annotation.html).
+To analyse bounding boxes' tracks, movement currently supports the [VGG Image Annotator](via:) (VIA) format for [tracks annotation](via:docs/face_track_annotation.html).
 
 :::{note}
-At the moment `movement` only deals with tracked data: either keypoints or bounding boxes whose identities are known from one frame to the next, for a consecutive set of frames. For the pose estimation case, this means it only deals with the predictions output by the software packages above. It currently does not support loading manually labelled data (since this is most often defined over a non-continuous set of frames).
+At the moment movement only deals with tracked data: either keypoints or bounding boxes whose identities are known from one frame to the next, for a consecutive set of frames. For the pose estimation case, this means it only deals with the predictions output by the software packages above. It currently does not support loading manually labelled data (since this is most often defined over a non-continuous set of frames).
 :::
 
-Below we explain how you can load pose tracks and bounding boxes' tracks into `movement`, and how you can export a `movement` poses dataset to different file formats. You can also try `movement` out on some [sample data](target-sample-data)
+Below we explain how you can load pose tracks and bounding boxes' tracks into movement, and how you can export a [movement poses dataset](target-poses-and-bboxes-dataset) to different file formats. You can also try movement out on some [sample data](target-sample-data)
 included with the package.
 
 
@@ -168,7 +168,7 @@ For more information on the bounding boxes data structure, see the [movement bou
 formats, including DeepLabCut-style files (.h5 or .csv) and
 [SLEAP-style analysis files](sleap:tutorials/analysis) (.h5).
 
-To export pose tracks from `movement`, first import the {mod}`movement.io.save_poses` module:
+To export pose tracks from movement, first import the {mod}`movement.io.save_poses` module:
 
 ```python
 from movement.io import save_poses
@@ -232,7 +232,7 @@ save_poses.to_dlc_file(ds, "/path/to/file.csv", split_individuals=True)
 (target-saving-bboxes-tracks)=
 ## Saving bounding boxes' tracks
 
-We currently do not provide explicit methods to export a movement bounding boxes dataset in a specific format. However, you can easily save the bounding boxes' trajectories to a .csv file using the standard Python library `csv`.
+We currently do not provide explicit methods to export a [movement bounding boxes dataset](target-poses-and-bboxes-dataset) in a specific format. However, you can easily save the bounding boxes' trajectories to a .csv file using the standard Python library `csv`.
 
 Here is an example of how you can save a bounding boxes dataset to a .csv file:
 
@@ -256,4 +256,4 @@ with open(filepath, mode="w", newline="") as file:
             writer.writerow([frame, individual, x, y, width, height, confidence])
 
 ```
-Alternatively, we can convert the `movement` bounding boxes' dataset to a pandas DataFrame with the {func}`.xarray.DataArray.to_dataframe()` method, wrangle the dataframe as required, and then apply the {func}`.pandas.DataFrame.to_csv()` method to save the data as a .csv file.
+Alternatively, we can convert the [movement bounding boxes dataset](target-poses-and-bboxes-dataset) to a pandas DataFrame with the {func}`.xarray.DataArray.to_dataframe()` method, wrangle the dataframe as required, and then apply the {func}`.pandas.DataFrame.to_csv()` method to save the data as a .csv file.

--- a/docs/source/getting_started/movement_dataset.md
+++ b/docs/source/getting_started/movement_dataset.md
@@ -1,17 +1,17 @@
 (target-poses-and-bboxes-dataset)=
 # The movement datasets
 
-In `movement`, poses or bounding boxes' tracks are represented
+In movement, poses or bounding boxes' tracks are represented
 as an {class}`xarray.Dataset` object.
 
 An {class}`xarray.Dataset` object is a container for multiple arrays. Each array is an {class}`xarray.DataArray` object holding different aspects of the collected data (position, time, confidence scores...). You can think of a {class}`xarray.DataArray` object as a multi-dimensional {class}`numpy.ndarray`
 with pandas-style indexing and labelling.
 
-So a `movement` dataset is simply an {class}`xarray.Dataset` with a specific
-structure to represent pose tracks or bounding boxes' tracks. Because pose data and bounding boxes data are somewhat different, `movement` provides two types of datasets: `poses` datasets and `bboxes` datasets.
+So a movement dataset is simply an {class}`xarray.Dataset` with a specific
+structure to represent pose tracks or bounding boxes' tracks. Because pose data and bounding boxes data are somewhat different, movement provides two types of datasets: `poses` datasets and `bboxes` datasets.
 
-To discuss the specifics of both types of `movement` datasets, it is useful to clarify some concepts such as **data variables**, **dimensions**,
-**coordinates** and **attributes**. In the next section, we will describe these concepts and the `movement` datasets' structure in some detail.
+To discuss the specifics of both types of movement datasets, it is useful to clarify some concepts such as **data variables**, **dimensions**,
+**coordinates** and **attributes**. In the next section, we will describe these concepts and the movement datasets' structure in some detail.
 
 To learn more about `xarray` data structures in general, see the relevant
 [documentation](xarray:user-guide/data-structures.html).
@@ -21,7 +21,7 @@ To learn more about `xarray` data structures in general, see the relevant
 
 ![](../_static/dataset_structure.png)
 
-The structure of a `movement` dataset `ds` can be easily inspected by simply
+The structure of a movement dataset `ds` can be easily inspected by simply
 printing it.
 
 ::::{tab-set}
@@ -109,7 +109,7 @@ the labelled "ticks" along each axis are called **coordinates** (`coords`).
 
 ::::{tab-set}
 :::{tab-item} Poses dataset
-A `movement` poses dataset has the following **dimensions**:
+A movement poses dataset has the following **dimensions**:
 - `time`, with size equal to the number of frames in the video.
 - `individuals`, with size equal to the number of tracked individuals/instances.
 - `keypoints`, with size equal to the number of tracked keypoints per individual.
@@ -117,7 +117,7 @@ A `movement` poses dataset has the following **dimensions**:
 :::
 
 :::{tab-item} Bounding boxes' dataset
-A `movement` bounding boxes dataset has the following **dimensions**s:
+A movement bounding boxes dataset has the following **dimensions**s:
 - `time`, with size equal to the number of frames in the video.
 - `individuals`, with size equal to the number of tracked individuals/instances.
 - `space`, which is the number of spatial dimensions. Currently, we support only 2D bounding boxes data.
@@ -132,19 +132,19 @@ In both cases, appropriate **coordinates** are assigned to each **dimension**.
 - `time` is labelled in seconds if `fps` is provided, otherwise the **coordinates** are expressed in frames (ascending 0-indexed integers).
 
 ### Data variables
-The data variables in a `movement` dataset are the arrays that hold the actual data, as {class}`xarray.DataArray` objects.
+The data variables in a movement dataset are the arrays that hold the actual data, as {class}`xarray.DataArray` objects.
 
-The specific data variables stored are slightly different between a `movement` poses dataset and a `movement` bounding boxes dataset.
+The specific data variables stored are slightly different between a movement poses dataset and a movement bounding boxes dataset.
 
 ::::{tab-set}
 :::{tab-item} Poses dataset
-A `movement` poses dataset contains two **data variables**:
+A movement poses dataset contains two **data variables**:
 - `position`: the 2D or 3D locations of the keypoints over time, with shape (`time`, `individuals`, `keypoints`, `space`).
 - `confidence`: the confidence scores associated with each predicted keypoint (as reported by the pose estimation model), with shape (`time`, `individuals`, `keypoints`).
 :::
 
 :::{tab-item} Bounding boxes' dataset
-A `movement` bounding boxes dataset contains three **data variables**:
+A movement bounding boxes dataset contains three **data variables**:
 - `position`: the 2D locations of the bounding boxes' centroids over time, with shape (`time`, `individuals`, `space`).
 - `shape`: the width and height of the bounding boxes over time, with shape (`time`, `individuals`, `space`).
 - `confidence`: the confidence scores associated with each predicted bounding box, with shape (`time`, `individuals`).
@@ -157,9 +157,9 @@ share some common **dimensions**.
 
 ### Attributes
 
-Both poses and bounding boxes datasets in `movement` have associated metadata. These can be stored as dataset **attributes** (i.e. inside the specially designated `attrs` dictionary) in the form of key-value pairs.
+Both poses and bounding boxes datasets in movement have associated metadata. These can be stored as dataset **attributes** (i.e. inside the specially designated `attrs` dictionary) in the form of key-value pairs.
 
-Right after loading a `movement` dataset, the following **attributes** are created:
+Right after loading a movement dataset, the following **attributes** are created:
 - `fps`: the number of frames per second in the video. If not provided, it is set to `None`.
 - `time_unit`: the unit of the `time` **coordinates** (either `frames` or `seconds`).
 - `source_software`: the software that produced the pose or bounding boxes tracks.
@@ -167,7 +167,7 @@ Right after loading a `movement` dataset, the following **attributes** are creat
 - `ds_type`: the type of dataset loaded (either `poses` or `bboxes`).
 
 Some of the [sample datasets](target-sample-data) provided with
-the `movement` package have additional **attributes**, such as:
+the movement package have additional **attributes**, such as:
 - `video_path`: the path to the video file corresponding to the pose tracks.
 - `frame_path`: the path to a single still frame from the video.
 
@@ -180,7 +180,7 @@ ds.attrs["frame_offset"] = 142
 
 ### Using xarray's built-in functionality
 
-Since a `movement` dataset is an {class}`xarray.Dataset`, you can use all of `xarray`'s intuitive interface
+Since a movement dataset is an {class}`xarray.Dataset`, you can use all of `xarray`'s intuitive interface
 and rich built-in functionalities for data manipulation and analysis.
 
 For example, you can:
@@ -221,8 +221,8 @@ position = ds.position.sel(
 
 ### Accessing movement-specific functionality
 
-`movement` extends `xarray`'s functionality with a number of convenience
-methods that are specific to `movement` datasets. These `movement`-specific methods are accessed using the
+movement extends `xarray`'s functionality with a number of convenience
+methods that are specific to movement datasets. These movement-specific methods are accessed using the
 `move` keyword.
 
 For example, to compute the velocity and acceleration vectors for all individuals and keypoints across time, we provide the `move.compute_velocity` and `move.compute_acceleration` methods:
@@ -232,7 +232,7 @@ velocity = ds.move.compute_velocity()
 acceleration = ds.move.compute_acceleration()
 ```
 
-The `movement`-specific functionalities are implemented in the
+The movement-specific functionalities are implemented in the
 {class}`movement.move_accessor.MovementDataset` class, which is an [accessor](https://docs.xarray.dev/en/stable/internals/extending-xarray.html) to the
 underlying {class}`xarray.Dataset` object. Defining a custom accessor is convenient
 to avoid conflicts with `xarray`'s built-in methods.
@@ -243,7 +243,7 @@ The `velocity` and `acceleration` produced in the above example are {class}`xarr
 original `position` **data variable**.
 
 In some cases, you may wish to
-add these or other new **data variables** to the `movement` dataset for
+add these or other new **data variables** to the movement dataset for
 convenience. This can be done by simply assigning them to the dataset
 with an appropriate name:
 

--- a/docs/source/getting_started/sample_data.md
+++ b/docs/source/getting_started/sample_data.md
@@ -1,7 +1,7 @@
 (target-sample-data)=
 # Sample data
 
-`movement` includes some sample data files that you can use to
+movement includes some sample data files that you can use to
 try the package out. These files contain pose and bounding boxes' tracks from
 various [supported formats](target-supported-formats).
 
@@ -50,5 +50,5 @@ and its path is stored in the `frame_path` attribute
 :color: info
 :icon: info
 When you import the `sample_data` module with `from movement import sample_data`,
-`movement` downloads a small metadata file to your local machine with information about the latest sample datasets available. Then, the first time you call the `fetch_dataset()` function, `movement` downloads the requested file to your machine and caches it in the `~/.movement/data` directory. On subsequent calls, the data are directly loaded from this local cache.
+movement downloads a small metadata file to your local machine with information about the latest sample datasets available. Then, the first time you call the `fetch_dataset()` function, movement downloads the requested file to your machine and caches it in the `~/.movement/data` directory. On subsequent calls, the data are directly loaded from this local cache.
 :::

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -3,4 +3,4 @@
 Examples
 ========
 
-Below is a gallery of examples using ``movement``.
+Below is a gallery of examples using movement.

--- a/examples/compute_polar_coordinates.py
+++ b/examples/compute_polar_coordinates.py
@@ -393,7 +393,7 @@ fig.show()
 # %%
 # Convert polar coordinates to cartesian
 # ------------------------------------------
-# ``movement`` also provides a ``pol2cart`` convenience function to transform
+# movement also provides a ``pol2cart`` convenience function to transform
 # a vector in polar coordinates back to cartesian.
 head_vector_cart = pol2cart(head_vector_polar)
 

--- a/examples/load_and_explore_poses.py
+++ b/examples/load_and_explore_poses.py
@@ -24,7 +24,7 @@ from movement.io import load_poses
 
 # %%
 # For the sake of this example, we will use the path to one of
-# the sample datasets provided with ``movement``.
+# the sample datasets provided in movement.
 
 file_path = sample_data.fetch_dataset_paths(
     "SLEAP_three-mice_Aeon_proofread.analysis.h5"


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
While working on #264 I noticed on the website, we sometimes use `movement`, but more often we use the un-styled 'movement'. Perhaps we could stick with the latter which simplifies the documentation process (NumPy and pandas do this as well).

**What does this PR do?**
This PR removes monospace formatting from 'movement' on the website (mostly .md files, except for the examples .py files). The monospace-formatting in the docstrings (API reference) remains unchanged.

## How has this PR been tested?
Docs built locally and on CI

## Notes
This PR is branched off #264 and needs rebasing.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
