### PR TITLE
Fix and relax bboxes requirements

### DIFF
--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -13,7 +13,11 @@ import xarray as xr
 
 from movement.utils.logging import log_error
 from movement.validators.datasets import ValidBboxesDataset
-from movement.validators.files import ValidFile, ValidVIATracksCSV
+from movement.validators.files import (
+    DEFAULT_FRAME_REGEXP,
+    ValidFile,
+    ValidVIATracksCSV,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -349,7 +353,7 @@ def from_via_tracks_file(
 
 
 def _numpy_arrays_from_via_tracks_file(
-    file_path: Path, frame_regexp: str = r"(0\d*)\.\w+$"
+    file_path: Path, frame_regexp: str = DEFAULT_FRAME_REGEXP
 ) -> dict:
     """Extract numpy arrays from the input VIA tracks .csv file.
 
@@ -427,7 +431,7 @@ def _numpy_arrays_from_via_tracks_file(
 
 
 def _df_from_via_tracks_file(
-    file_path: Path, frame_regexp: str = r"(0\d*)\.\w+$"
+    file_path: Path, frame_regexp: str = DEFAULT_FRAME_REGEXP
 ) -> pd.DataFrame:
     """Load VIA tracks .csv file as a dataframe.
 
@@ -526,7 +530,7 @@ def _extract_confidence_from_via_tracks_df(df: pd.DataFrame) -> np.ndarray:
 
 
 def _extract_frame_number_from_via_tracks_df(
-    df: pd.DataFrame, frame_regexp: str = r"(0\d*)\.\w+$"
+    df: pd.DataFrame, frame_regexp: str = DEFAULT_FRAME_REGEXP
 ) -> np.ndarray:
     """Extract frame numbers from the VIA tracks input dataframe.
 

--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -189,7 +189,8 @@ def from_file(
         Regular expression pattern to extract the frame number from the frame
         filename. By default, the frame number is expected to be encoded in
         the filename as an integer number led by at least one zero, followed
-        by the file extension.
+        by the file extension. Only used if ``use_frame_numbers_from_file`` is
+        True.
 
 
     Returns
@@ -265,7 +266,8 @@ def from_via_tracks_file(
         Regular expression pattern to extract the frame number from the frame
         filename. By default, the frame number is expected to be encoded in
         the filename as an integer number led by at least one zero, followed
-        by the file extension.
+        by the file extension. Only used if ``use_frame_numbers_from_file`` is
+        True.
 
     Returns
     -------

--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -349,7 +349,7 @@ def from_via_tracks_file(
 
 
 def _numpy_arrays_from_via_tracks_file(
-    file_path: Path, frame_regexp: str
+    file_path: Path, frame_regexp: str = r"(0\d*)\.\w+$"
 ) -> dict:
     """Extract numpy arrays from the input VIA tracks .csv file.
 
@@ -375,9 +375,9 @@ def _numpy_arrays_from_via_tracks_file(
 
     frame_regexp : str
         Regular expression pattern to extract the frame number from the
-        filename. The frame number is expected to be encoded in the filename
-        as an integer number led by at least one zero, followed by the file
-        extension.
+        filename. By default, the frame number is expected to be encoded in
+        the filename as an integer number led by at least one zero, followed
+        by the file extension.
 
     Returns
     -------
@@ -427,7 +427,7 @@ def _numpy_arrays_from_via_tracks_file(
 
 
 def _df_from_via_tracks_file(
-    file_path: Path, frame_regexp: str
+    file_path: Path, frame_regexp: str = r"(0\d*)\.\w+$"
 ) -> pd.DataFrame:
     """Load VIA tracks .csv file as a dataframe.
 
@@ -494,7 +494,7 @@ def _df_from_via_tracks_file(
     return df
 
 
-def _extract_confidence_from_via_tracks_df(df) -> np.ndarray:
+def _extract_confidence_from_via_tracks_df(df: pd.DataFrame) -> np.ndarray:
     """Extract confidence scores from the VIA tracks input dataframe.
 
     Parameters
@@ -525,7 +525,9 @@ def _extract_confidence_from_via_tracks_df(df) -> np.ndarray:
     return bbox_confidence
 
 
-def _extract_frame_number_from_via_tracks_df(df, frame_regexp) -> np.ndarray:
+def _extract_frame_number_from_via_tracks_df(
+    df: pd.DataFrame, frame_regexp: str = r"(0\d*)\.\w+$"
+) -> np.ndarray:
     """Extract frame numbers from the VIA tracks input dataframe.
 
     Parameters

--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -62,7 +62,7 @@ def from_numpy(
         bounding boxes are defined. If None (default), frame numbers will
         be assigned based on the first dimension of the ``position_array``,
         starting from 0. If a specific array of frame numbers is provided,
-        these need to be consecutive integers.
+        these need to be integers sorted in increasing order.
     fps : float, optional
         The video sampling rate. If None (default), the ``time`` coordinates
         of the resulting ``movement`` dataset will be in frame numbers. If

--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -326,7 +326,7 @@ def from_via_tracks_file(
         shape_array=bboxes_arrays["shape_array"],
         confidence_array=bboxes_arrays["confidence_array"],
         individual_names=[
-            f"id_{id}" for id in bboxes_arrays["ID_array"].squeeze()
+            f"id_{id.item()}" for id in bboxes_arrays["ID_array"]
         ],
         frame_array=(
             bboxes_arrays["frame_array"]
@@ -398,8 +398,11 @@ def _numpy_arrays_from_via_tracks_file(file_path: Path) -> dict:
             df[map_key_to_columns[key]].to_numpy(),
             indices_id_switch,  # indices along axis=0
         )
+        array_dict[key] = np.stack(list_arrays, axis=1)
 
-        array_dict[key] = np.stack(list_arrays, axis=1).squeeze()
+        # squeeze only last dimension if it is 1
+        if array_dict[key].shape[-1] == 1:
+            array_dict[key] = array_dict[key].squeeze(axis=-1)
 
     # Transform position_array to represent centroid of bbox,
     # rather than top-left corner

--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -374,7 +374,7 @@ def _numpy_arrays_from_via_tracks_file(
         Path to the VIA tracks .csv file containing the bounding boxes' tracks.
 
     frame_regexp : str
-        Regular expression pattern to extract the frame number from the
+        Regular expression pattern to extract the frame number from the frame
         filename. By default, the frame number is expected to be encoded in
         the filename as an integer number led by at least one zero, followed
         by the file extension.
@@ -537,10 +537,10 @@ def _extract_frame_number_from_via_tracks_df(
         ``df = pd.read_csv(file_path, sep=",", header=0)``.
 
     frame_regexp : str
-        Regular expression pattern to extract the frame number from the
-        filename. The frame number is expected to be encoded in the filename
-        as an integer number led by at least one zero, followed by the file
-        extension.
+        Regular expression pattern to extract the frame number from the frame
+        filename. By default, the frame number is expected to be encoded in
+        the filename as an integer number led by at least one zero, followed by
+        the file extension.
 
     Returns
     -------

--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -155,6 +155,7 @@ def from_file(
     source_software: Literal["VIA-tracks"],
     fps: float | None = None,
     use_frame_numbers_from_file: bool = False,
+    frame_regexp: str = DEFAULT_FRAME_REGEXP,
 ) -> xr.Dataset:
     """Create a ``movement`` bounding boxes dataset from a supported file.
 
@@ -184,6 +185,12 @@ def from_file(
         full video as the time origin. If False (default), the frame numbers
         in the VIA tracks .csv file are instead mapped to a 0-based sequence of
         consecutive integers.
+    frame_regexp : str, optional
+        Regular expression pattern to extract the frame number from the frame
+        filename. By default, the frame number is expected to be encoded in
+        the filename as an integer number led by at least one zero, followed
+        by the file extension.
+
 
     Returns
     -------
@@ -218,6 +225,7 @@ def from_file(
             file_path,
             fps,
             use_frame_numbers_from_file=use_frame_numbers_from_file,
+            frame_regexp=frame_regexp,
         )
     else:
         raise log_error(
@@ -229,6 +237,7 @@ def from_via_tracks_file(
     file_path: Path | str,
     fps: float | None = None,
     use_frame_numbers_from_file: bool = False,
+    frame_regexp: str = DEFAULT_FRAME_REGEXP,
 ) -> xr.Dataset:
     """Create a ``movement`` dataset from a VIA tracks .csv file.
 
@@ -252,6 +261,11 @@ def from_via_tracks_file(
         but you want to maintain the start of the full video as the time
         origin. If False (default), the frame numbers in the VIA tracks .csv
         file are instead mapped to a 0-based sequence of consecutive integers.
+    frame_regexp : str, optional
+        Regular expression pattern to extract the frame number from the frame
+        filename. By default, the frame number is expected to be encoded in
+        the filename as an integer number led by at least one zero, followed
+        by the file extension.
 
     Returns
     -------
@@ -320,7 +334,7 @@ def from_via_tracks_file(
     )
 
     # Specific VIA-tracks .csv file validation
-    via_file = ValidVIATracksCSV(file.path)
+    via_file = ValidVIATracksCSV(file.path, frame_regexp=frame_regexp)
     logger.debug(f"Validated VIA tracks .csv file {via_file.path}.")
 
     # Create an xarray.Dataset from the data

--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -349,11 +349,12 @@ class ValidBboxesDataset:
                 value,
                 expected_shape=(self.position_array.shape[0], 1),
             )
-            # check frames are continuous: exactly one frame number per row
-            if not np.all(np.diff(value, axis=0) == 1):
+            # check frames are monotonically increasing
+            if not np.all(np.diff(value, axis=0) >= 1):
                 raise log_error(
                     ValueError,
-                    f"Frame numbers in {attribute.name} are not continuous.",
+                    f"Frame numbers in {attribute.name} are not monotonically "
+                    "increasing.",
                 )
 
     # Define defaults

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -332,7 +332,7 @@ class ValidVIATracksCSV:
         for k_i, k in enumerate(file_attributes_dicts):
             try:
                 list_frame_numbers.append(int(k["frame"]))
-            except Exception as e:
+            except ValueError as e:
                 raise log_error(
                     ValueError,
                     f"{df.filename.iloc[k_i]} (row {k_i}): "

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -289,7 +289,9 @@ class ValidVIATracksCSV:
           files.
 
         If the frame number is included as part of the image file name, then
-        it is expected as an integer led by at least one zero, followed by the
+        it is expected to be captured by the regular expression in the
+        `frame_regexp` attribute of the ValidVIATracksCSV object. The default
+        regexp matches an integer led by at least one zero, followed by the
         file extension.
 
         """

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -320,9 +320,9 @@ class ValidVIATracksCSV:
         # else: extract frame number from filename.
         else:
             for f_i, f in enumerate(df["filename"]):
+                # try compiling the frame regexp
                 try:
                     regex_match = re.search(self.frame_regexp, f)
-                    list_frame_numbers.append(int(regex_match.group(1)))  # type: ignore
                 except re.error as e:
                     raise log_error(
                         re.error,
@@ -330,9 +330,14 @@ class ValidVIATracksCSV:
                         f"numbers ({self.frame_regexp}) could not be compiled."
                         " Please review its syntax.",
                     ) from e
+
+                # try extracting the frame number from the filename using the
+                # compiled regexp
+                try:
+                    list_frame_numbers.append(int(regex_match.group(1)))  # type: ignore
                 except AttributeError as e:
                     raise log_error(
-                        ValueError,
+                        AttributeError,
                         f"{f} (row {f_i}): The frame regexp did not "
                         "return any matches and a frame number could not "
                         "be extracted from the filename. If included in "

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -358,16 +358,14 @@ class ValidVIATracksCSV:
             # try extracting the frame number from the filename using the
             # compiled regexp
             try:
-                list_frame_numbers.append(int(regex_match.group(1)))  # type: ignore
+                list_frame_numbers.append(int(regex_match.group(1)))
             except AttributeError as e:
                 raise log_error(
                     AttributeError,
-                    f"{f} (row {f_i}): The frame regexp did not "
+                    f"{f} (row {f_i}): The provided frame regexp "
+                    f"({self.frame_regexp}) did not "
                     "return any matches and a frame number could not "
-                    "be extracted from the filename. If included in "
-                    "the filename, the frame number is expected as a "
-                    "zero-padded integer before the file extension "
-                    "(e.g. 00234.png).",
+                    "be extracted from the filename.",
                 ) from e
             except ValueError as e:
                 raise log_error(

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -322,39 +322,33 @@ class ValidVIATracksCSV:
             for f_i, f in enumerate(df["filename"]):
                 try:
                     regex_match = re.search(self.frame_regexp, f)
-                except Exception as e:
+                    if not regex_match:
+                        raise ValueError(
+                            f"{f} (row {f_i}): The frame regexp did not "
+                            "return any matches and a frame number could not "
+                            "be extracted from the filename. If included in "
+                            "the filename, the frame number is expected as a "
+                            "zero-padded integer before the file extension "
+                            "(e.g. 00234.png)."
+                        )
+                    list_frame_numbers.append(int(regex_match.group(1)))  # type: ignore
+
+                except re.error as e:
                     raise log_error(
                         re.error,
-                        "The provided regular expression for the frame numbers"
-                        f" ({self.frame_regexp}) "
-                        "could not be compiled. Please review its syntax.",
+                        "The provided regular expression for the frame "
+                        f"numbers ({self.frame_regexp}) could not be compiled."
+                        " Please review its syntax.",
                     ) from e
 
-                # if there is a pattern match
-                if regex_match:
-                    try:
-                        list_frame_numbers.append(
-                            int(regex_match.group(1))  # type: ignore
-                        )
-                    except Exception as e:
-                        raise log_error(
-                            ValueError,
-                            f"{f} (row {f_i}): "
-                            "The frame number extracted from the filename "
-                            "using the provided regexp "
-                            f"({self.frame_regexp}) "
-                            "could not be cast as an integer.",
-                        ) from e
-                else:
+                except ValueError as e:
                     raise log_error(
                         ValueError,
                         f"{f} (row {f_i}): "
-                        "The frame regexp did not return any matches and a "
-                        "frame number could not be extracted from the "
-                        "filename. If included in the filename, the frame "
-                        "number is expected as a zero-padded integer before "
-                        "the file extension (e.g. 00234.png).",
-                    )
+                        "The frame number extracted from the filename using "
+                        f"the provided regexp ({self.frame_regexp}) could not "
+                        "be cast as an integer.",
+                    ) from e
 
         # Check we have as many unique frame numbers as unique image files
         if len(set(list_frame_numbers)) != len(df.filename.unique()):

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -355,7 +355,6 @@ class ValidVIATracksCSV:
                     f"numbers ({self.frame_regexp}) could not be compiled."
                     " Please review its syntax.",
                 ) from e
-
             # try extracting the frame number from the filename using the
             # compiled regexp
             try:

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -234,6 +234,11 @@ class ValidVIATracksCSV:
     ----------
     path : pathlib.Path
         Path to the VIA tracks .csv file.
+    frame_regexp : str
+        Regular expression pattern to extract the frame number from the
+        filename. By default, the frame number is expected to be encoded in
+        the filename as an integer number led by at least one zero, followed
+        by the file extension.
 
     Raises
     ------
@@ -243,6 +248,7 @@ class ValidVIATracksCSV:
     """
 
     path: Path = field(validator=validators.instance_of(Path))
+    frame_regexp: str = r"(0\d*)\.\w+$"
 
     @path.validator
     def _file_contains_valid_header(self, attribute, value):
@@ -281,8 +287,8 @@ class ValidVIATracksCSV:
           files.
 
         If the frame number is included as part of the image file name, then
-        it is expected as an integer led by at least one zero, between "_" and
-        ".", followed by the file extension.
+        it is expected as an integer led by at least one zero, followed by the
+        file extension.
 
         """
         df = pd.read_csv(value, sep=",", header=0)
@@ -309,10 +315,8 @@ class ValidVIATracksCSV:
 
         # else: extract frame number from filename.
         else:
-            pattern = r"_(0\d*)\.\w+$"
-
             for f_i, f in enumerate(df["filename"]):
-                regex_match = re.search(pattern, f)
+                regex_match = re.search(self.frame_regexp, f)
                 if regex_match:  # if there is a pattern match
                     list_frame_numbers.append(
                         int(regex_match.group(1))  # type: ignore

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -250,7 +250,7 @@ class ValidVIATracksCSV:
     """
 
     path: Path = field(validator=validators.instance_of(Path))
-    frame_regexp: str = r"(0\d*)\.\w+$"
+    frame_regexp: str = DEFAULT_FRAME_REGEXP
 
     @path.validator
     def _file_contains_valid_header(self, attribute, value):

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -320,21 +320,40 @@ class ValidVIATracksCSV:
         # else: extract frame number from filename.
         else:
             for f_i, f in enumerate(df["filename"]):
-                regex_match = re.search(self.frame_regexp, f)
-                if regex_match:  # if there is a pattern match
-                    list_frame_numbers.append(
-                        int(regex_match.group(1))  # type: ignore
-                        # the match will always be castable as integer
-                    )
+                try:
+                    regex_match = re.search(self.frame_regexp, f)
+                except Exception as e:
+                    raise log_error(
+                        re.error,
+                        "The provided regular expression for the frame numbers"
+                        f" ({self.frame_regexp}) "
+                        "could not be compiled. Please review its syntax.",
+                    ) from e
+
+                # if there is a pattern match
+                if regex_match:
+                    try:
+                        list_frame_numbers.append(
+                            int(regex_match.group(1))  # type: ignore
+                        )
+                    except Exception as e:
+                        raise log_error(
+                            ValueError,
+                            f"{f} (row {f_i}): "
+                            "The frame number extracted from the filename "
+                            "using the provided regexp "
+                            f"({self.frame_regexp}) "
+                            "could not be cast as an integer.",
+                        ) from e
                 else:
                     raise log_error(
                         ValueError,
                         f"{f} (row {f_i}): "
-                        "a frame number could not be extracted from the "
+                        "The frame regexp did not return any matches and a "
+                        "frame number could not be extracted from the "
                         "filename. If included in the filename, the frame "
-                        "number is expected as a zero-padded integer between "
-                        "an underscore '_' and the file extension "
-                        "(e.g. img_00234.png).",
+                        "number is expected as a zero-padded integer before "
+                        "the file extension (e.g. 00234.png).",
                     )
 
         # Check we have as many unique frame numbers as unique image files

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -322,17 +322,7 @@ class ValidVIATracksCSV:
             for f_i, f in enumerate(df["filename"]):
                 try:
                     regex_match = re.search(self.frame_regexp, f)
-                    if not regex_match:
-                        raise ValueError(
-                            f"{f} (row {f_i}): The frame regexp did not "
-                            "return any matches and a frame number could not "
-                            "be extracted from the filename. If included in "
-                            "the filename, the frame number is expected as a "
-                            "zero-padded integer before the file extension "
-                            "(e.g. 00234.png)."
-                        )
                     list_frame_numbers.append(int(regex_match.group(1)))  # type: ignore
-
                 except re.error as e:
                     raise log_error(
                         re.error,
@@ -340,7 +330,16 @@ class ValidVIATracksCSV:
                         f"numbers ({self.frame_regexp}) could not be compiled."
                         " Please review its syntax.",
                     ) from e
-
+                except AttributeError as e:
+                    raise log_error(
+                        ValueError,
+                        f"{f} (row {f_i}): The frame regexp did not "
+                        "return any matches and a frame number could not "
+                        "be extracted from the filename. If included in "
+                        "the filename, the frame number is expected as a "
+                        "zero-padded integer before the file extension "
+                        "(e.g. 00234.png).",
+                    ) from e
                 except ValueError as e:
                     raise log_error(
                         ValueError,

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -304,55 +304,15 @@ class ValidVIATracksCSV:
 
         # If 'frame' is a file_attribute for all files:
         # extract frame number
-        list_frame_numbers = []
         if all(["frame" in d for d in file_attributes_dicts]):
-            for k_i, k in enumerate(file_attributes_dicts):
-                try:
-                    list_frame_numbers.append(int(k["frame"]))
-                except Exception as e:
-                    raise log_error(
-                        ValueError,
-                        f"{df.filename.iloc[k_i]} (row {k_i}): "
-                        "'frame' file attribute cannot be cast as an integer. "
-                        f"Please review the file attributes: {k}.",
-                    ) from e
-
+            list_frame_numbers = (
+                self._extract_frame_numbers_from_file_attributes(
+                    df, file_attributes_dicts
+                )
+            )
         # else: extract frame number from filename.
         else:
-            for f_i, f in enumerate(df["filename"]):
-                # try compiling the frame regexp
-                try:
-                    regex_match = re.search(self.frame_regexp, f)
-                except re.error as e:
-                    raise log_error(
-                        re.error,
-                        "The provided regular expression for the frame "
-                        f"numbers ({self.frame_regexp}) could not be compiled."
-                        " Please review its syntax.",
-                    ) from e
-
-                # try extracting the frame number from the filename using the
-                # compiled regexp
-                try:
-                    list_frame_numbers.append(int(regex_match.group(1)))  # type: ignore
-                except AttributeError as e:
-                    raise log_error(
-                        AttributeError,
-                        f"{f} (row {f_i}): The frame regexp did not "
-                        "return any matches and a frame number could not "
-                        "be extracted from the filename. If included in "
-                        "the filename, the frame number is expected as a "
-                        "zero-padded integer before the file extension "
-                        "(e.g. 00234.png).",
-                    ) from e
-                except ValueError as e:
-                    raise log_error(
-                        ValueError,
-                        f"{f} (row {f_i}): "
-                        "The frame number extracted from the filename using "
-                        f"the provided regexp ({self.frame_regexp}) could not "
-                        "be cast as an integer.",
-                    ) from e
+            list_frame_numbers = self._extract_frame_numbers_using_regexp(df)
 
         # Check we have as many unique frame numbers as unique image files
         if len(set(list_frame_numbers)) != len(df.filename.unique()):
@@ -363,6 +323,63 @@ class ValidVIATracksCSV:
                 "file and ensure a unique frame number is defined for each "
                 "file. ",
             )
+
+    def _extract_frame_numbers_from_file_attributes(
+        self, df, file_attributes_dicts
+    ):
+        """Get frame numbers from the 'frame' key under 'file_attributes'."""
+        list_frame_numbers = []
+        for k_i, k in enumerate(file_attributes_dicts):
+            try:
+                list_frame_numbers.append(int(k["frame"]))
+            except Exception as e:
+                raise log_error(
+                    ValueError,
+                    f"{df.filename.iloc[k_i]} (row {k_i}): "
+                    "'frame' file attribute cannot be cast as an integer. "
+                    f"Please review the file attributes: {k}.",
+                ) from e
+        return list_frame_numbers
+
+    def _extract_frame_numbers_using_regexp(self, df):
+        """Get frame numbers from the file names using the provided regexp."""
+        list_frame_numbers = []
+        for f_i, f in enumerate(df["filename"]):
+            # try compiling the frame regexp
+            try:
+                regex_match = re.search(self.frame_regexp, f)
+            except re.error as e:
+                raise log_error(
+                    re.error,
+                    "The provided regular expression for the frame "
+                    f"numbers ({self.frame_regexp}) could not be compiled."
+                    " Please review its syntax.",
+                ) from e
+
+            # try extracting the frame number from the filename using the
+            # compiled regexp
+            try:
+                list_frame_numbers.append(int(regex_match.group(1)))  # type: ignore
+            except AttributeError as e:
+                raise log_error(
+                    AttributeError,
+                    f"{f} (row {f_i}): The frame regexp did not "
+                    "return any matches and a frame number could not "
+                    "be extracted from the filename. If included in "
+                    "the filename, the frame number is expected as a "
+                    "zero-padded integer before the file extension "
+                    "(e.g. 00234.png).",
+                ) from e
+            except ValueError as e:
+                raise log_error(
+                    ValueError,
+                    f"{f} (row {f_i}): "
+                    "The frame number extracted from the filename using "
+                    f"the provided regexp ({self.frame_regexp}) could not "
+                    "be cast as an integer.",
+                ) from e
+
+        return list_frame_numbers
 
     @path.validator
     def _file_contains_tracked_bboxes(self, attribute, value):

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -12,6 +12,8 @@ from attrs import define, field, validators
 
 from movement.utils.logging import log_error
 
+DEFAULT_FRAME_REGEXP = r"(0\d*)\.\w+$"
+
 
 @define
 class ValidFile:

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -342,11 +342,9 @@ def test_from_via_tracks_file(
             r"_(0\d*)_$",
             AttributeError,
             "/crab_1/00000.jpg (row 0): "
-            "The frame regexp did not return any matches and a "
-            "frame number could not be extracted from the filename. "
-            "If included in the filename, the frame number is expected "
-            "as a zero-padded integer before the file extension "
-            "(e.g. 00234.png).",
+            "The provided frame regexp (_(0\d*)_$) did not return any "
+            "matches and a frame number could not be extracted from "
+            "the filename.",
         ),
         (
             r"(0\d*\.\w+)$",

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -91,8 +91,8 @@ def create_df_input_via_tracks():
         else:
             return update_attribute_column(
                 df_input=df,
-                attribute_column_name=attribute_column_name,  # "region_attributes", /// "file_attributes",
-                dict_to_append=dict_to_append,  # {"confidence": "0.5"}, /// {"frame": "1"},
+                attribute_column_name=attribute_column_name, 
+                dict_to_append=dict_to_append, 
             )
 
     return _create_df_input_via_tracks

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -15,50 +15,63 @@ from movement.validators.datasets import ValidBboxesDataset
 
 @pytest.fixture()
 def get_expected_attributes_dict():
+    """Define a factory of expected attributes dictionaries."""
+
     def _get_expected_attributes_dict(via_file_name: str) -> dict:
-        # Should match the first 3 rows of each file!
-        attributes_dict_per_test_file = {
-            "VIA_single-crab_MOCA-crab-1.csv": {
-                "region_shape_attributes": {
-                    "name": np.array(["rect"] * 3),
-                    "x_y": np.array(
-                        [
-                            [957.85, 296.708],
-                            [919.149, 296.708],
-                            [889.317, 303.158],
-                        ]
-                    ).reshape(-1, 2),
-                    "width_height": np.array(
-                        [
-                            [320.09, 153.191],
-                            [357.984, 158.835],
-                            [366.853, 162.867],
-                        ]
-                    ).reshape(-1, 2),
-                },
-                "region_attributes": {
-                    "track": np.ones((3,)),
-                },
+        """Return the expected attributes dictionary for the first 3 rows of
+        the input VIA file.
+        """
+        attributes_dict_per_test_file = {}
+
+        # add expected attributes for the first 3 rows of
+        # VIA_single-crab_MOCA-crab-1.csv
+        attributes_dict_per_test_file["VIA_single-crab_MOCA-crab-1.csv"] = {
+            "region_shape_attributes": {
+                "name": np.array(["rect"] * 3),
+                "x_y": np.array(
+                    [
+                        [957.85, 296.708],
+                        [919.149, 296.708],
+                        [889.317, 303.158],
+                    ]
+                ).reshape(-1, 2),
+                "width_height": np.array(
+                    [
+                        [320.09, 153.191],
+                        [357.984, 158.835],
+                        [366.853, 162.867],
+                    ]
+                ).reshape(-1, 2),
             },
-            "VIA_multiple-crabs_5-frames_labels.csv": {
-                "region_shape_attributes": {
-                    "name": np.array(["rect"] * 3),
-                    "x_y": np.array(
-                        [
-                            [526.2366942646654, 393.280914246804],
-                            [2565, 468],
-                            [759.6484377108334, 136.60946673708338],
-                        ]
-                    ).reshape(-1, 2),
-                    "width_height": np.array(
-                        [[46, 38], [41, 30], [29, 25]]
-                    ).reshape(-1, 2),
-                },
-                "region_attributes": {
-                    "track": np.array([71, 70, 69]),
-                },
+            "region_attributes": {
+                "track": np.ones((3,)),
             },
         }
+
+        # add expected attributes for the first 3 rows of
+        # "VIA_multiple-crabs_5-frames_labels.csv"
+        attributes_dict_per_test_file[
+            "VIA_multiple-crabs_5-frames_labels.csv"
+        ] = {
+            "region_shape_attributes": {
+                "name": np.array(["rect"] * 3),
+                "x_y": np.array(
+                    [
+                        [526.2366942646654, 393.280914246804],
+                        [2565, 468],
+                        [759.6484377108334, 136.60946673708338],
+                    ]
+                ).reshape(-1, 2),
+                "width_height": np.array(
+                    [[46, 38], [41, 30], [29, 25]]
+                ).reshape(-1, 2),
+            },
+            "region_attributes": {
+                "track": np.array([71, 70, 69]),
+            },
+        }
+
+        # return ValueError if the filename is not defined
         if via_file_name not in attributes_dict_per_test_file:
             raise ValueError(
                 f"Attributes dict not defined for filename '{via_file_name}''."
@@ -70,16 +83,24 @@ def get_expected_attributes_dict():
 
 @pytest.fixture()
 def create_df_input_via_tracks():
+    """Define a factory of dataframes for testing."""
+
     def _create_df_input_via_tracks(
         via_file_path: Path,
         small: bool = False,
         attribute_column_additions: dict[str, list[dict]] | None = None,
     ) -> pd.DataFrame:
-        """Return the dataframe that results from
+        """Return an optionally modified dataframe that results from
         reading the input VIA tracks .csv filepath.
 
-        attribute_column_additions is a dictionary mapping the name of the
-        attribute column to a list of dictionaries to append to that column.
+        If small is True, only the first 3 rows are returned.
+
+        If attribute_column_additions is not None, the dataframe is modified
+        to include the data under the specified attribute column.
+
+        The variable attribute_column_additions is a dictionary mapping the
+        name of the attribute column to a list of dictionaries to append to
+        that column.
         """
         # read the VIA tracks .csv file as a dataframe
         df = pd.read_csv(via_file_path, sep=",", header=0)
@@ -99,36 +120,6 @@ def create_df_input_via_tracks():
             )
 
     return _create_df_input_via_tracks
-
-
-@pytest.fixture()
-def create_valid_from_numpy_inputs():
-    n_frames = 5
-    n_individuals = 86
-    n_space = 2
-    individual_names_array = np.arange(n_individuals).reshape(-1, 1)
-    first_frame_number = 1  # should match sample file
-
-    rng = np.random.default_rng(seed=42)
-
-    def _create_valid_from_numpy_inputs(with_frame_array=False):
-        required_inputs = {
-            "position_array": rng.random((n_frames, n_individuals, n_space)),
-            "shape_array": rng.random((n_frames, n_individuals, n_space)),
-            "confidence_array": rng.random((n_frames, n_individuals)),
-            "individual_names": [
-                f"id_{id}" for id in individual_names_array.squeeze()
-            ],
-        }
-
-        if with_frame_array:
-            required_inputs["frame_array"] = np.arange(
-                first_frame_number, first_frame_number + n_frames
-            ).reshape(-1, 1)
-
-        return required_inputs
-
-    return _create_valid_from_numpy_inputs
 
 
 def update_attribute_column(
@@ -168,6 +159,38 @@ def update_attribute_column(
         df[attribute_column_name] = [str(d) for d in attributes_dicts]
 
     return df
+
+
+@pytest.fixture()
+def create_valid_from_numpy_inputs():
+    """Define a factory of valid inputs to "from_numpy" function."""
+    n_frames = 5
+    n_individuals = 86
+    n_space = 2
+    individual_names_array = np.arange(n_individuals).reshape(-1, 1)
+    first_frame_number = 1  # should match sample file
+
+    rng = np.random.default_rng(seed=42)
+
+    def _create_valid_from_numpy_inputs(with_frame_array=False):
+        """Return a dictionary of valid inputs to the `from_numpy` function."""
+        required_inputs = {
+            "position_array": rng.random((n_frames, n_individuals, n_space)),
+            "shape_array": rng.random((n_frames, n_individuals, n_space)),
+            "confidence_array": rng.random((n_frames, n_individuals)),
+            "individual_names": [
+                f"id_{id}" for id in individual_names_array.squeeze()
+            ],
+        }
+
+        if with_frame_array:
+            required_inputs["frame_array"] = np.arange(
+                first_frame_number, first_frame_number + n_frames
+            ).reshape(-1, 1)
+
+        return required_inputs
+
+    return _create_valid_from_numpy_inputs
 
 
 def assert_dataset(

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -340,7 +340,7 @@ def test_from_via_tracks_file(
         ),
         (
             r"_(0\d*)_$",
-            ValueError,
+            AttributeError,
             "/crab_1/00000.jpg (row 0): "
             "The frame regexp did not return any matches and a "
             "frame number could not be extracted from the filename. "

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -425,7 +425,9 @@ def test_df_from_via_tracks_file(via_tracks_file):
     """Test that the helper function correctly reads the VIA tracks .csv file
     as a dataframe.
     """
-    df = load_bboxes._df_from_via_tracks_file(via_tracks_file)
+    df = load_bboxes._df_from_via_tracks_file(
+        file_path=via_tracks_file,
+    )
 
     assert isinstance(df, pd.DataFrame)
     assert len(df.frame_number.unique()) == 5

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -450,8 +450,6 @@ def test_extract_confidence_from_via_tracks_df(
     """
     # None of the sample files includes a confidence column
     # so we add it to the dataframe here
-    # ----> can I use a crab one from tracking output & replace
-    # VIA_multiple-crabs_5-frames_labels?
     if input_confidence_value:
         df = create_df_input_via_tracks(
             via_file_path,

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -241,13 +241,17 @@ def assert_time_coordinates(ds, fps, start_frame=None, frame_array=None):
     # scale time coordinates with 1/fps if provided
     scale = 1 / fps if fps else 1
 
-    # build frame array if not provided
+    # build frame array from start_frame if provided
     if start_frame is not None:
         frame_array = np.array(
             range(start_frame, len(ds.coords["time"].data) + start_frame)
         )
-    # elif not frame_array:
-    #     frame_array = np.arange(1, len(ds.coords["time"].data) + 1)
+    elif frame_array is None:
+        raise ValueError(
+            "Either start_frame or frame_array must be provided."
+            "start_frame takes precedence over frame_array if "
+            "both are provided."
+        )
 
     # assert numpy array of time coordinates
     np.testing.assert_allclose(

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -542,6 +542,7 @@ def test_df_from_via_tracks_file(
         "confidence",
     ]
 
+
 @pytest.mark.parametrize(
     "via_file_path",
     [

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -91,8 +91,8 @@ def create_df_input_via_tracks():
         else:
             return update_attribute_column(
                 df_input=df,
-                attribute_column_name=attribute_column_name, 
-                dict_to_append=dict_to_append, 
+                attribute_column_name=attribute_column_name,
+                dict_to_append=dict_to_append,
             )
 
     return _create_df_input_via_tracks

--- a/tests/test_unit/test_validators/test_datasets_validators.py
+++ b/tests/test_unit/test_validators/test_datasets_validators.py
@@ -360,10 +360,16 @@ def test_bboxes_dataset_validator_confidence_array(
             f"Expected a numpy array, but got {type(list())}.",
         ),  # not an ndarray, should raise ValueError
         (
-            np.array([1, 2, 3, 4, 6, 7, 8, 9, 10, 11]).reshape(-1, 1),
+            np.array([1, 2, 3, 6, 7, 8, 4, 9, 10, 11]).reshape(-1, 1),
             pytest.raises(ValueError),
-            "Frame numbers in frame_array are not continuous.",
-        ),  # frame numbers are not continuous
+            "Frame numbers in frame_array are not monotonically increasing.",
+        ),
+        (
+            np.array([1, 2, 3, 5, 6, 7, 8, 9, 10, 11]).reshape(-1, 1),
+            does_not_raise(),
+            "",
+        ),  # valid, frame numbers are not continuous but are monotonically
+        # increasing
         (
             None,
             does_not_raise(),
@@ -389,10 +395,10 @@ def test_bboxes_dataset_validator_frame_array(
             frame_array=frame_array,
         )
 
-    if frame_array is None:
+    if frame_array is not None:
+        assert str(getattr(excinfo, "value", "")) == log_message
+    else:
         n_frames = ds.position_array.shape[0]
         default_frame_array = np.arange(n_frames).reshape(-1, 1)
         assert np.array_equal(ds.frame_array, default_frame_array)
         assert ds.frame_array.shape == (ds.position_array.shape[0], 1)
-    else:
-        assert str(excinfo.value) == log_message

--- a/tests/test_unit/test_validators/test_datasets_validators.py
+++ b/tests/test_unit/test_validators/test_datasets_validators.py
@@ -360,12 +360,14 @@ def test_bboxes_dataset_validator_confidence_array(
             f"Expected a numpy array, but got {type(list())}.",
         ),  # not an ndarray, should raise ValueError
         (
-            np.array([1, 2, 3, 6, 7, 8, 4, 9, 10, 11]).reshape(-1, 1),
+            np.array([1, 10, 2, 3, 4, 5, 6, 7, 8, 9]).reshape(-1, 1),
             pytest.raises(ValueError),
             "Frame numbers in frame_array are not monotonically increasing.",
         ),
         (
-            np.array([1, 2, 3, 5, 6, 7, 8, 9, 10, 11]).reshape(-1, 1),
+            np.array([1, 2, 22, 23, 24, 25, 100, 101, 102, 103]).reshape(
+                -1, 1
+            ),
             does_not_raise(),
             "",
         ),  # valid, frame numbers are not continuous but are monotonically

--- a/tests/test_unit/test_validators/test_files_validators.py
+++ b/tests/test_unit/test_validators/test_files_validators.py
@@ -68,11 +68,11 @@ def test_deeplabcut_csv_validator_with_invalid_input(
 
 
 @pytest.mark.parametrize(
-    "invalid_input, expected_exception, log_message",
+    "invalid_input, error_type, log_message",
     [
         (
             "via_tracks_csv_with_invalid_header",
-            pytest.raises(ValueError),
+            ValueError,
             ".csv header row does not match the known format for "
             "VIA tracks .csv files. "
             "Expected "
@@ -83,7 +83,7 @@ def test_deeplabcut_csv_validator_with_invalid_input(
         ),
         (
             "frame_number_in_file_attribute_not_integer",
-            pytest.raises(ValueError),
+            ValueError,
             "04.09.2023-04-Right_RE_test_frame_A.png (row 0): "
             "'frame' file attribute cannot be cast as an integer. "
             "Please review the file attributes: "
@@ -91,7 +91,7 @@ def test_deeplabcut_csv_validator_with_invalid_input(
         ),
         (
             "frame_number_in_filename_wrong_pattern",
-            pytest.raises(AttributeError),
+            AttributeError,
             "04.09.2023-04-Right_RE_test_frame_1.png (row 0): "
             "The frame regexp did not return any matches and a "
             "frame number could not be extracted from the "
@@ -101,28 +101,28 @@ def test_deeplabcut_csv_validator_with_invalid_input(
         ),
         (
             "more_frame_numbers_than_filenames",
-            pytest.raises(ValueError),
+            ValueError,
             "The number of unique frame numbers does not match the number "
             "of unique image files. Please review the VIA tracks .csv file "
             "and ensure a unique frame number is defined for each file. ",
         ),
         (
             "less_frame_numbers_than_filenames",
-            pytest.raises(ValueError),
+            ValueError,
             "The number of unique frame numbers does not match the number "
             "of unique image files. Please review the VIA tracks .csv file "
             "and ensure a unique frame number is defined for each file. ",
         ),
         (
             "region_shape_attribute_not_rect",
-            pytest.raises(ValueError),
+            ValueError,
             "04.09.2023-04-Right_RE_test_frame_01.png (row 0): "
             "bounding box shape must be 'rect' (rectangular) "
             "but instead got 'circle'.",
         ),
         (
             "region_shape_attribute_missing_x",
-            pytest.raises(ValueError),
+            ValueError,
             "04.09.2023-04-Right_RE_test_frame_01.png (row 0): "
             "at least one bounding box shape parameter is missing. "
             "Expected 'x', 'y', 'width', 'height' to exist as "
@@ -131,7 +131,7 @@ def test_deeplabcut_csv_validator_with_invalid_input(
         ),
         (
             "region_attribute_missing_track",
-            pytest.raises(ValueError),
+            ValueError,
             "04.09.2023-04-Right_RE_test_frame_01.png (row 0): "
             "bounding box does not have a 'track' attribute defined "
             "under 'region_attributes'. "
@@ -139,7 +139,7 @@ def test_deeplabcut_csv_validator_with_invalid_input(
         ),
         (
             "track_id_not_castable_as_int",
-            pytest.raises(ValueError),
+            ValueError,
             "04.09.2023-04-Right_RE_test_frame_01.png (row 0): "
             "the track ID for the bounding box cannot be cast "
             "as an integer. "
@@ -147,7 +147,7 @@ def test_deeplabcut_csv_validator_with_invalid_input(
         ),
         (
             "track_ids_not_unique_per_frame",
-            pytest.raises(ValueError),
+            ValueError,
             "04.09.2023-04-Right_RE_test_frame_01.png: "
             "multiple bounding boxes in this file have the same track ID. "
             "Please review the VIA tracks .csv file.",
@@ -155,7 +155,7 @@ def test_deeplabcut_csv_validator_with_invalid_input(
     ],
 )
 def test_via_tracks_csv_validator_with_invalid_input(
-    invalid_input, expected_exception, log_message, request
+    invalid_input, error_type, log_message, request
 ):
     """Test that invalid VIA tracks .csv files raise the appropriate errors.
 
@@ -172,7 +172,7 @@ def test_via_tracks_csv_validator_with_invalid_input(
     - error if bboxes IDs are not 1-based integers
     """
     file_path = request.getfixturevalue(invalid_input)
-    with expected_exception as excinfo:
+    with pytest.raises(error_type) as excinfo:
         ValidVIATracksCSV(file_path)
 
     assert str(excinfo.value) == log_message

--- a/tests/test_unit/test_validators/test_files_validators.py
+++ b/tests/test_unit/test_validators/test_files_validators.py
@@ -90,11 +90,11 @@ def test_deeplabcut_csv_validator_with_invalid_input(
         (
             "frame_number_in_filename_wrong_pattern",
             "04.09.2023-04-Right_RE_test_frame_1.png (row 0): "
-            "a frame number could not be extracted from the filename. "
-            "If included in the filename, the frame number is "
-            "expected as a zero-padded integer between an "
-            "underscore '_' and the file extension "
-            "(e.g. img_00234.png).",
+            "The frame regexp did not return any matches and a "
+            "frame number could not be extracted from the "
+            "filename. If included in the filename, the frame "
+            "number is expected as a zero-padded integer before "
+            "the file extension (e.g. 00234.png).",
         ),
         (
             "more_frame_numbers_than_filenames",

--- a/tests/test_unit/test_validators/test_files_validators.py
+++ b/tests/test_unit/test_validators/test_files_validators.py
@@ -68,10 +68,11 @@ def test_deeplabcut_csv_validator_with_invalid_input(
 
 
 @pytest.mark.parametrize(
-    "invalid_input, log_message",
+    "invalid_input, expected_exception, log_message",
     [
         (
             "via_tracks_csv_with_invalid_header",
+            pytest.raises(ValueError),
             ".csv header row does not match the known format for "
             "VIA tracks .csv files. "
             "Expected "
@@ -82,6 +83,7 @@ def test_deeplabcut_csv_validator_with_invalid_input(
         ),
         (
             "frame_number_in_file_attribute_not_integer",
+            pytest.raises(ValueError),
             "04.09.2023-04-Right_RE_test_frame_A.png (row 0): "
             "'frame' file attribute cannot be cast as an integer. "
             "Please review the file attributes: "
@@ -89,6 +91,7 @@ def test_deeplabcut_csv_validator_with_invalid_input(
         ),
         (
             "frame_number_in_filename_wrong_pattern",
+            pytest.raises(AttributeError),
             "04.09.2023-04-Right_RE_test_frame_1.png (row 0): "
             "The frame regexp did not return any matches and a "
             "frame number could not be extracted from the "
@@ -98,24 +101,28 @@ def test_deeplabcut_csv_validator_with_invalid_input(
         ),
         (
             "more_frame_numbers_than_filenames",
+            pytest.raises(ValueError),
             "The number of unique frame numbers does not match the number "
             "of unique image files. Please review the VIA tracks .csv file "
             "and ensure a unique frame number is defined for each file. ",
         ),
         (
             "less_frame_numbers_than_filenames",
+            pytest.raises(ValueError),
             "The number of unique frame numbers does not match the number "
             "of unique image files. Please review the VIA tracks .csv file "
             "and ensure a unique frame number is defined for each file. ",
         ),
         (
             "region_shape_attribute_not_rect",
+            pytest.raises(ValueError),
             "04.09.2023-04-Right_RE_test_frame_01.png (row 0): "
             "bounding box shape must be 'rect' (rectangular) "
             "but instead got 'circle'.",
         ),
         (
             "region_shape_attribute_missing_x",
+            pytest.raises(ValueError),
             "04.09.2023-04-Right_RE_test_frame_01.png (row 0): "
             "at least one bounding box shape parameter is missing. "
             "Expected 'x', 'y', 'width', 'height' to exist as "
@@ -124,6 +131,7 @@ def test_deeplabcut_csv_validator_with_invalid_input(
         ),
         (
             "region_attribute_missing_track",
+            pytest.raises(ValueError),
             "04.09.2023-04-Right_RE_test_frame_01.png (row 0): "
             "bounding box does not have a 'track' attribute defined "
             "under 'region_attributes'. "
@@ -131,6 +139,7 @@ def test_deeplabcut_csv_validator_with_invalid_input(
         ),
         (
             "track_id_not_castable_as_int",
+            pytest.raises(ValueError),
             "04.09.2023-04-Right_RE_test_frame_01.png (row 0): "
             "the track ID for the bounding box cannot be cast "
             "as an integer. "
@@ -138,6 +147,7 @@ def test_deeplabcut_csv_validator_with_invalid_input(
         ),
         (
             "track_ids_not_unique_per_frame",
+            pytest.raises(ValueError),
             "04.09.2023-04-Right_RE_test_frame_01.png: "
             "multiple bounding boxes in this file have the same track ID. "
             "Please review the VIA tracks .csv file.",
@@ -145,7 +155,7 @@ def test_deeplabcut_csv_validator_with_invalid_input(
     ],
 )
 def test_via_tracks_csv_validator_with_invalid_input(
-    invalid_input, log_message, request
+    invalid_input, expected_exception, log_message, request
 ):
     """Test that invalid VIA tracks .csv files raise the appropriate errors.
 
@@ -162,7 +172,7 @@ def test_via_tracks_csv_validator_with_invalid_input(
     - error if bboxes IDs are not 1-based integers
     """
     file_path = request.getfixturevalue(invalid_input)
-    with pytest.raises(ValueError) as excinfo:
+    with expected_exception as excinfo:
         ValidVIATracksCSV(file_path)
 
     assert str(excinfo.value) == log_message

--- a/tests/test_unit/test_validators/test_files_validators.py
+++ b/tests/test_unit/test_validators/test_files_validators.py
@@ -93,11 +93,10 @@ def test_deeplabcut_csv_validator_with_invalid_input(
             "frame_number_in_filename_wrong_pattern",
             AttributeError,
             "04.09.2023-04-Right_RE_test_frame_1.png (row 0): "
-            "The frame regexp did not return any matches and a "
+            "The provided frame regexp ((0\d*)\.\w+$) did not return "
+            "any matches and a "
             "frame number could not be extracted from the "
-            "filename. If included in the filename, the frame "
-            "number is expected as a zero-padded integer before "
-            "the file extension (e.g. 00234.png).",
+            "filename.",
         ),
         (
             "more_frame_numbers_than_filenames",


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
The current implementation gives an error when loading a dataset with a single individual.

It also has some inconveniences that I realised were a bit too strict when I started using it more. Mainly:
- the requirement for the encoding of the frames number in the filename - right now we expect the number to be prefixed by `frame_`, but often the filename is simply the frame number, so I removed this.
- when loading the frames as specified in the input file, it may be that the frames are not regularly spaced. 
    - Currently this would throw an error because we check the frames are separated by exactly 1. 
    - I relaxed this requirement to simply require the frame numbers increase.
    - If we extract them from the VIA file they are sorted before creating the dataset, but if the frame array is passed using `from_numpy` it is up to the user to sort it.

**What does this PR do?**
- Adds fix to load a bounding boxes' dataset of a single animal
    - fixes issue with squeezing 
    - extends existing tests to a file with a single animal
- Relaxes the requirement for extracting the frame number from the filename
    - before we required a `frame_` prefix
-  Relaxes the requirement on the loaded frames being continuous
    - continuous: frames increase exactly by one number
    - instead we just check the frame numbers always increase
    - two fixtures are added to `test_datasets_validators/test_bboxes_dataset_validator_frame_array` to check this behaves as expected.
- Simplifies the fixtures for the `load_bboxes` tests
	- Uses fixture "factories" to reduce the number of predefined fixtures 	
	- Adapts existing tests to use those fixtures

## References

Many of these issues were identified while working on #312 

## How has this PR been tested?

Tests pass locally and on CI.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

The relevant docstrings have been updated.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
