### PR TITLE
Revert "Pin pandas version for Py3.12 tests"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ license = { text = "BSD-3-Clause" }
 
 dependencies = [
   "numpy",
-  "pandas<2.2.2;python_version>='3.12'",
   "pandas",
   "h5py",
   "attrs",


### PR DESCRIPTION
Reverts neuroinformatics-unit/movement#259 since pytables made [a new release](https://github.com/PyTables/PyTables/releases/tag/v3.10.0) that should be compatible with numpy > 2.0

Fixes #263  