### PR TITLE
General validator function for checking dimensions and coordinates

### DIFF
--- a/movement/analysis/kinematics.py
+++ b/movement/analysis/kinematics.py
@@ -82,7 +82,10 @@ def compute_velocity(data: xr.DataArray) -> xr.DataArray:
     :meth:`xarray.DataArray.differentiate` : The underlying method used.
 
     """
-    return _compute_approximate_time_derivative(data, order=1)
+    # validate only presence of Cartesian space dimension
+    # (presence of time dimension will be checked in compute_time_derivative)
+    validate_dims_coords(data, {"space": []})
+    return compute_time_derivative(data, order=1)
 
 
 def compute_acceleration(data: xr.DataArray) -> xr.DataArray:
@@ -119,12 +122,13 @@ def compute_acceleration(data: xr.DataArray) -> xr.DataArray:
     :meth:`xarray.DataArray.differentiate` : The underlying method used.
 
     """
-    return _compute_approximate_time_derivative(data, order=2)
+    # validate only presence of Cartesian space dimension
+    # (presence of time dimension will be checked in compute_time_derivative)
+    validate_dims_coords(data, {"space": []})
+    return compute_time_derivative(data, order=2)
 
 
-def _compute_approximate_time_derivative(
-    data: xr.DataArray, order: int
-) -> xr.DataArray:
+def compute_time_derivative(data: xr.DataArray, order: int) -> xr.DataArray:
     """Compute the time-derivative of an array using numerical differentiation.
 
     This function uses :meth:`xarray.DataArray.differentiate`,
@@ -134,8 +138,7 @@ def _compute_approximate_time_derivative(
     Parameters
     ----------
     data : xarray.DataArray
-        The input data containing ``time`` and ``space`` (in Cartesian
-        coordinates) as required dimensions.
+        The input data containing ``time`` as a required dimension.
     order : int
         The order of the time-derivative. For an input containing position
         data, use 1 to compute velocity, and 2 to compute acceleration. Value
@@ -144,8 +147,11 @@ def _compute_approximate_time_derivative(
     Returns
     -------
     xarray.DataArray
-        An xarray DataArray containing the time-derivative of the
-        input data.
+        An xarray DataArray containing the time-derivative of the input data.
+
+    See Also
+    --------
+    :meth:`xarray.DataArray.differentiate` : The underlying method used.
 
     """
     if not isinstance(order, int):
@@ -154,7 +160,7 @@ def _compute_approximate_time_derivative(
         )
     if order <= 0:
         raise log_error(ValueError, "Order must be a positive integer.")
-    validate_dims_coords(data, {"time": [], "space": []})
+    validate_dims_coords(data, {"time": []})
     result = data
     for _ in range(order):
         result = result.differentiate("time")

--- a/movement/analysis/kinematics.py
+++ b/movement/analysis/kinematics.py
@@ -43,7 +43,7 @@ def compute_displacement(data: xr.DataArray) -> xr.DataArray:
     height per bounding box, between consecutive time points.
 
     """
-    validate_dims_coords(data, {"time": [], "space": ["x", "y"]})
+    validate_dims_coords(data, {"time": [], "space": []})
     result = data.diff(dim="time")
     result = result.reindex(data.coords, fill_value=0)
     return result
@@ -154,7 +154,7 @@ def _compute_approximate_time_derivative(
         )
     if order <= 0:
         raise log_error(ValueError, "Order must be a positive integer.")
-    validate_dims_coords(data, {"time": [], "space": ["x", "y"]})
+    validate_dims_coords(data, {"time": [], "space": []})
     result = data
     for _ in range(order):
         result = result.differentiate("time")

--- a/movement/analysis/kinematics.py
+++ b/movement/analysis/kinematics.py
@@ -3,6 +3,7 @@
 import xarray as xr
 
 from movement.utils.logging import log_error
+from movement.validators.arrays import validate_dimension_coordinates
 
 
 def compute_displacement(data: xr.DataArray) -> xr.DataArray:
@@ -42,7 +43,7 @@ def compute_displacement(data: xr.DataArray) -> xr.DataArray:
     height per bounding box, between consecutive time points.
 
     """
-    _validate_time_dimension(data)
+    validate_dimension_coordinates(data, {"time": []})
     result = data.diff(dim="time")
     result = result.reindex(data.coords, fill_value=0)
     return result
@@ -152,30 +153,8 @@ def _compute_approximate_time_derivative(
         )
     if order <= 0:
         raise log_error(ValueError, "Order must be a positive integer.")
-
-    _validate_time_dimension(data)
-
+    validate_dimension_coordinates(data, {"time": []})
     result = data
     for _ in range(order):
         result = result.differentiate("time")
     return result
-
-
-def _validate_time_dimension(data: xr.DataArray) -> None:
-    """Validate the input data contains a ``time`` dimension.
-
-    Parameters
-    ----------
-    data : xarray.DataArray
-        The input data to validate.
-
-    Raises
-    ------
-    ValueError
-        If the input data does not contain a ``time`` dimension.
-
-    """
-    if "time" not in data.dims:
-        raise log_error(
-            ValueError, "Input data must contain 'time' as a dimension."
-        )

--- a/movement/analysis/kinematics.py
+++ b/movement/analysis/kinematics.py
@@ -79,7 +79,7 @@ def compute_velocity(data: xr.DataArray) -> xr.DataArray:
 
     See Also
     --------
-    :meth:`xarray.DataArray.differentiate` : The underlying method used.
+    compute_time_derivative : The underlying function used.
 
     """
     # validate only presence of Cartesian space dimension
@@ -119,7 +119,7 @@ def compute_acceleration(data: xr.DataArray) -> xr.DataArray:
 
     See Also
     --------
-    :meth:`xarray.DataArray.differentiate` : The underlying method used.
+    compute_time_derivative : The underlying function used.
 
     """
     # validate only presence of Cartesian space dimension

--- a/movement/analysis/kinematics.py
+++ b/movement/analysis/kinematics.py
@@ -19,8 +19,8 @@ def compute_displacement(data: xr.DataArray) -> xr.DataArray:
     Parameters
     ----------
     data : xarray.DataArray
-        The input data array containing position vectors in cartesian
-        coordinates, with ``time`` as a dimension.
+        The input data containing position information, with ``time``
+        and ``space`` (in Cartesian coordinates) as required dimensions.
 
     Returns
     -------
@@ -43,7 +43,7 @@ def compute_displacement(data: xr.DataArray) -> xr.DataArray:
     height per bounding box, between consecutive time points.
 
     """
-    validate_dimension_coordinates(data, {"time": []})
+    validate_dimension_coordinates(data, {"time": [], "space": ["x", "y"]})
     result = data.diff(dim="time")
     result = result.reindex(data.coords, fill_value=0)
     return result
@@ -59,8 +59,8 @@ def compute_velocity(data: xr.DataArray) -> xr.DataArray:
     Parameters
     ----------
     data : xarray.DataArray
-        The input data array containing position vectors in cartesian
-        coordinates, with ``time`` as a dimension.
+        The input data containing position information, with ``time``
+        and ``space`` (in Cartesian coordinates) as required dimensions.
 
     Returns
     -------
@@ -95,8 +95,8 @@ def compute_acceleration(data: xr.DataArray) -> xr.DataArray:
     Parameters
     ----------
     data : xarray.DataArray
-        The input data array containing position vectors in cartesian
-        coordinates, with``time`` as a dimension.
+        The input data containing position information, with ``time``
+        and ``space`` (in Cartesian coordinates) as required dimensions.
 
     Returns
     -------
@@ -134,7 +134,8 @@ def _compute_approximate_time_derivative(
     Parameters
     ----------
     data : xarray.DataArray
-        The input data array containing ``time`` as a dimension.
+        The input data containing ``time`` and ``space`` (in Cartesian
+        coordinates) as required dimensions.
     order : int
         The order of the time-derivative. For an input containing position
         data, use 1 to compute velocity, and 2 to compute acceleration. Value
@@ -153,7 +154,7 @@ def _compute_approximate_time_derivative(
         )
     if order <= 0:
         raise log_error(ValueError, "Order must be a positive integer.")
-    validate_dimension_coordinates(data, {"time": []})
+    validate_dimension_coordinates(data, {"time": [], "space": ["x", "y"]})
     result = data
     for _ in range(order):
         result = result.differentiate("time")

--- a/movement/analysis/kinematics.py
+++ b/movement/analysis/kinematics.py
@@ -3,7 +3,7 @@
 import xarray as xr
 
 from movement.utils.logging import log_error
-from movement.validators.arrays import validate_dimension_coordinates
+from movement.validators.arrays import validate_dims_coords
 
 
 def compute_displacement(data: xr.DataArray) -> xr.DataArray:
@@ -43,7 +43,7 @@ def compute_displacement(data: xr.DataArray) -> xr.DataArray:
     height per bounding box, between consecutive time points.
 
     """
-    validate_dimension_coordinates(data, {"time": [], "space": ["x", "y"]})
+    validate_dims_coords(data, {"time": [], "space": ["x", "y"]})
     result = data.diff(dim="time")
     result = result.reindex(data.coords, fill_value=0)
     return result
@@ -154,7 +154,7 @@ def _compute_approximate_time_derivative(
         )
     if order <= 0:
         raise log_error(ValueError, "Order must be a positive integer.")
-    validate_dimension_coordinates(data, {"time": [], "space": ["x", "y"]})
+    validate_dims_coords(data, {"time": [], "space": ["x", "y"]})
     result = data
     for _ in range(order):
         result = result.differentiate("time")

--- a/movement/utils/vector.py
+++ b/movement/utils/vector.py
@@ -4,7 +4,7 @@ import numpy as np
 import xarray as xr
 
 from movement.utils.logging import log_error
-from movement.validators.arrays import validate_dimension_coordinates
+from movement.validators.arrays import validate_dims_coords
 
 
 def compute_norm(data: xr.DataArray) -> xr.DataArray:
@@ -40,7 +40,7 @@ def compute_norm(data: xr.DataArray) -> xr.DataArray:
 
     """
     if "space" in data.dims:
-        validate_dimension_coordinates(data, {"space": ["x", "y"]})
+        validate_dims_coords(data, {"space": ["x", "y"]})
         return xr.apply_ufunc(
             np.linalg.norm,
             data,
@@ -48,7 +48,7 @@ def compute_norm(data: xr.DataArray) -> xr.DataArray:
             kwargs={"axis": -1},
         )
     elif "space_pol" in data.dims:
-        validate_dimension_coordinates(data, {"space_pol": ["rho", "phi"]})
+        validate_dims_coords(data, {"space_pol": ["rho", "phi"]})
         return data.sel(space_pol="rho", drop=True)
     else:
         _raise_error_for_missing_spatial_dim()
@@ -79,10 +79,10 @@ def convert_to_unit(data: xr.DataArray) -> xr.DataArray:
 
     """
     if "space" in data.dims:
-        validate_dimension_coordinates(data, {"space": ["x", "y"]})
+        validate_dims_coords(data, {"space": ["x", "y"]})
         return data / compute_norm(data)
     elif "space_pol" in data.dims:
-        validate_dimension_coordinates(data, {"space_pol": ["rho", "phi"]})
+        validate_dims_coords(data, {"space_pol": ["rho", "phi"]})
         # Set both rho and phi values to NaN at null vectors (where rho = 0)
         new_data = xr.where(data.sel(space_pol="rho") == 0, np.nan, data)
         # Set the rho values to 1 for non-null vectors (phi is preserved)
@@ -112,7 +112,7 @@ def cart2pol(data: xr.DataArray) -> xr.DataArray:
         ``phi`` returned are in radians, in the range ``[-pi, pi]``.
 
     """
-    validate_dimension_coordinates(data, {"space": ["x", "y"]})
+    validate_dims_coords(data, {"space": ["x", "y"]})
     rho = compute_norm(data)
     phi = xr.apply_ufunc(
         np.arctan2,
@@ -148,7 +148,7 @@ def pol2cart(data: xr.DataArray) -> xr.DataArray:
         in the dimension coordinate.
 
     """
-    validate_dimension_coordinates(data, {"space_pol": ["rho", "phi"]})
+    validate_dims_coords(data, {"space_pol": ["rho", "phi"]})
     rho = data.sel(space_pol="rho")
     phi = data.sel(space_pol="phi")
     x = rho * np.cos(phi)

--- a/movement/utils/vector.py
+++ b/movement/utils/vector.py
@@ -4,6 +4,7 @@ import numpy as np
 import xarray as xr
 
 from movement.utils.logging import log_error
+from movement.validators.arrays import validate_dimension_coordinates
 
 
 def compute_norm(data: xr.DataArray) -> xr.DataArray:
@@ -39,7 +40,7 @@ def compute_norm(data: xr.DataArray) -> xr.DataArray:
 
     """
     if "space" in data.dims:
-        _validate_dimension_coordinates(data, {"space": ["x", "y"]})
+        validate_dimension_coordinates(data, {"space": ["x", "y"]})
         return xr.apply_ufunc(
             np.linalg.norm,
             data,
@@ -47,7 +48,7 @@ def compute_norm(data: xr.DataArray) -> xr.DataArray:
             kwargs={"axis": -1},
         )
     elif "space_pol" in data.dims:
-        _validate_dimension_coordinates(data, {"space_pol": ["rho", "phi"]})
+        validate_dimension_coordinates(data, {"space_pol": ["rho", "phi"]})
         return data.sel(space_pol="rho", drop=True)
     else:
         _raise_error_for_missing_spatial_dim()
@@ -78,10 +79,10 @@ def convert_to_unit(data: xr.DataArray) -> xr.DataArray:
 
     """
     if "space" in data.dims:
-        _validate_dimension_coordinates(data, {"space": ["x", "y"]})
+        validate_dimension_coordinates(data, {"space": ["x", "y"]})
         return data / compute_norm(data)
     elif "space_pol" in data.dims:
-        _validate_dimension_coordinates(data, {"space_pol": ["rho", "phi"]})
+        validate_dimension_coordinates(data, {"space_pol": ["rho", "phi"]})
         # Set both rho and phi values to NaN at null vectors (where rho = 0)
         new_data = xr.where(data.sel(space_pol="rho") == 0, np.nan, data)
         # Set the rho values to 1 for non-null vectors (phi is preserved)
@@ -111,7 +112,7 @@ def cart2pol(data: xr.DataArray) -> xr.DataArray:
         ``phi`` returned are in radians, in the range ``[-pi, pi]``.
 
     """
-    _validate_dimension_coordinates(data, {"space": ["x", "y"]})
+    validate_dimension_coordinates(data, {"space": ["x", "y"]})
     rho = compute_norm(data)
     phi = xr.apply_ufunc(
         np.arctan2,
@@ -147,7 +148,7 @@ def pol2cart(data: xr.DataArray) -> xr.DataArray:
         in the dimension coordinate.
 
     """
-    _validate_dimension_coordinates(data, {"space_pol": ["rho", "phi"]})
+    validate_dimension_coordinates(data, {"space_pol": ["rho", "phi"]})
     rho = data.sel(space_pol="rho")
     phi = data.sel(space_pol="phi")
     x = rho * np.cos(phi)
@@ -162,48 +163,6 @@ def pol2cart(data: xr.DataArray) -> xr.DataArray:
         ],
         concat_dim="space",
     ).transpose(*dims)
-
-
-def _validate_dimension_coordinates(
-    data: xr.DataArray, required_dim_coords: dict
-) -> None:
-    """Validate the input data array.
-
-    Ensure that it contains the required dimensions and coordinates.
-
-    Parameters
-    ----------
-    data : xarray.DataArray
-        The input data to validate.
-    required_dim_coords : dict
-        A dictionary of required dimensions and their corresponding
-        coordinate values.
-
-    Raises
-    ------
-    ValueError
-        If the input data does not contain the required dimension(s)
-        and/or the required coordinate(s).
-
-    """
-    missing_dims = [dim for dim in required_dim_coords if dim not in data.dims]
-    error_message = ""
-    if missing_dims:
-        error_message += (
-            f"Input data must contain {missing_dims} as dimensions.\n"
-        )
-    missing_coords = []
-    for dim, coords in required_dim_coords.items():
-        missing_coords = [
-            coord for coord in coords if coord not in data.coords.get(dim, [])
-        ]
-        if missing_coords:
-            error_message += (
-                "Input data must contain "
-                f"{missing_coords} in the '{dim}' coordinates."
-            )
-    if error_message:
-        raise log_error(ValueError, error_message)
 
 
 def _raise_error_for_missing_spatial_dim() -> None:

--- a/movement/validators/arrays.py
+++ b/movement/validators/arrays.py
@@ -1,0 +1,49 @@
+"""Validators for data arrays."""
+
+import xarray as xr
+
+from movement.utils.logging import log_error
+
+
+def validate_dimension_coordinates(
+    data: xr.DataArray, required_dim_coords: dict
+) -> None:
+    """Validate dimensions and coordinates in a data array.
+
+    This function raises a ValueError if the specified dimensions and
+    coordinates are not present in the input data array..
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        The input data array to validate.
+    required_dim_coords : dict
+        A dictionary of required dimensions and their corresponding
+        coordinate values. If you don't need to specify any
+        coordinate values, you can pass an empty list.
+
+    Raises
+    ------
+    ValueError
+        If the input data does not contain the required dimension(s)
+        and/or the required coordinate(s).
+
+    """
+    missing_dims = [dim for dim in required_dim_coords if dim not in data.dims]
+    error_message = ""
+    if missing_dims:
+        error_message += (
+            f"Input data must contain {missing_dims} as dimensions.\n"
+        )
+    missing_coords = []
+    for dim, coords in required_dim_coords.items():
+        missing_coords = [
+            coord for coord in coords if coord not in data.coords.get(dim, [])
+        ]
+        if missing_coords:
+            error_message += (
+                "Input data must contain "
+                f"{missing_coords} in the '{dim}' coordinates."
+            )
+    if error_message:
+        raise log_error(ValueError, error_message)

--- a/movement/validators/arrays.py
+++ b/movement/validators/arrays.py
@@ -5,7 +5,7 @@ import xarray as xr
 from movement.utils.logging import log_error
 
 
-def validate_dimension_coordinates(
+def validate_dims_coords(
     data: xr.DataArray, required_dim_coords: dict
 ) -> None:
     """Validate dimensions and coordinates in a data array.

--- a/movement/validators/arrays.py
+++ b/movement/validators/arrays.py
@@ -11,7 +11,7 @@ def validate_dims_coords(
     """Validate dimensions and coordinates in a data array.
 
     This function raises a ValueError if the specified dimensions and
-    coordinates are not present in the input data array..
+    coordinates are not present in the input data array.
 
     Parameters
     ----------
@@ -21,6 +21,18 @@ def validate_dims_coords(
         A dictionary of required dimensions and their corresponding
         coordinate values. If you don't need to specify any
         coordinate values, you can pass an empty list.
+
+    Examples
+    --------
+    Validate that a data array contains the dimension 'time'. No specific
+    coordinates are required.
+
+    >>> validate_dims_coords(data, {"time": []})
+
+    Validate that a data array contains the dimensions 'time' and 'space',
+    and that the 'space' dimension contains the coordinates 'x' and 'y'.
+
+    >>> validate_dims_coords(data, {"time": [], "space": ["x", "y"]})
 
     Raises
     ------

--- a/tests/test_unit/test_kinematics.py
+++ b/tests/test_unit/test_kinematics.py
@@ -181,4 +181,4 @@ def test_approximate_derivative_with_invalid_order(order):
     data = np.arange(10)
     expected_exception = ValueError if isinstance(order, int) else TypeError
     with pytest.raises(expected_exception):
-        kinematics._compute_approximate_time_derivative(data, order=order)
+        kinematics.compute_time_derivative(data, order=order)

--- a/tests/test_unit/test_validators/test_array_validators.py
+++ b/tests/test_unit/test_validators/test_array_validators.py
@@ -1,0 +1,60 @@
+import re
+
+import pytest
+import xarray as xr
+
+from movement.validators.arrays import validate_dims_coords
+
+
+@pytest.fixture
+def valid_data_array():
+    return xr.DataArray(
+        data=[[1, 2], [3, 4]],
+        dims=["time", "space"],
+        coords={"time": [0, 1], "space": ["x", "y"]},
+    )
+
+
+@pytest.mark.parametrize(
+    "required_dims_coords",
+    [
+        ({"time": []}),
+        ({"time": [0, 1]}),
+        ({"space": ["x", "y"]}),
+        ({"time": [], "space": []}),
+        ({"time": [], "space": ["x", "y"]}),
+    ],
+)
+def test_validate_dims_coords_on_valid_input(
+    valid_data_array,
+    required_dims_coords,
+):
+    """Test that valid inputs do not raise an error."""
+    validate_dims_coords(valid_data_array, required_dims_coords)
+
+
+@pytest.mark.parametrize(
+    "required_dims_coords, expected_error_message",
+    [
+        (
+            {"spacetime": []},
+            "Input data must contain ['spacetime'] as dimensions.",
+        ),
+        (
+            {"time": [0, 100], "space": ["x", "y"]},
+            "Input data must contain [100] in the 'time' coordinates.",
+        ),
+        (
+            {"space": ["x", "y", "z"]},
+            "Input data must contain ['z'] in the 'space' coordinates.",
+        ),
+    ],
+)
+def test_validate_dims_coords_on_invalid_input(
+    valid_data_array,
+    required_dims_coords,
+    expected_error_message,
+):
+    """Test that invalid inputs raise a ValueError with expected message."""
+    with pytest.raises(ValueError, match=re.escape(expected_error_message)):
+        validate_dims_coords(valid_data_array, required_dims_coords)

--- a/tests/test_unit/test_validators/test_array_validators.py
+++ b/tests/test_unit/test_validators/test_array_validators.py
@@ -1,18 +1,8 @@
 import re
 
 import pytest
-import xarray as xr
 
 from movement.validators.arrays import validate_dims_coords
-
-
-@pytest.fixture
-def valid_data_array():
-    return xr.DataArray(
-        data=[[1, 2], [3, 4]],
-        dims=["time", "space"],
-        coords={"time": [0, 1], "space": ["x", "y"]},
-    )
 
 
 @pytest.mark.parametrize(
@@ -26,11 +16,12 @@ def valid_data_array():
     ],
 )
 def test_validate_dims_coords_on_valid_input(
-    valid_data_array,
+    valid_poses_dataset_uniform_linear_motion,  # fixture from conftest.py
     required_dims_coords,
 ):
     """Test that valid inputs do not raise an error."""
-    validate_dims_coords(valid_data_array, required_dims_coords)
+    position_array = valid_poses_dataset_uniform_linear_motion["position"]
+    validate_dims_coords(position_array, required_dims_coords)
 
 
 @pytest.mark.parametrize(
@@ -51,10 +42,11 @@ def test_validate_dims_coords_on_valid_input(
     ],
 )
 def test_validate_dims_coords_on_invalid_input(
-    valid_data_array,
+    valid_poses_dataset_uniform_linear_motion,  # fixture from conftest.py
     required_dims_coords,
     expected_error_message,
 ):
     """Test that invalid inputs raise a ValueError with expected message."""
+    position_array = valid_poses_dataset_uniform_linear_motion["position"]
     with pytest.raises(ValueError, match=re.escape(expected_error_message)):
-        validate_dims_coords(valid_data_array, required_dims_coords)
+        validate_dims_coords(position_array, required_dims_coords)

--- a/tests/test_unit/test_validators/test_array_validators.py
+++ b/tests/test_unit/test_validators/test_array_validators.py
@@ -6,44 +6,51 @@ import pytest
 from movement.validators.arrays import validate_dims_coords
 
 
+def expect_value_error_with_message(error_msg):
+    """Expect a ValueError with the specified error message."""
+    return pytest.raises(ValueError, match=re.escape(error_msg))
+
+
+valid_cases = [
+    ({"time": []}, does_not_raise()),
+    ({"time": [0, 1]}, does_not_raise()),
+    ({"space": ["x", "y"]}, does_not_raise()),
+    ({"time": [], "space": []}, does_not_raise()),
+    ({"time": [], "space": ["x", "y"]}, does_not_raise()),
+]  # Valid cases (no error)
+
+invalid_cases = [
+    (
+        {"spacetime": []},
+        expect_value_error_with_message(
+            "Input data must contain ['spacetime'] as dimensions."
+        ),
+    ),
+    (
+        {"time": [0, 100], "space": ["x", "y"]},
+        expect_value_error_with_message(
+            "Input data must contain [100] in the 'time' coordinates."
+        ),
+    ),
+    (
+        {"space": ["x", "y", "z"]},
+        expect_value_error_with_message(
+            "Input data must contain ['z'] in the 'space' coordinates."
+        ),
+    ),
+]  # Invalid cases (raise ValueError)
+
+
 @pytest.mark.parametrize(
-    "required_dims_coords, expected_exception, expected_error_message",
-    [
-        # Valid cases (no error)
-        ({"time": []}, does_not_raise(), None),
-        ({"time": [0, 1]}, does_not_raise(), None),
-        ({"space": ["x", "y"]}, does_not_raise(), None),
-        ({"time": [], "space": []}, does_not_raise(), None),
-        ({"time": [], "space": ["x", "y"]}, does_not_raise(), None),
-        # Invalid cases (raise ValueError)
-        (
-            {"spacetime": []},
-            pytest.raises(ValueError),
-            "Input data must contain ['spacetime'] as dimensions.",
-        ),
-        (
-            {"time": [0, 100], "space": ["x", "y"]},
-            pytest.raises(ValueError),
-            "Input data must contain [100] in the 'time' coordinates.",
-        ),
-        (
-            {"space": ["x", "y", "z"]},
-            pytest.raises(ValueError),
-            "Input data must contain ['z'] in the 'space' coordinates.",
-        ),
-    ],
+    "required_dims_coords, expected_exception",
+    valid_cases + invalid_cases,
 )
 def test_validate_dims_coords(
     valid_poses_dataset_uniform_linear_motion,  # fixture from conftest.py
     required_dims_coords,
     expected_exception,
-    expected_error_message,
 ):
     """Test validate_dims_coords for both valid and invalid inputs."""
     position_array = valid_poses_dataset_uniform_linear_motion["position"]
-    with expected_exception as exc_info:
+    with expected_exception:
         validate_dims_coords(position_array, required_dims_coords)
-        if expected_error_message:
-            assert re.search(
-                re.escape(expected_error_message), str(exc_info.value)
-            )


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
See #292 and #291 

**What does this PR do?**
Turns a previously private function for validating the existence of dimensions and coordinates into a public function in `validators/arrays.py/validate_dims_coords`. This function is then used in both `kinematics.py` and `vector.py`.
In kinematics, it's now also used to assert cartesian coordinates for computing displacement, velocity and acceleration.

## How has this PR been tested?
Existing test were already indirectly covering this functionality, but I decided to also add some unit tests that directly test this new validator. These tests are also much stricter in checking that the thrown exception has the right error message.

## Is this a breaking change?

Nope.

## Does this PR require an update to the documentation?

No, API docs will be automatically updated.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [n/a] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)


## Update 2024-09-16
This PR also exposes `compute_time_derivative` as a public function, and thus closes #311, following discussions in #291. This function is not restricted to Cartesian space.