### PR TITLE
Launch napari plugin with `movement launch`

### DIFF
--- a/movement/cli_entrypoint.py
+++ b/movement/cli_entrypoint.py
@@ -2,6 +2,8 @@
 
 import argparse
 import platform
+import subprocess
+import sys
 
 import numpy as np
 import pandas as pd
@@ -41,11 +43,18 @@ def main() -> None:
     """Entrypoint for the CLI."""
     parser = argparse.ArgumentParser(prog="movement")
     subparsers = parser.add_subparsers(dest="command", title="commands")
+
     # Add 'info' command
     info_parser = subparsers.add_parser(
         "info", help="output diagnostic information about the environment"
     )
     info_parser.set_defaults(func=info)
+
+    # Add 'launch' command
+    launch_parser = subparsers.add_parser(
+        "launch", help="launch the movement plugin in napari"
+    )
+    launch_parser.set_defaults(func=launch)
 
     args = parser.parse_args()
     if args.command is None:
@@ -66,6 +75,21 @@ def info() -> None:
         f"     pandas: {pd.__version__}\n"
         f"     Platform: {platform.platform()}\n"
     )
+
+
+def launch() -> None:
+    """Launch the movement plugin in napari."""
+    try:
+        # Use sys.executable to ensure the correct Python interpreter is used
+        subprocess.run(
+            [sys.executable, "-m", "napari", "-w", "movement"], check=True
+        )
+    except subprocess.CalledProcessError as e:
+        # if subprocess.run() fails with non-zero exit code
+        print(
+            "\nAn error occurred while launching the movement plugin "
+            f"for napari:\n  {e}"
+        )
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_unit/test_cli_entrypoint.py
+++ b/tests/test_unit/test_cli_entrypoint.py
@@ -1,3 +1,5 @@
+import subprocess
+import sys
 from contextlib import nullcontext as does_not_raise
 from unittest.mock import patch
 
@@ -21,6 +23,7 @@ from movement.cli_entrypoint import main
     ],
 )
 def test_entrypoint_command(command, expected_exception):
+    """Test the entrypoint with different commands: 'info', 'invalid', ''."""
     with (
         patch("sys.argv", command),
         patch("builtins.print") as mock_print,
@@ -29,3 +32,30 @@ def test_entrypoint_command(command, expected_exception):
         main()
         printed_message = " ".join(map(str, mock_print.call_args.args))
         assert e in printed_message
+
+
+@pytest.mark.parametrize(
+    "run_side_effect, expected_message",
+    [
+        (None, ""),  # No error
+        (subprocess.CalledProcessError(1, "napari"), "error occurred while"),
+    ],
+)
+def test_launch_command(run_side_effect, expected_message, capsys):
+    """Test the 'launch' command.
+
+    We mock the subprocess.run function to avoid actually launching napari.
+    """
+    with (
+        patch("sys.argv", ["movement", "launch"]),
+        patch("subprocess.run", side_effect=run_side_effect) as mock_run,
+    ):
+        main()
+        # Assert that subprocess.run was called with the correct arguments
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        assert args[0] == sys.executable
+        assert args[1:] == ["-m", "napari", "-w", "movement"]
+        # Assert that the expected message was printed
+        captured = capsys.readouterr()
+        assert expected_message in captured.out


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

This was brought up by @lochhh while reviewing #253.

> We have in movement CLI movement info. We could also have movement gui as an alias to napari -w movement.

**What does this PR do?**

Adds a new CLI entry point, called `movement launch`, which aliases to `python -m napari -w movement` (i.e. launch napari with the movement plugin docked). I'm open to different names for this command.

## References

- raised during the review of #253
- PR introducing the `movement info` entry point #176

## How has this PR been tested?

I had troubles extending the existing unit test with parametrisation, so I added a separate test for the `movement launch` command. Let me know if there's a better way.

It would be nice to test if the command works as expected on Windows.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

Yes, but this will be part of the upcoming user guide for the `napari plugin` #283.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
