### PR TITLE
Reorder dimensions

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -110,7 +110,7 @@ sphinx_gallery_conf = {
         "dependencies": ["environment.yml"],
     },
     "reference_url": {"movement": None},
-    "default_thumb_file": "source/_static/data_icon.png",  # default thumbnail image  
+    "default_thumb_file": "source/_static/data_icon.png",  # default thumbnail image
     "remove_config_comments": True,
     # do not render config params set as # sphinx_gallery_config [= value]
 }
@@ -206,6 +206,7 @@ myst_url_schemes = {
 intersphinx_mapping = {
     "xarray": ("https://docs.xarray.dev/en/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/reference/", None),
+    "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
 }
 
 

--- a/docs/source/user_guide/input_output.md
+++ b/docs/source/user_guide/input_output.md
@@ -93,7 +93,7 @@ with three keypoints each: ``snout``, ``centre``, and ``tail_base``. These keypo
 import numpy as np
 
 ds = load_poses.from_numpy(
-    position_array=np.random.rand((100, 2, 3, 2)),
+    position_array=np.random.rand(100, 2, 3, 2),
     confidence_array=np.ones((100, 2, 3)),
     individual_names=["Alice", "Bob"],
     keypoint_names=["snout", "centre", "tail_base"],
@@ -256,7 +256,7 @@ with open(filepath, mode="w", newline="") as file:
             writer.writerow([frame, individual, x, y, width, height, confidence])
 
 ```
-Alternatively, we can convert the `movement` bounding boxes' dataset to a pandas DataFrame with the {func}`.xarray.DataArray.to_dataframe()` method, wrangle the dataframe as required, and then apply the {func}`.pandas.DataFrame.to_csv()` method to save the data as a .csv file.
+Alternatively, we can convert the `movement` bounding boxes' dataset to a pandas DataFrame with the {meth}`xarray.DataArray.to_dataframe` method, wrangle the dataframe as required, and then apply the {meth}`pandas.DataFrame.to_csv` method to save the data as a .csv file.
 
 
 (target-sample-data)=

--- a/docs/source/user_guide/movement_dataset.md
+++ b/docs/source/user_guide/movement_dataset.md
@@ -43,15 +43,15 @@ print(ds)
 and we would obtain an output such as:
 ```
 <xarray.Dataset> Size: 27kB
-Dimensions:      (time: 601, individuals: 3, keypoints: 1, space: 2)
+Dimensions:      (time: 601, space: 2, keypoints: 1, individuals: 3)
 Coordinates:
   * time         (time) float64 5kB 0.0 0.02 0.04 0.06 ... 11.96 11.98 12.0
-  * individuals  (individuals) <U10 120B 'AEON3B_NTP' 'AEON3B_TP1' 'AEON3B_TP2'
-  * keypoints    (keypoints) <U8 32B 'centroid'
   * space        (space) <U1 8B 'x' 'y'
+  * keypoints    (keypoints) <U8 32B 'centroid'
+  * individuals  (individuals) <U10 120B 'AEON3B_NTP' 'AEON3B_TP1' 'AEON3B_TP2'
 Data variables:
-    position     (time, individuals, keypoints, space) float32 14kB 770.3 ......
-    confidence   (time, individuals, keypoints) float32 7kB nan nan ... nan nan
+    position     (time, space, keypoints, individuals) float32 14kB 770.3 ......
+    confidence   (time, keypoints, individuals) float32 7kB nan nan ... nan nan
 Attributes:
     fps:              50.0
     time_unit:        seconds
@@ -78,14 +78,14 @@ print(ds)
 and the last command would print out:
 ```
 <xarray.Dataset> Size: 19kB
-Dimensions:      (time: 5, individuals: 86, space: 2)
+Dimensions:      (time: 5, space: 2, individuals: 86)
 Coordinates:
   * time         (time) int64 40B 0 1 2 3 4
-  * individuals  (individuals) <U5 2kB 'id_1' 'id_2' 'id_3' ... 'id_89' 'id_90'
   * space        (space) <U1 8B 'x' 'y'
+  * individuals  (individuals) <U5 2kB 'id_1' 'id_2' 'id_3' ... 'id_89' 'id_90'
 Data variables:
-    position     (time, individuals, space) float64 7kB 871.8 ... 905.3
-    shape        (time, individuals, space) float64 7kB 60.0 53.0 ... 51.0 36.0
+    position     (time, space, individuals) float64 7kB 901.8 ... 923.3
+    shape        (time, space, individuals) float64 7kB 60.0 30.0 ... 72.0 36.0
     confidence   (time, individuals) float64 3kB nan nan nan nan ... nan nan nan
 Attributes:
     fps:              None
@@ -114,25 +114,25 @@ the labelled "ticks" along each axis are called **coordinates** (`coords`).
 :::{tab-item} Poses dataset
 A `movement` poses dataset has the following **dimensions**:
 - `time`, with size equal to the number of frames in the video.
-- `individuals`, with size equal to the number of tracked individuals/instances.
-- `keypoints`, with size equal to the number of tracked keypoints per individual.
 - `space`, which is the number of spatial dimensions. Currently, we support only 2D poses.
+- `keypoints`, with size equal to the number of tracked keypoints per individual.
+- `individuals`, with size equal to the number of tracked individuals/instances.
 :::
 
 :::{tab-item} Bounding boxes' dataset
 A `movement` bounding boxes dataset has the following **dimensions**s:
 - `time`, with size equal to the number of frames in the video.
-- `individuals`, with size equal to the number of tracked individuals/instances.
 - `space`, which is the number of spatial dimensions. Currently, we support only 2D bounding boxes data.
+- `individuals`, with size equal to the number of tracked individuals/instances.
 Notice that these are the same dimensions as for a poses dataset, except for the `keypoints` dimension.
 :::
 ::::
 
 In both cases, appropriate **coordinates** are assigned to each **dimension**.
-- `individuals` are labelled with a list of unique names (e.g. `mouse1`, `mouse2`, etc. or `id_0`, `id_1`, etc.).
-- `keypoints` are likewise labelled with a list of unique body part names, e.g. `snout`, `right_ear`, etc. Note that this dimension only exists in the poses dataset.
-- `space` is labelled with either `x`, `y` (2D) or `x`, `y`, `z` (3D). Note that bounding boxes datasets are restricted to 2D space.
 - `time` is labelled in seconds if `fps` is provided, otherwise the **coordinates** are expressed in frames (ascending 0-indexed integers).
+- `space` is labelled with either `x`, `y` (2D) or `x`, `y`, `z` (3D). Note that bounding boxes datasets are restricted to 2D space.
+- `keypoints` are likewise labelled with a list of unique body part names, e.g. `snout`, `right_ear`, etc. Note that this dimension only exists in the poses dataset.
+- `individuals` are labelled with a list of unique names (e.g. `mouse1`, `mouse2`, etc. or `id_0`, `id_1`, etc.).
 
 :::{dropdown} Additional dimensions
 :color: info
@@ -156,14 +156,14 @@ The specific data variables stored are slightly different between a `movement` p
 ::::{tab-set}
 :::{tab-item} Poses dataset
 A `movement` poses dataset contains two **data variables**:
-- `position`: the 2D or 3D locations of the keypoints over time, with shape (`time`, `individuals`, `keypoints`, `space`).
-- `confidence`: the confidence scores associated with each predicted keypoint (as reported by the pose estimation model), with shape (`time`, `individuals`, `keypoints`).
+- `position`: the 2D or 3D locations of the keypoints over time, with shape (`time`, `space`, `keypoints`, `individuals`).
+- `confidence`: the confidence scores associated with each predicted keypoint (as reported by the pose estimation model), with shape (`time`, `keypoints`, `individuals`).
 :::
 
 :::{tab-item} Bounding boxes' dataset
 A `movement` bounding boxes dataset contains three **data variables**:
-- `position`: the 2D locations of the bounding boxes' centroids over time, with shape (`time`, `individuals`, `space`).
-- `shape`: the width and height of the bounding boxes over time, with shape (`time`, `individuals`, `space`).
+- `position`: the 2D locations of the bounding boxes' centroids over time, with shape (`time`, `space`, `individuals`).
+- `shape`: the width and height of the bounding boxes over time, with shape (`time`, `space`, `individuals`).
 - `confidence`: the confidence scores associated with each predicted bounding box, with shape (`time`, `individuals`).
 :::
 ::::

--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -36,12 +36,12 @@ def from_numpy(
     Parameters
     ----------
     position_array : np.ndarray
-        Array of shape (n_frames, n_individuals, n_space)
+        Array of shape (n_frames, n_space, n_individuals)
         containing the tracks of the bounding boxes' centroids.
         It will be converted to a :class:`xarray.DataArray` object
         named "position".
     shape_array : np.ndarray
-        Array of shape (n_frames, n_individuals, n_space)
+        Array of shape (n_frames, n_space, n_individuals)
         containing the shape of the bounding boxes. The shape of a bounding
         box is its width (extent along the x-axis of the image) and height
         (extent along the y-axis of the image). It will be converted to a
@@ -56,7 +56,7 @@ def from_numpy(
         If None (default), bounding boxes are assigned names based on the size
         of the ``position_array``. The names will be in the format of
         ``id_<N>``, where <N>  is an integer from 0 to
-        ``position_array.shape[1]-1`` (i.e., "id_0", "id_1"...).
+        ``position_array.shape[-1]-1`` (i.e., "id_0", "id_1"...).
     frame_array : np.ndarray, optional
         Array of shape (n_frames, 1) containing the frame numbers for which
         bounding boxes are defined. If None (default), frame numbers will
@@ -376,9 +376,9 @@ def _numpy_arrays_from_via_tracks_file(
     The extracted numpy arrays are returned in a dictionary with the following
     keys:
 
-    - position_array (n_frames, n_individuals, n_space):
+    - position_array (n_frames, n_space, n_individuals):
         contains the trajectories of the bounding boxes' centroids.
-    - shape_array (n_frames, n_individuals, n_space):
+    - shape_array (n_frames, n_space, n_individuals):
         contains the shape of the bounding boxes (width and height).
     - confidence_array (n_frames, n_individuals):
         contains the confidence score of each bounding box.

--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -700,4 +700,4 @@ def _ds_from_valid_data(data: ValidBboxesDataset) -> xr.Dataset:
             "source_file": None,
             "ds_type": "bboxes",
         },
-    )
+    ).transpose("time", "space", "individuals")

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -699,9 +699,9 @@ def _ds_from_valid_data(data: ValidPosesDataset) -> xr.Dataset:
         },
         coords={
             DIM_NAMES[0]: time_coords,
-            DIM_NAMES[1]: data.individual_names,
-            DIM_NAMES[2]: data.keypoint_names,
             DIM_NAMES[3]: ["x", "y", "z"][:n_space],
+            DIM_NAMES[2]: data.keypoint_names,
+            DIM_NAMES[1]: data.individual_names,
         },
         attrs={
             "fps": data.fps,
@@ -710,4 +710,4 @@ def _ds_from_valid_data(data: ValidPosesDataset) -> xr.Dataset:
             "source_file": None,
             "ds_type": "poses",
         },
-    )
+    ).transpose("time", "space", "keypoints", "individuals")

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -463,7 +463,7 @@ def _ds_from_sleap_analysis_file(
 
     with h5py.File(file.path, "r") as f:
         # transpose to shape: (n_frames, n_space, n_keypoints, n_tracks)
-        tracks = f["tracks"][:].transpose((3, 1, 2, 0))
+        tracks = f["tracks"][:].transpose(3, 1, 2, 0)
         # Create an array of NaNs for the confidence scores
         scores = np.full(tracks.shape[:1] + tracks.shape[2:], np.nan)
         individual_names = [n.decode() for n in f["track_names"][:]] or None

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -45,7 +45,6 @@ def _ds_to_dlc_style_df(
     # Reverse the order of the dimensions except for the time dimension
     transpose_order = [0] + list(range(tracks_with_scores.ndim - 1, 0, -1))
     tracks_with_scores = tracks_with_scores.transpose(transpose_order)
-
     # Create DataFrame with multi-index columns
     df = pd.DataFrame(
         data=tracks_with_scores.reshape(ds.sizes["time"], -1),
@@ -53,7 +52,6 @@ def _ds_to_dlc_style_df(
         columns=columns,
         dtype=float,
     )
-
     return df
 
 

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -35,7 +35,6 @@ def _ds_to_dlc_style_df(
 
     """
     # Concatenate the pose tracks and confidence scores into one array
-    # and reverse the order of the dimensions except for the time dimension
     tracks_with_scores = np.concatenate(
         (
             ds.position.data,
@@ -43,6 +42,7 @@ def _ds_to_dlc_style_df(
         ),
         axis=1,
     )
+    # Reverse the order of the dimensions except for the time dimension
     transpose_order = [0] + list(range(tracks_with_scores.ndim - 1, 0, -1))
     tracks_with_scores = tracks_with_scores.transpose(transpose_order)
 
@@ -324,8 +324,8 @@ def to_sleap_analysis_file(ds: xr.Dataset, file_path: str | Path) -> None:
     pos_x = ds.position.sel(space="x").values
     # Mask denoting which individuals are present in each frame
     track_occupancy = (~np.all(np.isnan(pos_x), axis=1)).astype(int)
-    tracks = np.transpose(ds.position.data, (3, 1, 2, 0))
-    point_scores = np.transpose(ds.confidence.data, (2, 1, 0))
+    tracks = ds.position.data.transpose(3, 1, 2, 0)
+    point_scores = ds.confidence.data.T
     instance_scores = np.full((n_individuals, n_frames), np.nan, dtype=float)
     tracking_scores = np.full((n_individuals, n_frames), np.nan, dtype=float)
     labels_path = (

--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -76,10 +76,11 @@ class ValidPosesDataset:
     The validator ensures that within the ``movement poses`` dataset:
 
     - The required ``position_array`` is a numpy array
-      with the last dimension containing 2 or 3 spatial coordinates.
+      with the ``space`` dimension containing 2 or 3 spatial coordinates.
     - The optional ``confidence_array``, if provided, is a numpy array
-      with its shape matching the first three dimensions of the
-      ``position_array``; otherwise, it defaults to an array of NaNs.
+      with its shape matching that of the ``position_array``,
+      excluding the ``space`` dimension;
+      otherwise, it defaults to an array of NaNs.
     - The optional ``individual_names`` and ``keypoint_names``,
       if provided, match the number of individuals and keypoints
       in the dataset, respectively; otherwise, default names are assigned.
@@ -90,10 +91,10 @@ class ValidPosesDataset:
     Attributes
     ----------
     position_array : np.ndarray
-        Array of shape (n_frames, n_individuals, n_keypoints, n_space)
+        Array of shape (n_frames, n_space, n_keypoints, n_individuals)
         containing the poses.
     confidence_array : np.ndarray, optional
-        Array of shape (n_frames, n_individuals, n_keypoints) containing
+        Array of shape (n_frames, n_keypoints, n_individuals) containing
         the point-wise confidence scores.
         If None (default), the scores will be set to an array of NaNs.
     individual_names : list of str, optional
@@ -231,10 +232,11 @@ class ValidBboxesDataset:
     within the ``movement bboxes`` dataset:
 
     - The required ``position_array`` and ``shape_array`` are numpy arrays,
-      with the last dimension containing 2 spatial coordinates.
+      with the ``space`` dimension containing 2 spatial coordinates.
     - The optional ``confidence_array``, if provided, is a numpy array
-      with its shape matching the first two dimensions of the
-      ``position_array``; otherwise, it defaults to an array of NaNs.
+      with its shape matching that of the ``position_array``,
+      excluding the ``space`` dimension;
+      otherwise, it defaults to an array of NaNs.
     - The optional ``individual_names``, if provided, match the number of
       individuals in the dataset; otherwise, default names are assigned.
     - The optional ``frame_array``, if provided, is a column vector
@@ -247,10 +249,10 @@ class ValidBboxesDataset:
     Attributes
     ----------
     position_array : np.ndarray
-        Array of shape (n_frames, n_individuals, n_space)
+        Array of shape (n_frames, n_space, n_individuals)
         containing the tracks of the bounding boxes' centroids.
     shape_array : np.ndarray
-        Array of shape (n_frames, n_individuals, n_space)
+        Array of shape (n_frames, n_space, n_individuals)
         containing the shape of the bounding boxes. The shape of a bounding
         box is its width (extent along the x-axis of the image) and height
         (extent along the y-axis of the image).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -397,9 +397,9 @@ def valid_poses_dataset(valid_position_array, request):
         },
         coords={
             "time": np.arange(n_frames),
-            "individuals": [f"ind{i}" for i in range(1, n_individuals + 1)],
-            "keypoints": [f"key{i}" for i in range(1, n_keypoints + 1)],
             "space": ["x", "y"],
+            "keypoints": [f"key{i}" for i in range(1, n_keypoints + 1)],
+            "individuals": [f"ind{i}" for i in range(1, n_individuals + 1)],
         },
         attrs={
             "fps": None,
@@ -408,7 +408,7 @@ def valid_poses_dataset(valid_position_array, request):
             "source_file": "test.h5",
             "ds_type": "poses",
         },
-    )
+    ).transpose("time", "space", "keypoints", "individuals")
 
 
 @pytest.fixture
@@ -504,9 +504,9 @@ def valid_poses_dataset_uniform_linear_motion(
         },
         coords={
             dim_names[0]: np.arange(n_frames),
-            dim_names[1]: [f"id_{i}" for i in range(1, n_individuals + 1)],
-            dim_names[2]: ["centroid", "left", "right"],
             dim_names[3]: ["x", "y"],
+            dim_names[2]: ["centroid", "left", "right"],
+            dim_names[1]: [f"id_{i}" for i in range(1, n_individuals + 1)],
         },
         attrs={
             "fps": None,
@@ -515,7 +515,7 @@ def valid_poses_dataset_uniform_linear_motion(
             "source_file": "test_poses.h5",
             "ds_type": "poses",
         },
-    )
+    ).transpose("time", "space", "keypoints", "individuals")
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -318,7 +318,7 @@ def valid_bboxes_dataset(
             "source_file": "test_bboxes.csv",
             "ds_type": "bboxes",
         },
-    )
+    ).transpose("time", "space", "individuals")
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -890,7 +890,29 @@ class MovementDatasetAsserts:
 
     @staticmethod
     def valid_dataset(dataset, expected_values):
-        """Assert the dataset is a proper ``movement`` Dataset."""
+        """Assert the dataset is a proper ``movement`` Dataset.
+
+        Parameters
+        ----------
+        dataset : xr.Dataset
+            The dataset to validate.
+        expected_values : dict
+            A dictionary containing the expected values for the dataset.
+            It must contain the following keys:
+
+            - dim_names: list of expected dimension names as defined in
+              movement.validators.datasets
+            - vars_dims: dictionary of data variable names and the
+              corresponding dimension sizes
+
+            Optional keys include:
+
+            - file_path: Path to the source file
+            - fps: int, frames per second
+            - source_software: str, name of the software used to generate
+              the dataset
+
+        """
         expected_dim_names = expected_values.get("dim_names")
         expected_file_path = expected_values.get("file_path")
         assert isinstance(dataset, xr.Dataset)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -358,10 +358,10 @@ def valid_position_array():
     def _valid_position_array(array_type):
         """Return a valid position array."""
         # Unless specified, default is a multi_individual_array with
-        # 10 frames, 2 individuals, and 2 keypoints.
+        # 10 frames, 2 keypoints, and 2 individuals.
         n_frames = 10
-        n_individuals = 2
         n_keypoints = 2
+        n_individuals = 2
         base = np.arange(n_frames, dtype=float)[
             :, np.newaxis, np.newaxis, np.newaxis
         ]
@@ -369,8 +369,8 @@ def valid_position_array():
             n_keypoints = 1
         elif array_type == "single_individual_array":
             n_individuals = 1
-        x_points = np.repeat(base * base, n_individuals * n_keypoints)
-        y_points = np.repeat(base * 4, n_individuals * n_keypoints)
+        x_points = np.repeat(base * base, n_keypoints * n_individuals)
+        y_points = np.repeat(base * 4, n_keypoints * n_individuals)
         position_array = np.vstack((x_points, y_points))
         return position_array.reshape(n_frames, 2, n_keypoints, n_individuals)
 
@@ -396,7 +396,7 @@ def valid_poses_dataset(valid_position_array, request):
             "confidence": xr.DataArray(
                 np.repeat(
                     np.linspace(0.1, 1.0, n_frames),
-                    n_individuals * n_keypoints,
+                    n_keypoints * n_individuals,
                 ).reshape(position_array.shape[:1] + position_array.shape[2:]),
                 dims=dim_names[:1] + dim_names[2:],  # exclude "space"
             ),

--- a/tests/test_integration/test_kinematics_vector_transform.py
+++ b/tests/test_integration/test_kinematics_vector_transform.py
@@ -72,16 +72,16 @@ def test_cart2pol_transform_on_kinematics(
 
     # Build expected data array
     expected_array_pol = xr.DataArray(
-        np.stack(expected_kinematics_polar, axis=1),
+        np.stack(expected_kinematics_polar, axis=-1),
         # Stack along the "individuals" axis
-        dims=["time", "individuals", "space"],
+        dims=["time", "space", "individuals"],
     )
     if "keypoints" in ds.position.coords:
         expected_array_pol = expected_array_pol.expand_dims(
             {"keypoints": ds.position.coords["keypoints"].size}
         )
         expected_array_pol = expected_array_pol.transpose(
-            "time", "individuals", "keypoints", "space"
+            "time", "space", "keypoints", "individuals"
         )
 
     # Compare the values of the kinematic_array against the expected_array

--- a/tests/test_unit/test_kinematics.py
+++ b/tests/test_unit/test_kinematics.py
@@ -86,19 +86,19 @@ def test_kinematics_uniform_linear_motion(
     # and in the final xarray.DataArray
     expected_dims = ["time", "individuals"]
     if kinematic_variable in ["displacement", "velocity", "acceleration"]:
-        expected_dims.append("space")
+        expected_dims.insert(1, "space")
 
     # Build expected data array from the expected numpy array
     expected_array = xr.DataArray(
         # Stack along the "individuals" axis
-        np.stack(expected_kinematics, axis=1),
+        np.stack(expected_kinematics, axis=-1),
         dims=expected_dims,
     )
     if "keypoints" in position.coords:
         expected_array = expected_array.expand_dims(
             {"keypoints": position.coords["keypoints"].size}
         )
-        expected_dims.insert(2, "keypoints")
+        expected_dims.insert(-1, "keypoints")
         expected_array = expected_array.transpose(*expected_dims)
 
     # Compare the values of the kinematic_array against the expected_array
@@ -263,11 +263,11 @@ def test_path_length_across_time_ranges(
             num_segments -= 9 - np.floor(min(9, stop))
 
         expected_path_length = xr.DataArray(
-            np.ones((2, 3)) * np.sqrt(2) * num_segments,
-            dims=["individuals", "keypoints"],
+            np.ones((3, 2)) * np.sqrt(2) * num_segments,
+            dims=["keypoints", "individuals"],
             coords={
-                "individuals": position.coords["individuals"],
                 "keypoints": position.coords["keypoints"],
+                "individuals": position.coords["individuals"],
             },
         )
         xr.testing.assert_allclose(path_length, expected_path_length)

--- a/tests/test_unit/test_kinematics.py
+++ b/tests/test_unit/test_kinematics.py
@@ -140,19 +140,15 @@ def test_kinematics_with_dataset_with_nans(
     kinematic_array = getattr(kinematics, f"compute_{kinematic_variable}")(
         position
     )
-
     # compute n nans in kinematic array per individual
     n_nans_kinematics_per_indiv = [
         helpers.count_nans(kinematic_array.isel(individuals=i))
         for i in range(valid_dataset.sizes["individuals"])
     ]
-
     # expected nans per individual adjusted for space and keypoints dimensions
-    if "space" in kinematic_array.dims:
-        n_space_dims = position.sizes["space"]
-    else:
-        n_space_dims = 1
-
+    n_space_dims = (
+        position.sizes["space"] if "space" in kinematic_array.dims else 1
+    )
     expected_nans_adjusted = [
         n * n_space_dims * valid_dataset.sizes.get("keypoints", 1)
         for n in expected_nans_per_individual

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -181,39 +181,6 @@ def create_valid_from_numpy_inputs():
     return _create_valid_from_numpy_inputs
 
 
-@pytest.fixture()
-def df_input_via_tracks_small(via_tracks_file):
-    """Return the first 3 rows of the VIA tracks .csv file as a dataframe."""
-    df = pd.read_csv(via_tracks_file, sep=",", header=0)
-    return df.loc[:2, :]
-
-
-@pytest.fixture()
-def df_input_via_tracks_small_with_confidence(df_input_via_tracks_small):
-    """Return a dataframe with the first three rows of the VIA tracks .csv file
-    and add confidence values to the bounding boxes.
-    """
-    df = update_attribute_column(
-        df_input=df_input_via_tracks_small,
-        attribute_column_name="region_attributes",
-        dict_to_append={"confidence": "0.5"},
-    )
-    return df
-
-
-@pytest.fixture()
-def df_input_via_tracks_small_with_frame_number(df_input_via_tracks_small):
-    """Return a dataframe with the first three rows of the VIA tracks .csv file
-    and add frame number values to the bounding boxes.
-    """
-    df = update_attribute_column(
-        df_input=df_input_via_tracks_small,
-        attribute_column_name="file_attributes",
-        dict_to_append={"frame": "1"},
-    )
-    return df
-
-
 def assert_time_coordinates(ds, fps, start_frame=None, frame_array=None):
     """Assert that the time coordinates are as expected, depending on
     fps value and start_frame or time_array. start_frame takes precedence

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -176,8 +176,8 @@ def create_valid_from_numpy_inputs():
     def _create_valid_from_numpy_inputs(with_frame_array=False):
         """Return a dictionary of valid inputs to the `from_numpy` function."""
         required_inputs = {
-            "position_array": rng.random((n_frames, n_individuals, n_space)),
-            "shape_array": rng.random((n_frames, n_individuals, n_space)),
+            "position_array": rng.random((n_frames, n_space, n_individuals)),
+            "shape_array": rng.random((n_frames, n_space, n_individuals)),
             "confidence_array": rng.random((n_frames, n_individuals)),
             "individual_names": [
                 f"id_{id}" for id in individual_names_array.squeeze()
@@ -210,13 +210,13 @@ def assert_dataset(
     # Confidence has the same shape as position, except for the space dim
     assert dataset.confidence.shape == position_shape[:1] + position_shape[2:]
     # Check the dims and coords
-    DIM_NAMES = ValidBboxesDataset.DIM_NAMES
-    expected_dim_length_dict = {
-        DIM_NAMES[idx]: position_shape[i] for i, idx in enumerate([0, 2, 1])
-    }
+    dim_names = ValidBboxesDataset.DIM_NAMES
+    expected_dim_length_dict = dict(
+        zip(dim_names, position_shape, strict=True)
+    )
     assert expected_dim_length_dict == dataset.sizes
     # Check the coords
-    for dim in DIM_NAMES[1:]:
+    for dim in dim_names[1:]:
         assert all(isinstance(s, str) for s in dataset.coords[dim].values)
     assert all(coord in dataset.coords["space"] for coord in ["x", "y"])
     # Check the metadata attributes
@@ -746,6 +746,6 @@ def test_position_numpy_array_from_via_tracks_file(via_file_path):
 
     # Compare to extracted position array
     assert np.allclose(
-        bboxes_arrays["position_array"],  # frames, individuals, xy
-        np.stack(list_derived_centroids, axis=1),
+        bboxes_arrays["position_array"],  # frames, xy, individuals
+        np.stack(list_derived_centroids, axis=-1),
     )

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -22,7 +22,6 @@ def get_expected_attributes_dict():
         the input VIA file.
         """
         attributes_dict_per_test_file = {}
-
         # add expected attributes for the first 3 rows of
         # VIA_single-crab_MOCA-crab-1.csv
         attributes_dict_per_test_file["VIA_single-crab_MOCA-crab-1.csv"] = {
@@ -47,7 +46,6 @@ def get_expected_attributes_dict():
                 "track": np.ones((3,)),
             },
         }
-
         # add expected attributes for the first 3 rows of
         # "VIA_multiple-crabs_5-frames_labels.csv"
         attributes_dict_per_test_file[
@@ -70,7 +68,6 @@ def get_expected_attributes_dict():
                 "track": np.array([71, 70, 69]),
             },
         }
-
         # return ValueError if the filename is not defined
         if via_file_name not in attributes_dict_per_test_file:
             raise ValueError(
@@ -104,11 +101,9 @@ def create_df_input_via_tracks():
         """
         # read the VIA tracks .csv file as a dataframe
         df = pd.read_csv(via_file_path, sep=",", header=0)
-
         # optionally return the first 3 rows only
         if small:
             df = df.loc[:2, :]
-
         # optionally modify the dataframe to include data
         # under an attribute column
         if attribute_column_additions is None:
@@ -129,20 +124,17 @@ def update_attribute_column(
     """Update an attributes column in the dataframe."""
     # copy the dataframe
     df = df_input.copy()
-
     # update each attribute column in the dataframe
     for attribute_column_name in attribute_column_additions:
         # get the list of dicts to append to the column
         list_dicts_to_append = attribute_column_additions[
             attribute_column_name
         ]
-
         # get the column to update, and convert it to a list of dicts
         # (one dict per row)
         attributes_dicts = [
             ast.literal_eval(d) for d in df[attribute_column_name]
         ]
-
         # update each dict in the list
         # (if we only have one dict to append, append it to all rows)
         if len(list_dicts_to_append) == 1:
@@ -153,11 +145,9 @@ def update_attribute_column(
                 attributes_dicts, list_dicts_to_append, strict=True
             ):
                 d.update(dict_to_append)
-
         # update the relevant column in the dataframe and format
         # back to string
         df[attribute_column_name] = [str(d) for d in attributes_dicts]
-
     return df
 
 
@@ -165,8 +155,8 @@ def update_attribute_column(
 def create_valid_from_numpy_inputs():
     """Define a factory of valid inputs to "from_numpy" function."""
     n_frames = 5
-    n_individuals = 86
     n_space = 2
+    n_individuals = 86
     individual_names_array = np.arange(n_individuals).reshape(-1, 1)
     first_frame_number = 1  # should match sample file
 
@@ -182,7 +172,6 @@ def create_valid_from_numpy_inputs():
                 f"id_{id}" for id in individual_names_array.squeeze()
             ],
         }
-
         if with_frame_array:
             required_inputs["frame_array"] = np.arange(
                 first_frame_number, first_frame_number + n_frames
@@ -209,7 +198,6 @@ def df_input_via_tracks_small_with_confidence(df_input_via_tracks_small):
         attribute_column_name="region_attributes",
         dict_to_append={"confidence": "0.5"},
     )
-
     return df
 
 
@@ -223,7 +211,6 @@ def df_input_via_tracks_small_with_frame_number(df_input_via_tracks_small):
         attribute_column_name="file_attributes",
         dict_to_append={"frame": "1"},
     )
-
     return df
 
 
@@ -234,7 +221,6 @@ def assert_time_coordinates(ds, fps, start_frame=None, frame_array=None):
     """
     # scale time coordinates with 1/fps if provided
     scale = 1 / fps if fps else 1
-
     # build frame array from start_frame if provided
     if start_frame is not None:
         frame_array = np.array(
@@ -246,7 +232,6 @@ def assert_time_coordinates(ds, fps, start_frame=None, frame_array=None):
             "start_frame takes precedence over frame_array if "
             "both are provided."
         )
-
     # assert numpy array of time coordinates
     np.testing.assert_allclose(
         ds.coords["time"].data, np.array([f * scale for f in frame_array])
@@ -266,7 +251,6 @@ def test_from_file(
     software_to_loader = {
         "VIA-tracks": "movement.io.load_bboxes.from_via_tracks_file",
     }
-
     if source_software == "Unknown":
         with pytest.raises(ValueError, match="Unsupported source"):
             load_bboxes.from_file(
@@ -398,7 +382,6 @@ def test_from_numpy(
     """
     # get the input arrays
     from_numpy_inputs = create_valid_from_numpy_inputs(with_frame_array)
-
     # run general dataset checks
     ds = load_bboxes.from_numpy(
         **from_numpy_inputs,
@@ -471,7 +454,6 @@ def test_via_attribute_column_to_numpy(
         list_keys=list_keys,
         cast_fn=cast_fn,
     )
-
     attributes_dict = get_expected_attributes_dict(
         via_file_path.name
     )  # returns results for the first 3 rows
@@ -526,9 +508,7 @@ def test_extract_confidence_from_via_tracks_df(
         )
     else:
         df = create_df_input_via_tracks(via_file_path, small=True)
-
     confidence_array = load_bboxes._extract_confidence_from_via_tracks_df(df)
-
     assert np.array_equal(
         confidence_array, expected_confidence_array, equal_nan=True
     )
@@ -560,15 +540,12 @@ def test_extract_frame_number_from_via_tracks_df_filenames(
         via_file_path,
         small=True,
     )
-
     # the VIA tracks .csv files have no frames defined under the
     # "file_attributes" so the frame numbers should be extracted
     # from the filenames
     assert not all(["frame" in row for row in df["file_attributes"]])
-
     # extract frame number from df
     frame_array = load_bboxes._extract_frame_number_from_via_tracks_df(df)
-
     assert np.array_equal(frame_array, expected_frame_array)
 
 
@@ -615,11 +592,9 @@ def test_extract_frame_number_from_via_tracks_df_file_attributes(
         small=True,
         attribute_column_additions=attribute_column_additions,
     )
-
     # extract frame number from the dataframe
     # (should take precedence over the frame numbers in the filenames)
     frame_array = load_bboxes._extract_frame_number_from_via_tracks_df(df)
-
     assert np.array_equal(frame_array, expected_frame_array)
 
 
@@ -665,16 +640,13 @@ def test_fps_and_time_coords(
         fps=fps,
         use_frame_numbers_from_file=use_frame_numbers_from_file,
     )
-
     # check time unit
     assert ds.time_unit == expected_time_unit
-
     # check fps is as expected
     if bool(expected_fps):
         assert ds.fps == expected_fps
     else:
         assert ds.fps is None
-
     # check loading frame numbers from file
     if use_frame_numbers_from_file:
         assert_time_coordinates(
@@ -701,10 +673,7 @@ def test_df_from_via_tracks_file(
     """Test that the `_df_from_via_tracks_file` helper function correctly
     reads the VIA tracks .csv file as a dataframe.
     """
-    df = load_bboxes._df_from_via_tracks_file(
-        via_file_path,
-    )
-
+    df = load_bboxes._df_from_via_tracks_file(via_file_path)
     assert isinstance(df, pd.DataFrame)
     assert len(df.frame_number.unique()) == expected_n_frames
     assert len(df.ID.unique()) == expected_n_individuals
@@ -737,10 +706,8 @@ def test_position_numpy_array_from_via_tracks_file(via_file_path):
     bboxes_arrays = load_bboxes._numpy_arrays_from_via_tracks_file(
         via_file_path
     )
-
     # Read VIA tracks .csv file as a dataframe
     df = load_bboxes._df_from_via_tracks_file(via_file_path)
-
     # Compute centroid positions from the dataframe
     # (go through in the same order as ID array)
     list_derived_centroids = []
@@ -750,7 +717,6 @@ def test_position_numpy_array_from_via_tracks_file(via_file_path):
             [df_one_id.x + df_one_id.w / 2, df_one_id.y + df_one_id.h / 2]
         ).T  # frames, xy
         list_derived_centroids.append(centroid_position)
-
     # Compare to extracted position array
     assert np.allclose(
         bboxes_arrays["position_array"],  # frames, xy, individuals

--- a/tests/test_unit/test_load_poses.py
+++ b/tests/test_unit/test_load_poses.py
@@ -82,14 +82,13 @@ class TestLoadPoses:
             dataset.confidence.shape == position_shape[:1] + position_shape[2:]
         )
         # Check the dims
-        DIM_NAMES = ValidPosesDataset.DIM_NAMES
-        expected_dim_length_dict = {
-            DIM_NAMES[idx]: position_shape[i]
-            for i, idx in enumerate([0, 3, 2, 1])
-        }
+        dim_names = ValidPosesDataset.DIM_NAMES
+        expected_dim_length_dict = dict(
+            zip(dim_names, position_shape, strict=True)
+        )
         assert expected_dim_length_dict == dataset.sizes
         # Check the coords
-        for dim in DIM_NAMES[1:]:
+        for dim in dim_names[1:]:
             assert all(isinstance(s, str) for s in dataset.coords[dim].values)
         assert all(coord in dataset.coords["space"] for coord in ["x", "y"])
         # Check the metadata attributes

--- a/tests/test_unit/test_load_poses.py
+++ b/tests/test_unit/test_load_poses.py
@@ -1,3 +1,5 @@
+"""Test suite for the load_poses module."""
+
 from unittest.mock import patch
 
 import h5py
@@ -12,313 +14,313 @@ from movement.io import load_poses
 from movement.validators.datasets import ValidPosesDataset
 
 
-class TestLoadPoses:
-    """Test suite for the load_poses module."""
-
-    @pytest.fixture
-    def sleap_slp_file_without_tracks(self, tmp_path):
-        """Mock and return the path to a SLEAP .slp file without tracks."""
-        sleap_file = DATA_PATHS.get("SLEAP_single-mouse_EPM.predictions.slp")
-        labels = read_labels(sleap_file)
-        file_path = tmp_path / "track_is_none.slp"
-        lfs = []
-        for lf in labels.labeled_frames:
-            instances = []
-            for inst in lf.instances:
-                inst.track = None
-                inst.tracking_score = 0
-                instances.append(inst)
-            lfs.append(
-                LabeledFrame(
-                    video=lf.video, frame_idx=lf.frame_idx, instances=instances
-                )
+@pytest.fixture
+def sleap_slp_file_without_tracks(tmp_path):
+    """Mock and return the path to a SLEAP .slp file without tracks."""
+    sleap_file = DATA_PATHS.get("SLEAP_single-mouse_EPM.predictions.slp")
+    labels = read_labels(sleap_file)
+    file_path = tmp_path / "track_is_none.slp"
+    lfs = []
+    for lf in labels.labeled_frames:
+        instances = []
+        for inst in lf.instances:
+            inst.track = None
+            inst.tracking_score = 0
+            instances.append(inst)
+        lfs.append(
+            LabeledFrame(
+                video=lf.video, frame_idx=lf.frame_idx, instances=instances
             )
-        write_labels(
-            file_path,
-            Labels(
-                labeled_frames=lfs,
-                videos=labels.videos,
-                skeletons=labels.skeletons,
-            ),
         )
-        return file_path
-
-    @pytest.fixture
-    def sleap_h5_file_without_tracks(self, tmp_path):
-        """Mock and return the path to a SLEAP .h5 file without tracks."""
-        sleap_file = DATA_PATHS.get("SLEAP_single-mouse_EPM.analysis.h5")
-        file_path = tmp_path / "track_is_none.h5"
-        with h5py.File(sleap_file, "r") as f1, h5py.File(file_path, "w") as f2:
-            for key in list(f1.keys()):
-                if key == "track_names":
-                    f2.create_dataset(key, data=[])
-                else:
-                    f1.copy(key, f2, name=key)
-        return file_path
-
-    @pytest.fixture(
-        params=[
-            "sleap_h5_file_without_tracks",
-            "sleap_slp_file_without_tracks",
-        ]
+    write_labels(
+        file_path,
+        Labels(
+            labeled_frames=lfs,
+            videos=labels.videos,
+            skeletons=labels.skeletons,
+        ),
     )
-    def sleap_file_without_tracks(self, request):
-        """Fixture to parametrize the SLEAP files without tracks."""
-        return request.getfixturevalue(request.param)
+    return file_path
 
-    def assert_dataset(
-        self, dataset, file_path=None, expected_source_software=None
-    ):
-        """Assert that the dataset is a proper xarray Dataset."""
-        assert isinstance(dataset, xr.Dataset)
-        # Expected variables are present and of right shape/type
-        for var in ["position", "confidence"]:
-            assert var in dataset.data_vars
-            assert isinstance(dataset[var], xr.DataArray)
-        assert dataset.position.ndim == 4
-        position_shape = dataset.position.shape
-        # Confidence has the same shape as position, except for the space dim
-        assert (
-            dataset.confidence.shape == position_shape[:1] + position_shape[2:]
-        )
-        # Check the dims
-        dim_names = ValidPosesDataset.DIM_NAMES
-        expected_dim_length_dict = dict(
-            zip(dim_names, position_shape, strict=True)
-        )
-        assert expected_dim_length_dict == dataset.sizes
-        # Check the coords
-        for dim in dim_names[1:]:
-            assert all(isinstance(s, str) for s in dataset.coords[dim].values)
-        assert all(coord in dataset.coords["space"] for coord in ["x", "y"])
-        # Check the metadata attributes
-        assert (
-            dataset.source_file is None
-            if file_path is None
-            else dataset.source_file == file_path.as_posix()
-        )
-        assert (
-            dataset.source_software is None
-            if expected_source_software is None
-            else dataset.source_software == expected_source_software
-        )
-        assert dataset.fps is None
 
-    def test_load_from_sleap_file(self, sleap_file):
-        """Test that loading pose tracks from valid SLEAP files
-        returns a proper Dataset.
-        """
-        ds = load_poses.from_sleap_file(sleap_file)
-        self.assert_dataset(ds, sleap_file, "SLEAP")
+@pytest.fixture
+def sleap_h5_file_without_tracks(tmp_path):
+    """Mock and return the path to a SLEAP .h5 file without tracks."""
+    sleap_file = DATA_PATHS.get("SLEAP_single-mouse_EPM.analysis.h5")
+    file_path = tmp_path / "track_is_none.h5"
+    with h5py.File(sleap_file, "r") as f1, h5py.File(file_path, "w") as f2:
+        for key in list(f1.keys()):
+            if key == "track_names":
+                f2.create_dataset(key, data=[])
+            else:
+                f1.copy(key, f2, name=key)
+    return file_path
 
-    def test_load_from_sleap_file_without_tracks(
-        self, sleap_file_without_tracks
-    ):
-        """Test that loading pose tracks from valid SLEAP files
-        with tracks removed returns a dataset that matches the
-        original file, except for the individual names which are
-        set to default.
-        """
-        ds_from_trackless = load_poses.from_sleap_file(
-            sleap_file_without_tracks
-        )
-        ds_from_tracked = load_poses.from_sleap_file(
-            DATA_PATHS.get("SLEAP_single-mouse_EPM.analysis.h5")
-        )
-        # Check if the "individuals" coordinate matches
-        # the assigned default "individuals_0"
-        assert ds_from_trackless.individuals == ["individual_0"]
-        xr.testing.assert_allclose(
-            ds_from_trackless.drop_vars("individuals"),
-            ds_from_tracked.drop_vars("individuals"),
-        )
 
-    @pytest.mark.parametrize(
-        "slp_file, h5_file",
-        [
-            (
-                "SLEAP_single-mouse_EPM.analysis.h5",
-                "SLEAP_single-mouse_EPM.predictions.slp",
-            ),
-            (
-                "SLEAP_three-mice_Aeon_proofread.analysis.h5",
-                "SLEAP_three-mice_Aeon_proofread.predictions.slp",
-            ),
-            (
-                "SLEAP_three-mice_Aeon_mixed-labels.analysis.h5",
-                "SLEAP_three-mice_Aeon_mixed-labels.predictions.slp",
-            ),
-        ],
+@pytest.fixture(
+    params=[
+        "sleap_h5_file_without_tracks",
+        "sleap_slp_file_without_tracks",
+    ]
+)
+def sleap_file_without_tracks(request):
+    """Fixture to parametrize the SLEAP files without tracks."""
+    return request.getfixturevalue(request.param)
+
+
+def assert_dataset(dataset, file_path=None, expected_source_software=None):
+    """Assert that the dataset is a proper xarray Dataset."""
+    assert isinstance(dataset, xr.Dataset)
+    # Expected variables are present and of right shape/type
+    for var in ["position", "confidence"]:
+        assert var in dataset.data_vars
+        assert isinstance(dataset[var], xr.DataArray)
+    assert dataset.position.ndim == 4
+
+    position_shape = dataset.position.shape
+    # Confidence has the same shape as position, except for the space dim
+    assert dataset.confidence.shape == position_shape[:1] + position_shape[2:]
+    # Check the dims
+    dim_names = ValidPosesDataset.DIM_NAMES
+    expected_dim_length_dict = dict(
+        zip(dim_names, position_shape, strict=True)
     )
-    def test_load_from_sleap_slp_file_or_h5_file_returns_same(
-        self, slp_file, h5_file
-    ):
-        """Test that loading pose tracks from SLEAP .slp and .h5 files
-        return the same Dataset.
-        """
-        slp_file_path = DATA_PATHS.get(slp_file)
-        h5_file_path = DATA_PATHS.get(h5_file)
-        ds_from_slp = load_poses.from_sleap_file(slp_file_path)
-        ds_from_h5 = load_poses.from_sleap_file(h5_file_path)
-        xr.testing.assert_allclose(ds_from_h5, ds_from_slp)
-
-    @pytest.mark.parametrize(
-        "file_name",
-        [
-            "DLC_single-wasp.predictions.h5",
-            "DLC_single-wasp.predictions.csv",
-            "DLC_two-mice.predictions.csv",
-        ],
+    assert expected_dim_length_dict == dataset.sizes
+    # Check the coords
+    for dim in dim_names[1:]:
+        assert all(isinstance(s, str) for s in dataset.coords[dim].values)
+    assert all(coord in dataset.coords["space"] for coord in ["x", "y"])
+    # Check the metadata attributes
+    assert (
+        dataset.source_file is None
+        if file_path is None
+        else dataset.source_file == file_path.as_posix()
     )
-    def test_load_from_dlc_file(self, file_name):
-        """Test that loading pose tracks from valid DLC files
-        returns a proper Dataset.
-        """
-        file_path = DATA_PATHS.get(file_name)
-        ds = load_poses.from_dlc_file(file_path)
-        self.assert_dataset(ds, file_path, "DeepLabCut")
-
-    @pytest.mark.parametrize(
-        "source_software", ["DeepLabCut", "LightningPose", None]
+    assert (
+        dataset.source_software is None
+        if expected_source_software is None
+        else dataset.source_software == expected_source_software
     )
-    def test_load_from_dlc_style_df(self, dlc_style_df, source_software):
-        """Test that loading pose tracks from a valid DLC-style DataFrame
-        returns a proper Dataset.
-        """
-        ds = load_poses.from_dlc_style_df(
-            dlc_style_df, source_software=source_software
-        )
-        self.assert_dataset(ds, expected_source_software=source_software)
+    assert dataset.fps is None
 
-    def test_load_from_dlc_file_csv_or_h5_file_returns_same(self):
-        """Test that loading pose tracks from DLC .csv and .h5 files
-        return the same Dataset.
-        """
-        csv_file_path = DATA_PATHS.get("DLC_single-wasp.predictions.csv")
-        h5_file_path = DATA_PATHS.get("DLC_single-wasp.predictions.h5")
-        ds_from_csv = load_poses.from_dlc_file(csv_file_path)
-        ds_from_h5 = load_poses.from_dlc_file(h5_file_path)
-        xr.testing.assert_allclose(ds_from_h5, ds_from_csv)
 
-    @pytest.mark.parametrize(
-        "fps, expected_fps, expected_time_unit",
-        [
-            (None, None, "frames"),
-            (-5, None, "frames"),
-            (0, None, "frames"),
-            (30, 30, "seconds"),
-            (60.0, 60, "seconds"),
-        ],
+def test_load_from_sleap_file(sleap_file):
+    """Test that loading pose tracks from valid SLEAP files
+    returns a proper Dataset.
+    """
+    ds = load_poses.from_sleap_file(sleap_file)
+    assert_dataset(ds, sleap_file, "SLEAP")
+
+
+def test_load_from_sleap_file_without_tracks(sleap_file_without_tracks):
+    """Test that loading pose tracks from valid SLEAP files
+    with tracks removed returns a dataset that matches the
+    original file, except for the individual names which are
+    set to default.
+    """
+    ds_from_trackless = load_poses.from_sleap_file(sleap_file_without_tracks)
+    ds_from_tracked = load_poses.from_sleap_file(
+        DATA_PATHS.get("SLEAP_single-mouse_EPM.analysis.h5")
     )
-    def test_fps_and_time_coords(self, fps, expected_fps, expected_time_unit):
-        """Test that time coordinates are set according to the provided fps."""
-        ds = load_poses.from_sleap_file(
-            DATA_PATHS.get("SLEAP_three-mice_Aeon_proofread.analysis.h5"),
-            fps=fps,
-        )
-        assert ds.time_unit == expected_time_unit
-        if expected_fps is None:
-            assert ds.fps is expected_fps
-        else:
-            assert ds.fps == expected_fps
-            np.testing.assert_allclose(
-                ds.coords["time"].data,
-                np.arange(ds.sizes["time"], dtype=int) / ds.attrs["fps"],
-            )
-
-    @pytest.mark.parametrize(
-        "file_name",
-        [
-            "LP_mouse-face_AIND.predictions.csv",
-            "LP_mouse-twoview_AIND.predictions.csv",
-        ],
+    # Check if the "individuals" coordinate matches
+    # the assigned default "individuals_0"
+    assert ds_from_trackless.individuals == ["individual_0"]
+    xr.testing.assert_allclose(
+        ds_from_trackless.drop_vars("individuals"),
+        ds_from_tracked.drop_vars("individuals"),
     )
-    def test_load_from_lp_file(self, file_name):
-        """Test that loading pose tracks from valid LightningPose (LP) files
-        returns a proper Dataset.
-        """
-        file_path = DATA_PATHS.get(file_name)
-        ds = load_poses.from_lp_file(file_path)
-        self.assert_dataset(ds, file_path, "LightningPose")
 
-    def test_load_from_lp_or_dlc_file_returns_same(self):
-        """Test that loading a single-animal DeepLabCut-style .csv file
-        using either the `from_lp_file` or `from_dlc_file` function
-        returns the same Dataset (except for the source_software).
-        """
-        file_path = DATA_PATHS.get("LP_mouse-face_AIND.predictions.csv")
-        ds_drom_lp = load_poses.from_lp_file(file_path)
-        ds_from_dlc = load_poses.from_dlc_file(file_path)
-        xr.testing.assert_allclose(ds_from_dlc, ds_drom_lp)
-        assert ds_drom_lp.source_software == "LightningPose"
-        assert ds_from_dlc.source_software == "DeepLabCut"
 
-    def test_load_multi_individual_from_lp_file_raises(self):
-        """Test that loading a multi-individual .csv file using the
-        `from_lp_file` function raises a ValueError.
-        """
-        file_path = DATA_PATHS.get("DLC_two-mice.predictions.csv")
-        with pytest.raises(ValueError):
-            load_poses.from_lp_file(file_path)
+@pytest.mark.parametrize(
+    "slp_file, h5_file",
+    [
+        (
+            "SLEAP_single-mouse_EPM.analysis.h5",
+            "SLEAP_single-mouse_EPM.predictions.slp",
+        ),
+        (
+            "SLEAP_three-mice_Aeon_proofread.analysis.h5",
+            "SLEAP_three-mice_Aeon_proofread.predictions.slp",
+        ),
+        (
+            "SLEAP_three-mice_Aeon_mixed-labels.analysis.h5",
+            "SLEAP_three-mice_Aeon_mixed-labels.predictions.slp",
+        ),
+    ],
+)
+def test_load_from_sleap_slp_file_or_h5_file_returns_same(slp_file, h5_file):
+    """Test that loading pose tracks from SLEAP .slp and .h5 files
+    return the same Dataset.
+    """
+    slp_file_path = DATA_PATHS.get(slp_file)
+    h5_file_path = DATA_PATHS.get(h5_file)
+    ds_from_slp = load_poses.from_sleap_file(slp_file_path)
+    ds_from_h5 = load_poses.from_sleap_file(h5_file_path)
+    xr.testing.assert_allclose(ds_from_h5, ds_from_slp)
 
-    @pytest.mark.parametrize(
-        "source_software", ["SLEAP", "DeepLabCut", "LightningPose", "Unknown"]
+
+@pytest.mark.parametrize(
+    "file_name",
+    [
+        "DLC_single-wasp.predictions.h5",
+        "DLC_single-wasp.predictions.csv",
+        "DLC_two-mice.predictions.csv",
+    ],
+)
+def test_load_from_dlc_file(file_name):
+    """Test that loading pose tracks from valid DLC files
+    returns a proper Dataset.
+    """
+    file_path = DATA_PATHS.get(file_name)
+    ds = load_poses.from_dlc_file(file_path)
+    assert_dataset(ds, file_path, "DeepLabCut")
+
+
+@pytest.mark.parametrize(
+    "source_software", ["DeepLabCut", "LightningPose", None]
+)
+def test_load_from_dlc_style_df(dlc_style_df, source_software):
+    """Test that loading pose tracks from a valid DLC-style DataFrame
+    returns a proper Dataset.
+    """
+    ds = load_poses.from_dlc_style_df(
+        dlc_style_df, source_software=source_software
     )
-    @pytest.mark.parametrize("fps", [None, 30, 60.0])
-    def test_from_file_delegates_correctly(self, source_software, fps):
-        """Test that the from_file() function delegates to the correct
-        loader function according to the source_software.
-        """
-        software_to_loader = {
-            "SLEAP": "movement.io.load_poses.from_sleap_file",
-            "DeepLabCut": "movement.io.load_poses.from_dlc_file",
-            "LightningPose": "movement.io.load_poses.from_lp_file",
-        }
+    assert_dataset(ds, expected_source_software=source_software)
 
-        if source_software == "Unknown":
-            with pytest.raises(ValueError, match="Unsupported source"):
-                load_poses.from_file("some_file", source_software)
-        else:
-            with patch(software_to_loader[source_software]) as mock_loader:
-                load_poses.from_file("some_file", source_software, fps)
-                mock_loader.assert_called_with("some_file", fps)
 
-    @pytest.mark.parametrize("source_software", [None, "SLEAP"])
-    def test_from_numpy_valid(
-        self,
-        valid_position_array,
-        source_software,
-    ):
-        """Test that loading pose tracks from a multi-animal numpy array
-        with valid parameters returns a proper Dataset.
-        """
-        valid_position = valid_position_array("multi_individual_array")
-        rng = np.random.default_rng(seed=42)
-        valid_confidence = rng.random(valid_position.shape[:-1])
+def test_load_from_dlc_file_csv_or_h5_file_returns_same():
+    """Test that loading pose tracks from DLC .csv and .h5 files
+    return the same Dataset.
+    """
+    csv_file_path = DATA_PATHS.get("DLC_single-wasp.predictions.csv")
+    h5_file_path = DATA_PATHS.get("DLC_single-wasp.predictions.h5")
+    ds_from_csv = load_poses.from_dlc_file(csv_file_path)
+    ds_from_h5 = load_poses.from_dlc_file(h5_file_path)
+    xr.testing.assert_allclose(ds_from_h5, ds_from_csv)
 
-        ds = load_poses.from_numpy(
-            valid_position,
-            valid_confidence,
-            individual_names=["mouse1", "mouse2"],
-            keypoint_names=["snout", "tail"],
-            fps=None,
-            source_software=source_software,
-        )
-        self.assert_dataset(ds, expected_source_software=source_software)
 
-    def test_from_multiview_files(self):
-        """Test that the from_file() function delegates to the correct
-        loader function according to the source_software.
-        """
-        view_names = ["view_0", "view_1"]
-        file_path_dict = {
-            view: DATA_PATHS.get("DLC_single-wasp.predictions.h5")
-            for view in view_names
-        }
-        multi_view_ds = load_poses.from_multiview_files(
-            file_path_dict, source_software="DeepLabCut"
+@pytest.mark.parametrize(
+    "fps, expected_fps, expected_time_unit",
+    [
+        (None, None, "frames"),
+        (-5, None, "frames"),
+        (0, None, "frames"),
+        (30, 30, "seconds"),
+        (60.0, 60, "seconds"),
+    ],
+)
+def test_fps_and_time_coords(fps, expected_fps, expected_time_unit):
+    """Test that time coordinates are set according to the provided fps."""
+    ds = load_poses.from_sleap_file(
+        DATA_PATHS.get("SLEAP_three-mice_Aeon_proofread.analysis.h5"),
+        fps=fps,
+    )
+    assert ds.time_unit == expected_time_unit
+    if expected_fps is None:
+        assert ds.fps is expected_fps
+    else:
+        assert ds.fps == expected_fps
+        np.testing.assert_allclose(
+            ds.coords["time"].data,
+            np.arange(ds.sizes["time"], dtype=int) / ds.attrs["fps"],
         )
 
-        assert isinstance(multi_view_ds, xr.Dataset)
-        assert "view" in multi_view_ds.dims
-        assert multi_view_ds.view.values.tolist() == view_names
+
+@pytest.mark.parametrize(
+    "file_name",
+    [
+        "LP_mouse-face_AIND.predictions.csv",
+        "LP_mouse-twoview_AIND.predictions.csv",
+    ],
+)
+def test_load_from_lp_file(file_name):
+    """Test that loading pose tracks from valid LightningPose (LP) files
+    returns a proper Dataset.
+    """
+    file_path = DATA_PATHS.get(file_name)
+    ds = load_poses.from_lp_file(file_path)
+    assert_dataset(ds, file_path, "LightningPose")
+
+
+def test_load_from_lp_or_dlc_file_returns_same():
+    """Test that loading a single-animal DeepLabCut-style .csv file
+    using either the `from_lp_file` or `from_dlc_file` function
+    returns the same Dataset (except for the source_software).
+    """
+    file_path = DATA_PATHS.get("LP_mouse-face_AIND.predictions.csv")
+    ds_drom_lp = load_poses.from_lp_file(file_path)
+    ds_from_dlc = load_poses.from_dlc_file(file_path)
+    xr.testing.assert_allclose(ds_from_dlc, ds_drom_lp)
+    assert ds_drom_lp.source_software == "LightningPose"
+    assert ds_from_dlc.source_software == "DeepLabCut"
+
+
+def test_load_multi_individual_from_lp_file_raises():
+    """Test that loading a multi-individual .csv file using the
+    `from_lp_file` function raises a ValueError.
+    """
+    file_path = DATA_PATHS.get("DLC_two-mice.predictions.csv")
+    with pytest.raises(ValueError):
+        load_poses.from_lp_file(file_path)
+
+
+@pytest.mark.parametrize(
+    "source_software", ["SLEAP", "DeepLabCut", "LightningPose", "Unknown"]
+)
+@pytest.mark.parametrize("fps", [None, 30, 60.0])
+def test_from_file_delegates_correctly(source_software, fps):
+    """Test that the from_file() function delegates to the correct
+    loader function according to the source_software.
+    """
+    software_to_loader = {
+        "SLEAP": "movement.io.load_poses.from_sleap_file",
+        "DeepLabCut": "movement.io.load_poses.from_dlc_file",
+        "LightningPose": "movement.io.load_poses.from_lp_file",
+    }
+
+    if source_software == "Unknown":
+        with pytest.raises(ValueError, match="Unsupported source"):
+            load_poses.from_file("some_file", source_software)
+    else:
+        with patch(software_to_loader[source_software]) as mock_loader:
+            load_poses.from_file("some_file", source_software, fps)
+            mock_loader.assert_called_with("some_file", fps)
+
+
+@pytest.mark.parametrize("source_software", [None, "SLEAP"])
+def test_from_numpy_valid(valid_position_array, source_software):
+    """Test that loading pose tracks from a multi-animal numpy array
+    with valid parameters returns a proper Dataset.
+    """
+    valid_position = valid_position_array("multi_individual_array")
+    rng = np.random.default_rng(seed=42)
+    valid_confidence = rng.random(valid_position.shape[:-1])
+
+    ds = load_poses.from_numpy(
+        valid_position,
+        valid_confidence,
+        individual_names=["mouse1", "mouse2"],
+        keypoint_names=["snout", "tail"],
+        fps=None,
+        source_software=source_software,
+    )
+    assert_dataset(ds, expected_source_software=source_software)
+
+
+def test_from_multiview_files():
+    """Test that the from_file() function delegates to the correct
+    loader function according to the source_software.
+    """
+    view_names = ["view_0", "view_1"]
+    file_path_dict = {
+        view: DATA_PATHS.get("DLC_single-wasp.predictions.h5")
+        for view in view_names
+    }
+    multi_view_ds = load_poses.from_multiview_files(
+        file_path_dict, source_software="DeepLabCut"
+    )
+
+    assert isinstance(multi_view_ds, xr.Dataset)
+    assert "view" in multi_view_ds.dims
+    assert multi_view_ds.view.values.tolist() == view_names

--- a/tests/test_unit/test_load_poses.py
+++ b/tests/test_unit/test_load_poses.py
@@ -269,7 +269,6 @@ def test_from_file_delegates_correctly(source_software, fps):
         "DeepLabCut": "movement.io.load_poses.from_dlc_file",
         "LightningPose": "movement.io.load_poses.from_lp_file",
     }
-
     if source_software == "Unknown":
         with pytest.raises(ValueError, match="Unsupported source"):
             load_poses.from_file("some_file", source_software)
@@ -316,7 +315,6 @@ def test_from_multiview_files():
     multi_view_ds = load_poses.from_multiview_files(
         file_path_dict, source_software="DeepLabCut"
     )
-
     assert isinstance(multi_view_ds, xr.Dataset)
     assert "view" in multi_view_ds.dims
     assert multi_view_ds.view.values.tolist() == view_names

--- a/tests/test_unit/test_validators/test_datasets_validators.py
+++ b/tests/test_unit/test_validators/test_datasets_validators.py
@@ -75,10 +75,10 @@ invalid_bboxes_arrays_and_expected_log = {
             f"Expected a numpy array, but got {type(list())}.",
         ),  # not an ndarray
         (
-            np.zeros((10, 2, 3)),
+            np.zeros((10, 3, 2)),
             f"Expected '{key}_array' to have 2 spatial "
             "coordinates, but got 3.",
-        ),  # last dim not 2
+        ),  # `space` dim (at idx 1) not 2
     ]
     for key in ["position", "shape"]
 }
@@ -101,10 +101,10 @@ invalid_bboxes_arrays_and_expected_log = {
             "Expected 'position_array' to have 4 dimensions, but got 3.",
         ),  # not 4d
         (
-            np.zeros((10, 2, 3, 4)),
+            np.zeros((10, 4, 3, 2)),
             "Expected 'position_array' to have 2 or 3 "
             "spatial dimensions, but got 4.",
-        ),  # last dim not 2 or 3
+        ),  # `space` dim (at idx 1) not 2 or 3
     ],
 )
 def test_poses_dataset_validator_with_invalid_position_array(


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
This PR closes #236. 

**What does this PR do?**
This PR 
- reorders the dimensions of movement `poses` and `bboxes` datasets as follows:
  - `poses`: `("time", "individuals", "keypoints", "space")` &rarr; `("time", "space", "keypoints", "individuals")`
  - `bboxes`:  `("time", "individuals", "space")` &rarr; `("time", "space", "individuals")`
- updates the docs (by first checking changed files, and then searching for the keyword "shape" in the entire directory) 
- removes the duplicated `assert_dataset` in `test_load_poses` and `test_load_bboxes` by introducing a new helper class `MovementDatasetAsserts` in `conftest.py` that provides a common `valid_dataset` function to assert poses and bboxes dataset validity in tests
- replaces if-else-blocks with a ternary operator
- fixes broken examples (in docstrings and in .md)
- fixes broken references to external packages

**Strategy**:
- [x] Directly transpose after datasets are loaded as xarray.Datasets (i.e. validators are still using the old "dims order") 
- [x] Make tests pass (by transposing fixtures) for both poses and bboxes
- [x] Change the order in Validators (at the root) so that we don't need to transpose the dataset after loading them into movement
- [x] Drop transpose in test fixtures and make tests pass by creating fixtures with the new "dims order"
- [x] Refactor tests (e.g. [duplicated code](https://github.com/neuroinformatics-unit/movement/pull/351/checks?check_run_id=33561095934) )
- [x] Update documentation/docstrings

## References
#236

## How has this PR been tested?
Tests pass locally and on CI.

## Does this PR require an update to the documentation?
Done.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
