### PR TITLE
Fix for check-manifest pre-commit hook in Python 3.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
       hooks:
           - id: check-manifest
             args: [--no-build-isolation]
-            additional_dependencies: [setuptools-scm]
+            additional_dependencies: [setuptools-scm, wheel]
     - repo: https://github.com/codespell-project/codespell
       # Configuration for codespell is in pyproject.toml
       rev: v2.3.0


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
With Python 3.12, `pre-commit run check-manifest` returns an error of missing dependencies -- see more details in [this issue](https://github.com/neuroinformatics-unit/python-cookiecutter/pull/126).

To fix it,`wheel` needs to be specified as a dependency of `check-manifest` in the pre-commit config.

This error doesn't show up in CI because:
- in [CI](https://github.com/neuroinformatics-unit/actions/blob/main/check_manifest/action.yml), we run `check-manifest` with Python 3.10 and without the `--no-build-isolation` flag.
- the linting action runs on [python 3.10](https://github.com/neuroinformatics-unit/actions/blob/bd77478abf60d6fac828158f4e56caf806cb6865/lint/action.yml#L12)

## Question
- Right now, when we say we support Python 3.12 in practice we mean we run the code tests in Python 3.12. 
- But should we ensure other bits, like the developer tools, also run on the Python versions we support?
- If so, maybe it makes sense if we ensure that the CI actions related to precommits run the latest python version?

**What does this PR do?**
Adds `wheel` as a dependency to `check-manifest` in the pre-commit config.

## References

The most relevant is [this issue](https://github.com/neuroinformatics-unit/python-cookiecutter/pull/126). from the cookiecutter repo.

## How has this PR been tested?

Tests pass locally and in CI.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
