### PR TITLE
Implement `compute_speed` and `compute_path_length`

### DIFF
--- a/movement/kinematics.py
+++ b/movement/kinematics.py
@@ -184,15 +184,15 @@ def compute_speed(data: xr.DataArray) -> xr.DataArray:
     Parameters
     ----------
     data : xarray.DataArray
-        The input data containing position information in Cartesian
-        coordinates, with ``time`` and ``space`` as dimensions.
+        The input data containing position information, with ``time``
+        and ``space`` (in Cartesian coordinates) as required dimensions.
 
     Returns
     -------
     xarray.DataArray
-        An xarray DataArray containing the computed speed. Will have
-        the same dimensions as the input data, except for ``space``
-        which will be removed.
+        An xarray DataArray containing the computed speed,
+        with dimensions matching those of the input data, 
+        except ``space`` is removed.
 
     """
     return compute_norm(compute_velocity(data))
@@ -720,13 +720,13 @@ def compute_path_length(
     Parameters
     ----------
     data : xarray.DataArray
-        The input data containing position information in Cartesian
-        coordinates, with ``time`` and ``space`` among the dimensions.
+        The input data containing position information, with ``time``
+        and ``space`` (in Cartesian coordinates) as required dimensions.
     start : float, optional
-        The time to consider as the path's starting point. If None (default),
+        The start time of the path. If None (default),
         the minimum time coordinate in the data is used.
     stop : float, optional
-        The time to consider as the path's end point. If None (default),
+        The end time of the path. If None (default),
         the maximum time coordinate in the data is used.
     nan_policy : Literal["drop", "scale"], optional
         Policy to handle NaN (missing) values. Can be one of the ``"drop"``
@@ -739,15 +739,15 @@ def compute_path_length(
     Returns
     -------
     xarray.DataArray
-        An xarray DataArray containing the computed path length.
-        Will have the same dimensions as the input data, except for ``time``
-        and ``space`` which will be removed.
+        An xarray DataArray containing the computed path length,
+        with dimensions matching those of the input data, 
+        except ``time`` and ``space`` are removed.
 
     Notes
     -----
     Choosing ``nan_policy="drop"`` will drop NaN values from each point track
     before computing path length. This equates to assuming that a track
-    follows a straight line between two valid points flanking a missing
+    follows a straight line between two valid points adjacent to a missing
     segment. Missing segments at the beginning or end of the specified
     time range are not counted. This approach tends to underestimate
     the path length, and the error increases with the number of missing
@@ -757,8 +757,8 @@ def compute_path_length(
     the proportion of valid segments per point track. For example, if only
     80% of segments are present, the path length will be computed based on
     these and the result will be divided by 0.8. This approach assumes
-    that motion dynamics are similar across present and missing time
-    segments, which may not be the case.
+    that motion dynamics are similar across observed and missing time
+    segments, which may not accurately reflect actual conditions.
 
     """
     _validate_start_stop_times(data, start, stop)
@@ -774,9 +774,8 @@ def compute_path_length(
         raise log_error(
             ValueError,
             f"Invalid value for nan_policy: {nan_policy}. "
-            "Must be one of 'drop' or 'weight'.",
+            "Must be one of 'drop' or 'scale'.",
         )
-
 
 def _validate_start_stop_times(
     data: xr.DataArray,
@@ -855,10 +854,10 @@ def _warn_about_nan_proportion(
 
     """
     nan_warn_threshold = float(nan_warn_threshold)
-    if nan_warn_threshold < 0 or nan_warn_threshold > 1:
+    if not 0 <= nan_warn_threshold <= 1:
         raise log_error(
             ValueError,
-            "nan_warn_threshold must be a number between 0 and 1.",
+            "nan_warn_threshold must be between 0 and 1.",
         )
 
     n_nans = data.isnull().any(dim="space").sum(dim="time")

--- a/movement/kinematics.py
+++ b/movement/kinematics.py
@@ -870,7 +870,7 @@ def _warn_about_nan_proportion(
             "missing values. The following tracks have more than "
             f"{nan_warn_threshold * 100:.3} %) NaN values:",
         )
-        report_nan_values(data_to_warn_about)
+        print(report_nan_values(data_to_warn_about))
 
 
 def _compute_scaled_path_length(

--- a/movement/kinematics.py
+++ b/movement/kinematics.py
@@ -728,21 +728,10 @@ def compute_path_length(
     stop : float, optional
         The time to consider as the path's end point. If None (default),
         the maximum time coordinate in the data is used.
-    nan_policy : str, optional
-        Policy to handle NaN (missing) values. Can be one of the following:
-        - ``"drop"``: drop any NaN values before computing path length. This
-            is the default behavior, and it equates to assuming that a track
-            follows a straight line between two valid points flanking a missing
-            segment. Missing segments at the beginning or end of the specified
-            time range are not counted. This approach tends to underestimate
-            the path length, and the error increases with the number of missing
-            values.
-        - ``"scale"``: scale path length based on the proportion of valid
-            segments per point track. For example, if only 80% of segments
-            are present, the path length will be computed based on these
-            and the result will be divided by 0.8. This approach
-            assumes that motion dynamics are similar across present
-            and missing time segments, which may not be the case.
+    nan_policy : Literal["drop", "scale"], optional
+        Policy to handle NaN (missing) values. Can be one of the ``"drop"``
+        or ``"scale"``. Defaults to ``"drop"``. See Notes for more details
+        on the two policies.
     nan_warn_threshold : float, optional
         If more than this proportion of values are missing in any point track,
         a warning will be emitted. Defaults to 0.2 (20%).
@@ -753,6 +742,23 @@ def compute_path_length(
         An xarray DataArray containing the computed path length.
         Will have the same dimensions as the input data, except for ``time``
         and ``space`` which will be removed.
+
+    Notes
+    -----
+    Choosing ``nan_policy="drop"`` will drop NaN values from each point track
+    before computing path length. This equates to assuming that a track
+    follows a straight line between two valid points flanking a missing
+    segment. Missing segments at the beginning or end of the specified
+    time range are not counted. This approach tends to underestimate
+    the path length, and the error increases with the number of missing
+    values.
+
+    Choosing ``nan_policy="scale"`` will adjust the path length based on the
+    the proportion of valid segments per point track. For example, if only
+    80% of segments are present, the path length will be computed based on
+    these and the result will be divided by 0.8. This approach assumes
+    that motion dynamics are similar across present and missing time
+    segments, which may not be the case.
 
     """
     _validate_start_stop_times(data, start, stop)

--- a/movement/kinematics.py
+++ b/movement/kinematics.py
@@ -789,7 +789,7 @@ def compute_path_length(
             f"Invalid value for nan_policy: {nan_policy}. "
             "Must be one of 'ffill' or 'scale'.",
         )
-    
+
 
 def _warn_about_nan_proportion(
     data: xr.DataArray, nan_warn_threshold: float

--- a/movement/kinematics.py
+++ b/movement/kinematics.py
@@ -191,7 +191,7 @@ def compute_speed(data: xr.DataArray) -> xr.DataArray:
     -------
     xarray.DataArray
         An xarray DataArray containing the computed speed,
-        with dimensions matching those of the input data, 
+        with dimensions matching those of the input data,
         except ``space`` is removed.
 
     """
@@ -740,7 +740,7 @@ def compute_path_length(
     -------
     xarray.DataArray
         An xarray DataArray containing the computed path length,
-        with dimensions matching those of the input data, 
+        with dimensions matching those of the input data,
         except ``time`` and ``space`` are removed.
 
     Notes
@@ -900,7 +900,7 @@ def _compute_scaled_path_length(
     # Skip first displacement segment (always 0) to not mess up the scaling
     displacement = compute_displacement(data).isel(time=slice(1, None))
     # count number of valid displacement segments per point track
-    valid_segments = (~displacement.isnull()).any(dim="space").sum(dim="time")
+    valid_segments = (~displacement.isnull()).all(dim="space").sum(dim="time")
     # compute proportion of valid segments per point track
     valid_proportion = valid_segments / (data.sizes["time"] - 1)
     # return scaled path length

--- a/movement/kinematics.py
+++ b/movement/kinematics.py
@@ -194,7 +194,6 @@ def compute_speed(data: xr.DataArray) -> xr.DataArray:
         which will be removed.
 
     """
-    _validate_type_data_array(data)
     return compute_norm(compute_velocity(data))
 
 

--- a/movement/kinematics.py
+++ b/movement/kinematics.py
@@ -886,15 +886,15 @@ def _compute_scaled_path_length(
     Parameters
     ----------
     data : xarray.DataArray
-        The input data containing position information in Cartesian
-        coordinates, with ``time`` and ``space`` among the dimensions.
+        The input data containing position information, with ``time``
+        and ``space`` (in Cartesian coordinates) as required dimensions.
 
     Returns
     -------
     xarray.DataArray
-        An xarray DataArray containing the computed path length.
-        Will have the same dimensions as the input data, except for ``time``
-        and ``space`` which will be removed.
+        An xarray DataArray containing the computed path length,
+        with dimensions matching those of the input data,
+        except ``time`` and ``space`` are removed.
 
     """
     # Skip first displacement segment (always 0) to not mess up the scaling
@@ -921,15 +921,15 @@ def _compute_path_length_drop_nan(
     Parameters
     ----------
     data : xarray.DataArray
-        The input data containing position information in Cartesian
-        coordinates, with ``time`` and ``space`` among the dimensions.
+        The input data containing position information, with ``time``
+        and ``space`` (in Cartesian coordinates) as required dimensions.
 
     Returns
     -------
     xarray.DataArray
-        An xarray DataArray containing the computed path length.
-        Will have the same dimensions as the input data, except for ``time``
-        and ``space`` which will be removed.
+        An xarray DataArray containing the computed path length,
+        with dimensions matching those of the input data,
+        except ``time`` and ``space`` are removed.
 
     """
     # Create array for holding results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,6 @@ fix = true
 ignore = [
   "D203", # one blank line before class
   "D213", # multi-line-summary second line
-  "B905", # zip without explicit strict
 ]
 select = [
   "E",      # pycodestyle errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ fix = true
 ignore = [
   "D203", # one blank line before class
   "D213", # multi-line-summary second line
+  "B905", # zip without explicit strict
 ]
 select = [
   "E",      # pycodestyle errors

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -518,6 +518,40 @@ def valid_poses_dataset_uniform_linear_motion(
     )
 
 
+@pytest.fixture
+def valid_poses_dataset_uniform_linear_motion_with_nans(
+    valid_poses_dataset_uniform_linear_motion,
+):
+    """Return a valid poses dataset with NaN values in the position array.
+
+    Specifically, we will introducde:
+    - 1 NaN value in the centroid keypoint of individual id_1 at time=0
+    - 5 NaN values in the left keypoint of individual id_1 (frames 3-7)
+    - 10 NaN values in the right keypoint of individual id_1 (all frames)
+    """
+    valid_poses_dataset_uniform_linear_motion.position.loc[
+        {
+            "individuals": "id_1",
+            "keypoints": "centroid",
+            "time": 0,
+        }
+    ] = np.nan
+    valid_poses_dataset_uniform_linear_motion.position.loc[
+        {
+            "individuals": "id_1",
+            "keypoints": "left",
+            "time": slice(3, 7),
+        }
+    ] = np.nan
+    valid_poses_dataset_uniform_linear_motion.position.loc[
+        {
+            "individuals": "id_1",
+            "keypoints": "right",
+        }
+    ] = np.nan
+    return valid_poses_dataset_uniform_linear_motion
+
+
 # -------------------- Invalid datasets fixtures ------------------------------
 @pytest.fixture
 def not_a_dataset():

--- a/tests/test_unit/test_kinematics.py
+++ b/tests/test_unit/test_kinematics.py
@@ -277,7 +277,7 @@ def test_path_length_across_time_ranges(
     "nan_policy, expected_path_lengths_id_1, expected_exception",
     [
         (
-            "drop",
+            "ffill",
             np.array([np.sqrt(2) * 8, np.sqrt(2) * 9, np.nan]),
             does_not_raise(),
         ),
@@ -316,8 +316,8 @@ def test_path_length_with_nans(
 
     Because the underlying motion is uniform linear, the "scale" policy should
     perfectly restore the path length for individual "id_1" to its true value.
-    The "drop" policy should do likewise if frames are missing in the middle,
-    but will not count any missing frames at the edges.
+    The "ffill" policy should do likewise if frames are missing in the middle,
+    but will not "correct" for missing values at the edges.
     """
     position = valid_poses_dataset_uniform_linear_motion_with_nans.position
     with expected_exception:

--- a/tests/test_unit/test_kinematics.py
+++ b/tests/test_unit/test_kinematics.py
@@ -278,28 +278,17 @@ def test_path_length_across_time_ranges(
     [
         (
             "drop",
-            {
-                # 9 segments - 1 missing on edge
-                "centroid": np.sqrt(2) * 8,
-                # missing mid frames should have no effect
-                "left": np.sqrt(2) * 9,
-                "right": np.nan,  # all frames missing
-            },
+            np.array([np.sqrt(2) * 8, np.sqrt(2) * 9, np.nan]),
             does_not_raise(),
         ),
         (
             "scale",
-            {
-                # scaling should restore "true" path length
-                "centroid": np.sqrt(2) * 9,
-                "left": np.sqrt(2) * 9,
-                "right": np.nan,  # all frames missing
-            },
+            np.array([np.sqrt(2) * 9, np.sqrt(2) * 9, np.nan]),
             does_not_raise(),
         ),
         (
             "invalid",  # invalid value for nan_policy
-            {},
+            np.zeros(3),
             pytest.raises(ValueError, match="Invalid value for nan_policy"),
         ),
     ],
@@ -336,20 +325,12 @@ def test_path_length_with_nans(
             position,
             nan_policy=nan_policy,
         )
-        # Initialise with expected path lengths for scenario without NaNs
-        expected_array = xr.DataArray(
-            np.ones((2, 3)) * np.sqrt(2) * 9,
-            dims=["individuals", "keypoints"],
-            coords={
-                "individuals": position.coords["individuals"],
-                "keypoints": position.coords["keypoints"],
-            },
+        # Get path_length for individual "id_1" as a numpy array
+        path_length_id_1 = path_length.sel(individuals="id_1").values
+        # Check them against the expected values
+        np.testing.assert_allclose(
+            path_length_id_1, expected_path_lengths_id_1
         )
-        # insert expected path lengths for individual id_1
-        for kpt, value in expected_path_lengths_id_1.items():
-            target_loc = {"individuals": "id_1", "keypoints": kpt}
-            expected_array.loc[target_loc] = value
-        xr.testing.assert_allclose(path_length, expected_array)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_unit/test_kinematics.py
+++ b/tests/test_unit/test_kinematics.py
@@ -385,7 +385,7 @@ def test_path_length_with_nans(
     [
         (1, does_not_raise()),
         (0.2, does_not_raise()),
-        (-1, pytest.raises(ValueError, match="a number between 0 and 1")),
+        (-1, pytest.raises(ValueError, match="between 0 and 1")),
     ],
 )
 def test_path_length_warns_about_nans(

--- a/tests/test_unit/test_kinematics.py
+++ b/tests/test_unit/test_kinematics.py
@@ -289,7 +289,6 @@ def test_path_length_across_time_ranges(
             num_segments -= np.ceil(start)
         if stop is not None:
             num_segments -= 9 - np.floor(stop)
-        print("num_segments", num_segments)
 
         expected_path_length = xr.DataArray(
             np.ones((2, 3)) * np.sqrt(2) * num_segments,

--- a/tests/test_unit/test_kinematics.py
+++ b/tests/test_unit/test_kinematics.py
@@ -204,6 +204,12 @@ def test_approximate_derivative_with_invalid_order(order):
         kinematics.compute_time_derivative(data, order=order)
 
 
+time_points_value_error = pytest.raises(
+    ValueError,
+    match="At least 2 time points are required to compute path length",
+)
+
+
 @pytest.mark.parametrize(
     "start, stop, expected_exception",
     [
@@ -217,33 +223,11 @@ def test_approximate_derivative_with_invalid_order(order):
         (1, 8, does_not_raise()),
         (1.5, 8.5, does_not_raise()),
         (2, None, does_not_raise()),
-        # Empty time range (because start > stop)
-        (
-            9,
-            0,
-            pytest.raises(
-                ValueError,
-                match="At least 2 time points",
-            ),
-        ),
-        # Empty time range (because of invalid start type)
-        (
-            "text",
-            9,
-            pytest.raises(
-                ValueError,
-                match="At least 2 time points",
-            ),
-        ),
+        # Empty time ranges
+        (9, 0, time_points_value_error),  # start > stop
+        ("text", 9, time_points_value_error),  # invalid start type
         # Time range too short
-        (
-            0,
-            0.5,
-            pytest.raises(
-                ValueError,
-                match="At least 2 time points",
-            ),
-        ),
+        (0, 0.5, time_points_value_error),
     ],
 )
 def test_path_length_across_time_ranges(


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**What does this PR do?**

It introduces two new functions in the kinematics module:
- `compute_speed`: quite straightforward to implement, it just returns the norm of velocity, using existing `movement` functions
- `compute_path_length`: in theory also straightforward, as it should just be the sum of the norms of displacement vectors, but I spent a lot of time debating how to handle missing values. See extensive [discussion on zulip](https://neuroinformatics.zulipchat.com/#narrow/stream/406001-Movement/topic/Path.20length.20with.20missing.20values).

In the end I opted for providing two alternative nan policies, and emitting a warning if too many values are missing. Expand the dropdown below for more details.

<details>
<summary> compute_path_length() function signatures and docstring</summary>

```python
def compute_path_length(
    data: xr.DataArray,
    start: float | None = None,
    stop: float | None = None,
    nan_policy: Literal["drop", "scale"] = "drop",
    nan_warn_threshold: float = 0.2,
) -> xr.DataArray:
    """Compute the length of a path travelled between two time points.

    The path length is defined as the sum of the norms (magnitudes) of the
    displacement vectors between two time points ``start`` and ``stop``,
    which should be provided in the time units of the data array.
    If not specified, the minimum and maximum time coordinates of the data
    array are used as start and stop times, respectively.

    Parameters
    ----------
    data : xarray.DataArray
        The input data containing position information in Cartesian
        coordinates, with ``time`` and ``space`` among the dimensions.
    start : float, optional
        The time to consider as the path's starting point. If None (default),
        the minimum time coordinate in the data is used.
    stop : float, optional
        The time to consider as the path's end point. If None (default),
        the maximum time coordinate in the data is used.
    nan_policy : Literal["drop", "scale"], optional
        Policy to handle NaN (missing) values. Can be one of the ``"drop"``
        or ``"scale"``. Defaults to ``"drop"``. See Notes for more details
        on the two policies.
    nan_warn_threshold : float, optional
        If more than this proportion of values are missing in any point track,
        a warning will be emitted. Defaults to 0.2 (20%).

    Returns
    -------
    xarray.DataArray
        An xarray DataArray containing the computed path length.
        Will have the same dimensions as the input data, except for ``time``
        and ``space`` which will be removed.

    Notes
    -----
    Choosing ``nan_policy="drop"`` will drop NaN values from each point track
    before computing path length. This equates to assuming that a track
    follows a straight line between two valid points flanking a missing
    segment. Missing segments at the beginning or end of the specified
    time range are not counted. This approach tends to underestimate
    the path length, and the error increases with the number of missing
    values.

    Choosing ``nan_policy="scale"`` will adjust the path length based on the
    the proportion of valid segments per point track. For example, if only
    80% of segments are present, the path length will be computed based on
    these and the result will be divided by 0.8. This approach assumes
    that motion dynamics are similar across present and missing time
    segments, which may not be the case.

    """
```

</details>

I'm in two minds as to whether we need the `start` and `stop` arguments, as the user could easily select a time range using `ds.position.sel(time=slice(0, 10))`, before passing the data array to `compute_path_length()`. I've chosen to include them for now, but I'm open to counter-arguments, CC @b-peri.

## References

Closes #147 

## How has this PR been tested?

For speed, I used the existing kinematics tests (added "speed" as a parameter) with a bit of modification needed.

Testing for the path length was harder because:
- this variable lacks both time and space dimensions, so modifying existing kinematics tests to account for it would b complicated
- With the two aforementioned nan_policies, there are several tricky edge cases, and I tried to cover them all. The uniform linear motion fixture has been instrumental in helping me implement , debug and test these nan policies.
- I also had to test that the nan warning is emitted in the right scenarios and contains specific messages.

As a result I ended up adding 3 new unit tests to account for all of the above, but suggestion to streamline the tests are welcome.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

API docs should be automatically updated. We might consider mentioning the new functions in some of the examples in the future, but not necessary right now.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)