### PR TITLE
Add bbox centroid fix

### DIFF
--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -402,6 +402,11 @@ def _numpy_arrays_from_via_tracks_file(file_path: Path) -> dict:
 
         array_dict[key] = np.stack(list_arrays, axis=1).squeeze()
 
+    # Transform position_array to represent centroid of bbox,
+    # rather than top-left corner
+    # (top left corner: corner of the bbox with minimum x and y coordinates)
+    array_dict["position_array"] += array_dict["shape_array"] / 2
+
     # Add remaining arrays to dict
     array_dict["ID_array"] = df["ID"].unique().reshape(-1, 1)
     array_dict["frame_array"] = df["frame_number"].unique().reshape(-1, 1)
@@ -415,14 +420,16 @@ def _df_from_via_tracks_file(file_path: Path) -> pd.DataFrame:
     Read the VIA tracks .csv file as a pandas dataframe with columns:
     - ID: the integer ID of the tracked bounding box.
     - frame_number: the frame number of the tracked bounding box.
-    - x: the x-coordinate of the tracked bounding box centroid.
-    - y: the y-coordinate of the tracked bounding box centroid.
+    - x: the x-coordinate of the tracked bounding box top-left corner.
+    - y: the y-coordinate of the tracked bounding box top-left corner.
     - w: the width of the tracked bounding box.
     - h: the height of the tracked bounding box.
     - confidence: the confidence score of the tracked bounding box.
 
     The dataframe is sorted by ID and frame number, and for each ID,
-    empty frames are filled in with NaNs.
+    empty frames are filled in with NaNs. The coordinates of the bboxes
+    are assumed to be in the image coordinate system, with the origin at the
+    top-left corner of the image.
     """
     # Read VIA tracks .csv file as a pandas dataframe
     df_file = pd.read_csv(file_path, sep=",", header=0)

--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -420,16 +420,16 @@ def _df_from_via_tracks_file(file_path: Path) -> pd.DataFrame:
     Read the VIA tracks .csv file as a pandas dataframe with columns:
     - ID: the integer ID of the tracked bounding box.
     - frame_number: the frame number of the tracked bounding box.
-    - x: the x-coordinate of the tracked bounding box top-left corner.
-    - y: the y-coordinate of the tracked bounding box top-left corner.
+    - x: the x-coordinate of the tracked bounding box's top-left corner.
+    - y: the y-coordinate of the tracked bounding box's top-left corner.
     - w: the width of the tracked bounding box.
     - h: the height of the tracked bounding box.
     - confidence: the confidence score of the tracked bounding box.
 
     The dataframe is sorted by ID and frame number, and for each ID,
     empty frames are filled in with NaNs. The coordinates of the bboxes
-    are assumed to be in the image coordinate system, with the origin at the
-    top-left corner of the image.
+    are assumed to be in the image coordinate system (i.e., the top-left
+    corner of a bbox is its corner with minimum x and y coordinates).
     """
     # Read VIA tracks .csv file as a pandas dataframe
     df_file = pd.read_csv(file_path, sep=",", header=0)

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -459,14 +459,18 @@ def test_position_numpy_array_from_via_tracks_file(via_tracks_file):
     # Read VIA tracks .csv file as a dataframe
     df = load_bboxes._df_from_via_tracks_file(via_tracks_file)
 
-    # Check the centroid values
-    for k, id in enumerate(bboxes_arrays["ID_array"]):
+    # Compute centroid positions from the dataframe
+    # (go thru in the same order as ID array)
+    list_derived_centroids = []
+    for id in bboxes_arrays["ID_array"]:
         df_one_ID = df[df["ID"] == id.item()]
         centroid_position = np.array(
             [df_one_ID.x + df_one_ID.w / 2, df_one_ID.y + df_one_ID.h / 2]
-        ).T
+        ).T  # frames, xy
+        list_derived_centroids.append(centroid_position)
 
-        assert np.allclose(
-            bboxes_arrays["position_array"][:, k, :],
-            centroid_position,
-        )
+    # Compare to extracted position array
+    assert np.allclose(
+        bboxes_arrays["position_array"],  # frames, individuals, xy
+        np.stack(list_derived_centroids, axis=1),
+    )

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -428,14 +428,10 @@ def test_df_from_via_tracks_file(via_tracks_file):
     df = load_bboxes._df_from_via_tracks_file(via_tracks_file)
 
     assert isinstance(df, pd.DataFrame)
-
-    # Check data is for 5 frames
     assert len(df.frame_number.unique()) == 5
-
-    # Check all individuals are defined for every frame (even if Nan)
-    assert df.shape[0] == len(df.ID.unique()) * 5
-
-    # Check columns
+    assert (
+        df.shape[0] == len(df.ID.unique()) * 5
+    )  # all individuals in all frames (even if nan)
     assert list(df.columns) == [
         "ID",
         "frame_number",
@@ -451,7 +447,7 @@ def test_position_numpy_array_from_via_tracks_file(via_tracks_file):
     """Test the extracted position array from the VIA tracks .csv file
     represents the centroid of the bbox.
     """
-    # Extract arrays from VIA tracks .csv file
+    # Extract numpy arrays from VIA tracks .csv file
     bboxes_arrays = load_bboxes._numpy_arrays_from_via_tracks_file(
         via_tracks_file
     )

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -459,9 +459,9 @@ def test_position_numpy_array_from_via_tracks_file(via_tracks_file):
     # (go thru in the same order as ID array)
     list_derived_centroids = []
     for id in bboxes_arrays["ID_array"]:
-        df_one_ID = df[df["ID"] == id.item()]
+        df_one_id = df[df["ID"] == id.item()]
         centroid_position = np.array(
-            [df_one_ID.x + df_one_ID.w / 2, df_one_ID.y + df_one_ID.h / 2]
+            [df_one_id.x + df_one_id.w / 2, df_one_id.y + df_one_id.h / 2]
         ).T  # frames, xy
         list_derived_centroids.append(centroid_position)
 


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
When loading bboxes datasets from a VIA tracks file, we stored the coordinates of the top-left corner of each bbox in the dataset. This is inconsistent with the current description in the docs (which always refer to the centroid of the bboxes), and also somewhat inconsistent with the rest of the tools we support.

Fixes #302  

**What does this PR do?**
- Transforms the top-left corner coordinates from the VIA tracks file into the centroid ones, before creating the movement dataset
- Adds some tests

Opinions on the tests are particularly welcome. I aimed to reduce the circularity but not sure if there is a better way.

## How has this PR been tested?

Tests pass locally and in CI.

## Is this a breaking change?
No.

## Does this PR require an update to the documentation?

No, but docstrings of the relevant private functions have been updated.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
