### PR TITLE
Fix xarray FutureWarning about dims vs sizes

### DIFF
--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -83,8 +83,8 @@ def test_interpolate_over_time_on_position(
 
     # The number of NaNs after interpolating should be as expected
     assert n_nans_after == (
-        valid_dataset_in_frames.dims["space"]
-        * valid_dataset_in_frames.dims.get("keypoints", 1)
+        valid_dataset_in_frames.sizes["space"]
+        * valid_dataset_in_frames.sizes.get("keypoints", 1)
         # in bboxes dataset there is no keypoints dimension
         * expected_n_nans_in_position
     )
@@ -120,7 +120,7 @@ def test_filter_by_confidence_on_position(
     # the number of low confidence keypoints by the number of
     # space dimensions
     assert isinstance(position_filtered, xr.DataArray)
-    assert n_nans == valid_input_dataset.dims["space"] * n_low_confidence_kpts
+    assert n_nans == valid_input_dataset.sizes["space"] * n_low_confidence_kpts
 
 
 @pytest.mark.parametrize(
@@ -198,15 +198,15 @@ def test_filter_with_nans_on_position(
         # compute n nans in position after filtering per individual
         n_nans_after_filtering_per_indiv = {
             i: helpers.count_nans(position_filtered.isel(individuals=i))
-            for i in range(valid_input_dataset.dims["individuals"])
+            for i in range(valid_input_dataset.sizes["individuals"])
         }
 
         # check number of nans per indiv is as expected
-        for i in range(valid_input_dataset.dims["individuals"]):
+        for i in range(valid_input_dataset.sizes["individuals"]):
             assert n_nans_after_filtering_per_indiv[i] == (
                 expected_nans_in_filt_position_per_indiv[i]
-                * valid_input_dataset.dims["space"]
-                * valid_input_dataset.dims.get("keypoints", 1)
+                * valid_input_dataset.sizes["space"]
+                * valid_input_dataset.sizes.get("keypoints", 1)
             )
 
     # Filter position

--- a/tests/test_unit/test_kinematics.py
+++ b/tests/test_unit/test_kinematics.py
@@ -128,14 +128,14 @@ def test_kinematics_with_dataset_with_nans(
     # compute n nans in kinematic array per individual
     n_nans_kinematics_per_indiv = [
         helpers.count_nans(kinematic_array.isel(individuals=i))
-        for i in range(valid_dataset.dims["individuals"])
+        for i in range(valid_dataset.sizes["individuals"])
     ]
 
     # expected nans per individual adjusted for space and keypoints dimensions
     expected_nans_adjusted = [
         n
-        * valid_dataset.dims["space"]
-        * valid_dataset.dims.get("keypoints", 1)
+        * valid_dataset.sizes["space"]
+        * valid_dataset.sizes.get("keypoints", 1)
         for n in expected_nans_per_individual
     ]
     # check number of nans per individual is as expected in kinematic array


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

`pytest` caught a bunch of FutureWarnings of this type:

> FutureWarning: The return type of `Dataset.dims` will be changed to return a set of dimension names in future, in order to be more consistent with `DataArray.dims`. To access a mapping from dimension names to lengths, please use `Dataset.sizes`.

To reproduce, run `pytest` locally on the `main` branch.

**What does this PR do?**

For cases when we actually access a dimensions size, we now switch to using `ds.sizes` (which returns a `dict("dim_name": dims_size)`), instead of `ds.dims` (which will return a set of dimensions names in future).

For cases when we just need the dim names (e.g. for checking if a given dimension exists), we keep using `ds.dims`, which works now (because it returns the dict keys) and should continue working in the future (will return a set).

## References
I think some of the "offending" uses of `ds.dims` where introduced in #267 and I hadn't caught them during review.

## How has this PR been tested?

All test pass without warnings.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [n/a] Tests have been added to cover all new functionality
- [n/a] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
