### PR TITLE
Removed "analysis" level from namespace

### DIFF
--- a/docs/source/getting_started/movement_dataset.md
+++ b/docs/source/getting_started/movement_dataset.md
@@ -232,7 +232,7 @@ Let's imagine we want to compute the instantaneous velocity of all tracked
 points and store the results within the same dataset, for convenience.
 
 ```python
-from movement.analysis.kinematics import compute_velocity
+from movement.kinematics import compute_velocity
 
 # compute velocity from position
 velocity = compute_velocity(ds.position)
@@ -246,7 +246,7 @@ ds["velocity"] = compute_velocity(ds.position)
 ds.velocity
 ```
 
-The output of {func}`movement.analysis.kinematics.compute_velocity` is an {class}`xarray.DataArray` object,
+The output of {func}`movement.kinematics.compute_velocity` is an {class}`xarray.DataArray` object,
 with the same **dimensions** as the original `position` **data variable**,
 so adding it to the existing `ds` makes sense and works seamlessly.
 

--- a/examples/compute_kinematics.py
+++ b/examples/compute_kinematics.py
@@ -117,18 +117,18 @@ plt.gcf().show()
 # %%
 # Compute displacement
 # ---------------------
-# The :mod:`movement.analysis.kinematics` module provides functions to compute
+# The :mod:`movement.kinematics` module provides functions to compute
 # various kinematic quantities,
 # such as displacement, velocity, and acceleration.
 # We can start off by computing the distance travelled by the mice along
 # their trajectories:
 
-import movement.analysis.kinematics as kin
+import movement.kinematics as kin
 
 displacement = kin.compute_displacement(position)
 
 # %%
-# The :func:`movement.analysis.kinematics.compute_displacement`
+# The :func:`movement.kinematics.compute_displacement`
 # function will return a data array equivalent to the ``position`` one,
 # but holding displacement data along the ``space`` axis, rather than
 # position data.
@@ -269,7 +269,7 @@ print(
 velocity = kin.compute_velocity(position)
 
 # %%
-# The :func:`movement.analysis.kinematics.compute_velocity`
+# The :func:`movement.kinematics.compute_velocity`
 # function will return a data array equivalent to
 # the ``position`` one, but holding velocity data along the ``space`` axis,
 # rather than position data. Notice how ``xarray`` nicely deals with the

--- a/examples/filter_and_interpolate.py
+++ b/examples/filter_and_interpolate.py
@@ -9,8 +9,8 @@ missing values.
 # Imports
 # -------
 from movement import sample_data
-from movement.analysis.kinematics import compute_velocity
 from movement.filtering import filter_by_confidence, interpolate_over_time
+from movement.kinematics import compute_velocity
 
 # %%
 # Load a sample dataset

--- a/movement/kinematics.py
+++ b/movement/kinematics.py
@@ -290,7 +290,7 @@ def compute_head_direction_vector(
     """Compute the 2D head direction vector given two keypoints on the head.
 
     This function is an alias for :func:`compute_forward_vector()\
-    <movement.analysis.kinematics.compute_forward_vector>`. For more
+    <movement.kinematics.compute_forward_vector>`. For more
     detailed information on how the head direction vector is computed,
     please refer to the documentation for that function.
 

--- a/tests/test_integration/test_kinematics_vector_transform.py
+++ b/tests/test_integration/test_kinematics_vector_transform.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-import movement.analysis.kinematics as kin
+import movement.kinematics as kin
 from movement.utils import vector
 
 

--- a/tests/test_unit/test_kinematics.py
+++ b/tests/test_unit/test_kinematics.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from movement.analysis import kinematics
+from movement import kinematics
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Refactoring

**Why is this PR needed?**

Closes #320.

The "analysis" folder was unnecessary, because it only contains the `kinematics.py` module, and it made our import statements unnecessarily long and complicated.

**What does this PR do?**

I removed the `analysis` folder, and moved `kinematics.py` to be a "top-level" module - i.e. instead of `movement.analysis.kinematics` we have `movement.kinematics`.

I then searched and replaced `.analysis.kinematics` with `.kinematics`, throughout the repo.

## References

Related to #327 and #328, but those will be further discussed and tackled separately.

## How has this PR been tested?

Existing tests still pass, and docs still build successfully.

## Is this a breaking change?

Yes.

## Does this PR require an update to the documentation?

Automatically done.

## Checklist:

- [x] The code has been tested locally
- [n/a] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
