### PR TITLE
Remove `defaults` from test_and_deploy.yml

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           auto-update-conda: true
-          channels: conda-forge
+          channels: conda-forge,nodefaults
           activate-environment: movement-env
       - uses: neuroinformatics-unit/actions/test@v2
         with:


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
We are currently using the `defaults` channel in our actions, which from Aug2024 [is not free to use for our case](https://www.anaconda.com/blog/is-conda-free)

**What does this PR do?**
Add `nodefaults` channel to prevent from using the `defaults` channel. See [docs](https://docs.conda.io/projects/conda/en/4.6.1/user-guide/tasks/manage-environments.html#:~:text=You%20can%20exclude%20the%20default%20channels%20by%20adding%20nodefaults%20to%20the%20channels%20list.)

## References

\

## How has this PR been tested?

The CI in this PR shows the `default` channel is omitted.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

Should we include this in our docs for our users?

## Checklist:

- [ n/a ] The code has been tested locally
- [ n/a ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
