### PR TITLE
Fix command for installation of docs dependencies in the guide.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,6 +171,84 @@ The build job is triggered on each PR, ensuring that the documentation build is 
 The deployment job is only triggered whenever a tag is pushed to the _main_ branch,
 ensuring that the documentation is published in sync with each PyPI release.
 
+
+### Building the documentation locally
+We recommend that you build and view the documentation website locally, before you push your proposed changes.
+
+You will first need to install the required dependencies for building the documentation. To do so, we recommend you create a new virtual environment, activate it and run the following command from the root of the repository:
+```sh
+pip install -r ./docs/requirements.txt
+```
+
+Then navigate to the `docs/` directory:
+```sh
+cd docs
+```
+All subsequent commands should be run from within this directory.
+
+To build the documentation, run:
+
+::::{tab-set}
+:::{tab-item} Unix platforms with `make`
+```sh
+make html
+```
+The local build can be viewed by opening `docs/build/html/index.html` in a browser.
+:::
+
+:::{tab-item} All platforms
+```sh
+python make_api_index.py && sphinx-build source build -W --keep-going
+```
+The local build can be viewed by opening `docs/build/index.html` in a browser.
+:::
+::::
+
+To re-build the documentation after making changes, run the command below. It will remove all generated files in `docs/`,
+including the auto-generated API index `source/api_index.rst`, and those in `build/`, `source/api/`, and `source/examples/`, and then re-build the documentation.
+
+::::{tab-set}
+:::{tab-item} Unix platforms with `make`
+```sh
+make clean html
+```
+:::
+
+:::{tab-item} All platforms
+```sh
+rm -f source/api_index.rst && rm -rf build && rm -rf source/api && rm -rf source/examples
+python make_api_index.py && sphinx-build source build -W --keep-going
+```
+:::
+::::
+
+To check that external links are correctly resolved, run:
+
+::::{tab-set}
+:::{tab-item} Unix platforms with `make`
+```sh
+make linkcheck
+```
+:::
+
+:::{tab-item} All platforms
+```sh
+sphinx-build source build -b linkcheck -W --keep-going
+```
+:::
+::::
+
+If the linkcheck step incorrectly marks links with valid anchors as broken, you can skip checking the anchors in specific links by adding the URLs to `linkcheck_anchors_ignore_for_url` in `docs/source/conf.py`, e.g.:
+
+```python
+# The linkcheck builder will skip verifying that anchors exist when checking
+# these URLs
+linkcheck_anchors_ignore_for_url = [
+    "https://gin.g-node.org/G-Node/Info/wiki/",
+    "https://neuroinformatics.zulipchat.com/",
+]
+```
+
 ### Editing the documentation
 
 To edit the documentation, first clone the repository, and install movement in a
@@ -272,84 +350,6 @@ For example, to reference the {meth}`xarray.Dataset.update` method, use:
 ```
 :::
 ::::
-
-### Building the documentation locally
-We recommend that you build and view the documentation website locally, before you push your proposed changes.
-
-You will first need to install the required dependencies for building the documentation. To do so, we recommend you create a new virtual environment, activate it and run the following command from the root of the repository:
-```sh
-pip install -r ./docs/requirements.txt
-```
-
-Then navigate to the `docs/` directory:
-```sh
-cd docs
-```
-All subsequent commands should be run from within this directory.
-
-To build the documentation, run:
-
-::::{tab-set}
-:::{tab-item} Unix platforms with `make`
-```sh
-make html
-```
-The local build can be viewed by opening `docs/build/html/index.html` in a browser.
-:::
-
-:::{tab-item} All platforms
-```sh
-python make_api_index.py && sphinx-build source build -W --keep-going
-```
-The local build can be viewed by opening `docs/build/index.html` in a browser.
-:::
-::::
-
-To refresh the documentation after making changes, run the command below. It will remove all generated files in `docs/`,
-including the auto-generated API index `source/api_index.rst`, and those in `build/`, `source/api/`, and `source/examples/`.
-Then, re-run the above command to rebuild the documentation.
-
-::::{tab-set}
-:::{tab-item} Unix platforms with `make`
-```sh
-make clean html
-```
-:::
-
-:::{tab-item} All platforms
-```sh
-rm -f source/api_index.rst && rm -rf build && rm -rf source/api && rm -rf source/examples
-python make_api_index.py && sphinx-build source build -W --keep-going
-```
-:::
-::::
-
-To check that external links are correctly resolved, run:
-
-::::{tab-set}
-:::{tab-item} Unix platforms with `make`
-```sh
-make linkcheck
-```
-:::
-
-:::{tab-item} All platforms
-```sh
-sphinx-build source build -b linkcheck -W --keep-going
-```
-:::
-::::
-
-If the linkcheck step incorrectly marks links with valid anchors as broken, you can skip checking the anchors in specific links by adding the URLs to `linkcheck_anchors_ignore_for_url` in `docs/source/conf.py`, e.g.:
-
-```python
-# The linkcheck builder will skip verifying that anchors exist when checking
-# these URLs
-linkcheck_anchors_ignore_for_url = [
-    "https://gin.g-node.org/G-Node/Info/wiki/",
-    "https://neuroinformatics.zulipchat.com/",
-]
-```
 
 ## Sample data
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,9 +274,9 @@ For example, to reference the {meth}`xarray.Dataset.update` method, use:
 ::::
 
 ### Building the documentation locally
-We recommend that you build and view the documentation website locally, before you push it.
+We recommend that you build and view the documentation website locally, before you push your proposed changes.
 
-You first need to install the requirements for building the documentation. To do so, run the following command from the root of the repository:
+You will first need to install the required dependencies for building the documentation. To do so, we recommend you create a new virtual environment, activate it and run the following command from the root of the repository:
 ```sh
 pip install -r ./docs/requirements.txt
 ```
@@ -305,7 +305,7 @@ The local build can be viewed by opening `docs/build/index.html` in a browser.
 :::
 ::::
 
-To refresh the documentation after making changes, remove all generated files in `docs/`,
+To refresh the documentation after making changes, run the command below. It will remove all generated files in `docs/`,
 including the auto-generated API index `source/api_index.rst`, and those in `build/`, `source/api/`, and `source/examples/`.
 Then, re-run the above command to rebuild the documentation.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,87 +172,15 @@ The deployment job is only triggered whenever a tag is pushed to the _main_ bran
 ensuring that the documentation is published in sync with each PyPI release.
 
 
-### Building the documentation locally
-We recommend that you build and view the documentation website locally, before you push your proposed changes.
+### Editing the documentation
 
-You will first need to install the required dependencies for building the documentation. To do so, we recommend you create a new virtual environment, activate it and run the following command from the root of the repository:
+To edit the documentation, first clone the repository, and install `movement` in a
+[development environment](#creating-a-development-environment).
+
+Then, install a few additional dependencies in your development environment to be able to build the documentation locally. To do this, run the following command from the root of the repository:
 ```sh
 pip install -r ./docs/requirements.txt
 ```
-
-Then navigate to the `docs/` directory:
-```sh
-cd docs
-```
-All subsequent commands should be run from within this directory.
-
-To build the documentation, run:
-
-::::{tab-set}
-:::{tab-item} Unix platforms with `make`
-```sh
-make html
-```
-The local build can be viewed by opening `docs/build/html/index.html` in a browser.
-:::
-
-:::{tab-item} All platforms
-```sh
-python make_api_index.py && sphinx-build source build -W --keep-going
-```
-The local build can be viewed by opening `docs/build/index.html` in a browser.
-:::
-::::
-
-To re-build the documentation after making changes, run the command below. It will remove all generated files in `docs/`,
-including the auto-generated API index `source/api_index.rst`, and those in `build/`, `source/api/`, and `source/examples/`, and then re-build the documentation.
-
-::::{tab-set}
-:::{tab-item} Unix platforms with `make`
-```sh
-make clean html
-```
-:::
-
-:::{tab-item} All platforms
-```sh
-rm -f source/api_index.rst && rm -rf build && rm -rf source/api && rm -rf source/examples
-python make_api_index.py && sphinx-build source build -W --keep-going
-```
-:::
-::::
-
-To check that external links are correctly resolved, run:
-
-::::{tab-set}
-:::{tab-item} Unix platforms with `make`
-```sh
-make linkcheck
-```
-:::
-
-:::{tab-item} All platforms
-```sh
-sphinx-build source build -b linkcheck -W --keep-going
-```
-:::
-::::
-
-If the linkcheck step incorrectly marks links with valid anchors as broken, you can skip checking the anchors in specific links by adding the URLs to `linkcheck_anchors_ignore_for_url` in `docs/source/conf.py`, e.g.:
-
-```python
-# The linkcheck builder will skip verifying that anchors exist when checking
-# these URLs
-linkcheck_anchors_ignore_for_url = [
-    "https://gin.g-node.org/G-Node/Info/wiki/",
-    "https://neuroinformatics.zulipchat.com/",
-]
-```
-
-### Editing the documentation
-
-To edit the documentation, first clone the repository, and install movement in a
-[development environment](#creating-a-development-environment).
 
 Now create a new branch, edit the documentation source files (`.md` or `.rst` in the `docs` folder),
 and commit your changes. Submit your documentation changes via a pull request,
@@ -350,6 +278,79 @@ For example, to reference the {meth}`xarray.Dataset.update` method, use:
 ```
 :::
 ::::
+
+
+### Building the documentation locally
+We recommend that you build and view the documentation website locally, before you push your proposed changes.
+
+First, ensure your development environment with the required dependencies is active (see [Editing the documentation](#editing-the-documentation) for details on how to create it). Then, navigate to the `docs/` directory:
+```sh
+cd docs
+```
+All subsequent commands should be run from this directory.
+
+To build the documentation, run:
+
+::::{tab-set}
+:::{tab-item} Unix platforms with `make`
+```sh
+make html
+```
+The local build can be viewed by opening `docs/build/html/index.html` in a browser.
+:::
+
+:::{tab-item} All platforms
+```sh
+python make_api_index.py && sphinx-build source build -W --keep-going
+```
+The local build can be viewed by opening `docs/build/index.html` in a browser.
+:::
+::::
+
+To re-build the documentation after making changes, run the command below. It will remove all generated files in `docs/`,
+including the auto-generated API index `source/api_index.rst`, and those in `build/`, `source/api/`, and `source/examples/`, and then re-build the documentation.
+
+::::{tab-set}
+:::{tab-item} Unix platforms with `make`
+```sh
+make clean html
+```
+:::
+
+:::{tab-item} All platforms
+```sh
+rm -f source/api_index.rst && rm -rf build && rm -rf source/api && rm -rf source/examples
+python make_api_index.py && sphinx-build source build -W --keep-going
+```
+:::
+::::
+
+To check that external links are correctly resolved, run:
+
+::::{tab-set}
+:::{tab-item} Unix platforms with `make`
+```sh
+make linkcheck
+```
+:::
+
+:::{tab-item} All platforms
+```sh
+sphinx-build source build -b linkcheck -W --keep-going
+```
+:::
+::::
+
+If the linkcheck step incorrectly marks links with valid anchors as broken, you can skip checking the anchors in specific links by adding the URLs to `linkcheck_anchors_ignore_for_url` in `docs/source/conf.py`, e.g.:
+
+```python
+# The linkcheck builder will skip verifying that anchors exist when checking
+# these URLs
+linkcheck_anchors_ignore_for_url = [
+    "https://gin.g-node.org/G-Node/Info/wiki/",
+    "https://neuroinformatics.zulipchat.com/",
+]
+```
 
 ## Sample data
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -275,17 +275,19 @@ For example, to reference the {meth}`xarray.Dataset.update` method, use:
 
 ### Building the documentation locally
 We recommend that you build and view the documentation website locally, before you push it.
-To do so, first navigate to `docs/`.
-All subsequent commands should be run from within this directory.
+
+You first need to install the requirements for building the documentation. To do so, run the following command from the root of the repository:
+```sh
+pip install -r ./docs/requirements.txt
+```
+
+Then navigate to the `docs/` directory:
 ```sh
 cd docs
 ```
-Install the requirements for building the documentation:
-```sh
-pip install -r requirements.txt
-```
+All subsequent commands should be run from within this directory.
 
-Build the documentation:
+To build the documentation, run:
 
 ::::{tab-set}
 :::{tab-item} Unix platforms with `make`


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
- It fixes the installation instructions for the docs dependencies
	- more details on the next section.
- It combines all the dependencies installations into the same section.
	- Right now, the contributors first install `movement` in a development environment, and then install a few more additional dependencies to be able to build the docs locally in a later section. In this PR I put both steps in the same section.
- Some small updates to the phrasing
	- e.g., `make clean html` cleans and re-builds the docs, so there is no need to run the build command again as the text suggests.

**What does this PR do?**
The docs `requirements.txt` file specifies the installation of the `movement` package on its first line, as `-e .`. The dot syntax refers to the current directory (the one executing the command), and it should match the location of the `movement` metadata file (`pyproject.toml` for us). 

Since `pyproject.toml` is at the root of the directory, this means the command is expected to be run from the root of the directory too.

However, the documentation asks to run the `pip install -r requirements.txt` command from the `docs` directory. If this instructions are followed, we get an error because `pip` is unable to find the `pyproject.toml` file for the `movement` package. 

Note that in CI we run the same command that this PR proposes (see [here](https://github.com/neuroinformatics-unit/actions/blob/59e7da59bb54de3798a6baf9c0ea6a16e76dbedf/build_sphinx_docs/action.yml#L52C10-L52C59))


## References
\

## How has this PR been tested?
\

## Is this a breaking change?
No.

## Does this PR require an update to the documentation?
\

## Checklist:

- [x] The code has been tested locally
- [ n/a ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
