### PR TITLE
Loading function for Anipose data

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -201,6 +201,7 @@ myst_url_schemes = {
     "xarray": "https://docs.xarray.dev/en/stable/{{path}}#{{fragment}}",
     "lp": "https://lightning-pose.readthedocs.io/en/stable/{{path}}#{{fragment}}",
     "via": "https://www.robots.ox.ac.uk/~vgg/software/via/{{path}}#{{fragment}}",
+    "anipose": "https://anipose.readthedocs.io/en/latest/",
 }
 
 intersphinx_mapping = {

--- a/docs/source/user_guide/input_output.md
+++ b/docs/source/user_guide/input_output.md
@@ -10,6 +10,7 @@ To analyse pose tracks, `movement` supports loading data from various frameworks
 - [DeepLabCut](dlc:) (DLC)
 - [SLEAP](sleap:) (SLEAP)
 - [LightingPose](lp:) (LP)
+- [Anipose](anipose:) (Anipose)
 
 To analyse bounding boxes' tracks, `movement` currently supports the [VGG Image Annotator](via:) (VIA) format for [tracks annotation](via:docs/face_track_annotation.html).
 
@@ -81,6 +82,22 @@ ds = load_poses.from_lp_file("/path/to/file.analysis.csv", fps=30)
 ds = load_poses.from_file(
     "/path/to/file.analysis.csv", source_software="LightningPose", fps=30
 )
+```
+:::
+
+:::{tab-item} Anipose
+
+To load Anipose files in .csv format:
+```python
+ds = load_poses.from_anipose_file(
+    "/path/to/file.analysis.csv", fps=30, individual_name="individual_0"
+)  # We can optionally specify the individual name, by default it is "individual_0"
+
+# or equivalently
+ds = load_poses.from_file(
+    "/path/to/file.analysis.csv", source_software="Anipose", fps=30, individual_name="individual_0"
+)
+
 ```
 :::
 

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -801,4 +801,6 @@ def from_anipose_file(
     file = ValidAniposeCSV(file.path)
     anipose_triangulation_df = pd.read_csv(file.path)
 
-    return from_anipose_style_df(anipose_triangulation_df, individual_name)
+    return from_anipose_style_df(anipose_triangulation_df, 
+                                 fps=fps,
+                                 individual_name=individual_name)

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -96,8 +96,9 @@ def from_numpy(
 
 def from_file(
     file_path: Path | str,
-    source_software: Literal["DeepLabCut", "SLEAP", "LightningPose"],
+    source_software: Literal["DeepLabCut", "SLEAP", "LightningPose", "Anipose"],
     fps: float | None = None,
+    **kwargs,
 ) -> xr.Dataset:
     """Create a ``movement`` poses dataset from any supported file.
 
@@ -114,6 +115,8 @@ def from_file(
     fps : float, optional
         The number of frames per second in the video. If None (default),
         the ``time`` coordinates will be in frame numbers.
+    **kwargs : dict, optional
+        Additional keyword arguments to pass to specific loading functions.
 
     Returns
     -------
@@ -126,6 +129,7 @@ def from_file(
     movement.io.load_poses.from_dlc_file
     movement.io.load_poses.from_sleap_file
     movement.io.load_poses.from_lp_file
+    movement.io.load_poses.from_anipose_file
 
     Examples
     --------
@@ -141,6 +145,8 @@ def from_file(
         return from_sleap_file(file_path, fps)
     elif source_software == "LightningPose":
         return from_lp_file(file_path, fps)
+    elif source_software == "Anipose":
+        return from_anipose_file(file_path, fps, **kwargs)
     else:
         raise log_error(
             ValueError, f"Unsupported source software: {source_software}"
@@ -808,10 +814,10 @@ def from_anipose_file(
 
     """
     file = ValidFile(
-    file_path,
-    expected_permission="r",
-    expected_suffix=[".csv"],
-)
+        file_path,
+        expected_permission="r",
+        expected_suffix=[".csv"],
+    )
     file = ValidAniposeCSV(file.path)
     anipose_triangulation_df = pd.read_csv(file.path)
 

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -735,11 +735,15 @@ def from_anipose_df(anipose_triangulation_df, individual_name="individual_0"):
     n_keypoints = len(keypoint_names)
 
     # Initialize arrays and fill
-    position_array = np.zeros((n_frames, 3, n_keypoints, 1))  # 1 for single individual
+    position_array = np.zeros(
+        (n_frames, 3, n_keypoints, 1)
+    )  # 1 for single individual
     confidence_array = np.zeros((n_frames, n_keypoints, 1))
     for i, kp in enumerate(keypoint_names):
         for j, coord in enumerate(["x", "y", "z"]):
-            position_array[:, j, i, 0] = anipose_triangulation_df[f"{kp}_{coord}"]
+            position_array[:, j, i, 0] = anipose_triangulation_df[
+                f"{kp}_{coord}"
+            ]
         confidence_array[:, i, 0] = anipose_triangulation_df[f"{kp}_score"]
 
     individual_names = [individual_name]

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -793,8 +793,6 @@ def from_anipose_file(
     ----------
     file_path : pathlib.Path
         Path to the Anipose triangulation csv file
-    individual_name : str, optional
-        Name of the individual, by default "individual_0"
     fps : float, optional
         The number of frames per second in the video. If None (default),
         the ``time`` coordinates will be in frame units.

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -13,7 +13,12 @@ from sleap_io.model.labels import Labels
 
 from movement.utils.logging import log_error, log_warning
 from movement.validators.datasets import ValidPosesDataset
-from movement.validators.files import ValidAniposeCSV, ValidDeepLabCutCSV, ValidFile, ValidHDF5
+from movement.validators.files import (
+    ValidAniposeCSV,
+    ValidDeepLabCutCSV,
+    ValidFile,
+    ValidHDF5,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -707,8 +712,11 @@ def from_anipose_style_df(
 
     Parameters
     ----------
-    anipose_triangulation_df : pd.DataFrame
+    df : pd.DataFrame
         Anipose triangulation dataframe
+    fps : float, optional
+        The number of frames per second in the video. If None (default),
+        the ``time`` coordinates will be in frame units.
     individual_name : str, optional
         Name of the individual, by default "individual_0"
 
@@ -776,8 +784,13 @@ def from_anipose_file(
 
     Parameters
     ----------
-    anipose_csv_path : pathlib.Path
+    file_path : pathlib.Path
         Path to the Anipose triangulation csv file
+    individual_name : str, optional
+        Name of the individual, by default "individual_0"
+    fps : float, optional
+        The number of frames per second in the video. If None (default),
+        the ``time`` coordinates will be in frame units.
     individual_name : str, optional
         Name of the individual, by default "individual_0"
 
@@ -789,8 +802,9 @@ def from_anipose_file(
 
     Notes
     -----
-    We currently do not load all information, only x, y, z, and score (confidence)
-    for each keypoint. Future versions will load n of cameras and error.
+    We currently do not load all information, only x, y, z, and score
+    (confidence) for each keypoint. Future versions will load n of cameras
+    and error.
 
     """
     file = ValidFile(

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -700,7 +700,7 @@ def _ds_from_valid_data(data: ValidPosesDataset) -> xr.Dataset:
 
 def from_anipose_df(anipose_triangulation_df, individual_name="individual_0"):
     """Convert triangulation dataframe to xarray dataset.
-    
+
     Reshape dataframe with columns keypoint1_x, keypoint1_y, keypoint1_z,
     keypoint1_confidence_score,keypoint2_x, keypoint2_y, keypoint2_z,
     keypoint2_confidence_score...to array of positions with dimensions

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -118,7 +118,8 @@ def from_file(
         The number of frames per second in the video. If None (default),
         the ``time`` coordinates will be in frame numbers.
     **kwargs : dict, optional
-        Additional keyword arguments to pass to specific loading functions.
+        Additional keyword arguments to pass to the software-specific
+        loading functions that are listed under "See Also".
 
     Returns
     -------

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -702,7 +702,7 @@ def from_anipose_style_df(
     df: pd.DataFrame,
     fps: float | None = None,
     individual_name: str = "individual_0",
-) -> xr.Dataset
+) -> xr.Dataset:
     """Create a ``movement`` poses dataset from an Anipose 3D dataframe.
 
     Parameters

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -112,7 +112,7 @@ def from_file(
         ``from_slp_file()`` or ``from_lp_file()`` functions. One of these
         these functions will be called internally, based on
         the value of ``source_software``.
-    source_software : "DeepLabCut", "SLEAP" "LightningPose", or "Anipose"
+    source_software : "DeepLabCut", "SLEAP", "LightningPose", or "Anipose"
         The source software of the file.
     fps : float, optional
         The number of frames per second in the video. If None (default),

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -700,10 +700,12 @@ def _ds_from_valid_data(data: ValidPosesDataset) -> xr.Dataset:
 
 def from_anipose_df(anipose_triangulation_df, individual_name="individual_0"):
     """Convert triangulation dataframe to xarray dataset.
-    Reshape dataframe with columns keypoint1_x, keypoint1_y, keypoint1_z, keypoint1_confidence_score,
-    keypoint2_x, keypoint2_y, keypoint2_z, keypoint2_confidence_score, ...
-    to array of positions with dimensions time, individuals, keypoints, space,
-    and array of confidence scores with dimensions time, individuals, keypoints
+    
+    Reshape dataframe with columns keypoint1_x, keypoint1_y, keypoint1_z,
+    keypoint1_confidence_score,keypoint2_x, keypoint2_y, keypoint2_z,
+    keypoint2_confidence_score...to array of positions with dimensions
+    time, individuals, keypoints, space, and array of confidence scores
+    with dimensions time, individuals, keypoints.
 
     Parameters
     ----------

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -696,3 +696,67 @@ def _ds_from_valid_data(data: ValidPosesDataset) -> xr.Dataset:
             "ds_type": "poses",
         },
     )
+
+
+def from_anipose_df(anipose_triangulation_df, individual_name="individual_0"):
+    """Convert triangulation dataframe to xarray dataset.
+    Reshape dataframe with columns keypoint1_x, keypoint1_y, keypoint1_z, keypoint1_confidence_score, 
+    keypoint2_x, keypoint2_y, keypoint2_z, keypoint2_confidence_score, ...
+    to array of positions with dimensions time, individuals, keypoints, space,
+    and array of confidence scores with dimensions time, individuals, keypoints
+
+    Parameters
+    ----------
+    anipose_triangulation_df : pd.DataFrame
+        Anipose triangulation dataframe
+    individual_name : str, optional
+        Name of the individual, by default "individual_0"
+
+    Returns
+    -------
+    xarray.Dataset
+        ``movement`` dataset containing the pose tracks, confidence scores,
+        and associated metadata.
+    """
+    keypoint_names = sorted(list(set([col.rsplit('_', 1)[0] for col in anipose_triangulation_df.columns 
+                                   if any(col.endswith(f'_{s}') for s in ['x','y','z'])])))
+
+    n_frames = len(anipose_triangulation_df)
+    n_keypoints = len(keypoint_names)
+
+    # Initialize arrays and fill
+    position_array = np.zeros((n_frames, 1, n_keypoints, 3))  # 1 for single individual
+    confidence_array = np.zeros((n_frames, 1, n_keypoints))
+    for i, kp in enumerate(keypoint_names):
+        for j, coord in enumerate(['x', 'y', 'z']):
+            position_array[:, 0, i, j] = anipose_triangulation_df[f'{kp}_{coord}']
+        confidence_array[:, 0, i] = anipose_triangulation_df[f'{kp}_score']
+
+    individual_names = [individual_name]
+
+    return from_numpy(position_array=position_array,
+                      confidence_array=confidence_array, 
+                      individual_names=individual_names,
+                      keypoint_names=keypoint_names,
+                      source_software="anipose_triangulation")
+
+
+def from_anipose_csv(anipose_csv_path, individual_name="individual_0"):
+    """Convert anipose csv to xarray dataset.
+
+    Parameters
+    ----------
+    anipose_csv_path : pathlib.Path
+        Path to the Anipose triangulation csv file
+    individual_name : str, optional
+        Name of the individual, by default "individual_0"
+
+    Returns
+    -------
+    xarray.Dataset
+        ``movement`` dataset containing the pose tracks, confidence scores,
+        and associated metadata.
+    """
+    anipose_triangulation_df = pd.read_csv(anipose_csv_path)
+    # TODO add a validator for the anipose csv file at this level?
+    return from_anipose_df(anipose_triangulation_df, individual_name)

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -818,9 +818,9 @@ def from_anipose_file(
         expected_permission="r",
         expected_suffix=[".csv"],
     )
-    file = ValidAniposeCSV(file.path)
-    anipose_triangulation_df = pd.read_csv(file.path)
+    anipose_file = ValidAniposeCSV(file.path)
+    anipose_df = pd.read_csv(anipose_file.path)
 
     return from_anipose_style_df(
-        anipose_triangulation_df, fps=fps, individual_name=individual_name
+        anipose_df, fps=fps, individual_name=individual_name
     )

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -741,8 +741,8 @@ def from_anipose_style_df(
     Reshape dataframe with columns keypoint1_x, keypoint1_y, keypoint1_z,
     keypoint1_confidence_score,keypoint2_x, keypoint2_y, keypoint2_z,
     keypoint2_confidence_score...to array of positions with dimensions
-    time, individuals, keypoints, space, and array of confidence scores
-    with dimensions time, individuals, keypoints.
+    time, space, keypoints, individuals, and array of confidence scores
+    with dimensions time, keypoints, individuals.
 
     """
     keypoint_names = sorted(

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -96,7 +96,10 @@ def from_numpy(
 
 def from_file(
     file_path: Path | str,
-    source_software: Literal["DeepLabCut", "SLEAP", "LightningPose", "Anipose"],
+    source_software: Literal["DeepLabCut",
+                             "SLEAP",
+                             "LightningPose",
+                             "Anipose"] | None = None,
     fps: float | None = None,
     **kwargs,
 ) -> xr.Dataset:

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -735,16 +735,12 @@ def from_anipose_df(anipose_triangulation_df, individual_name="individual_0"):
     n_keypoints = len(keypoint_names)
 
     # Initialize arrays and fill
-    position_array = np.zeros(
-        (n_frames, 1, n_keypoints, 3)
-    )  # 1 for single individual
-    confidence_array = np.zeros((n_frames, 1, n_keypoints))
+    position_array = np.zeros((n_frames, 3, n_keypoints, 1))  # 1 for single individual
+    confidence_array = np.zeros((n_frames, n_keypoints, 1))
     for i, kp in enumerate(keypoint_names):
         for j, coord in enumerate(["x", "y", "z"]):
-            position_array[:, 0, i, j] = anipose_triangulation_df[
-                f"{kp}_{coord}"
-            ]
-        confidence_array[:, 0, i] = anipose_triangulation_df[f"{kp}_score"]
+            position_array[:, j, i, 0] = anipose_triangulation_df[f"{kp}_{coord}"]
+        confidence_array[:, i, 0] = anipose_triangulation_df[f"{kp}_score"]
 
     individual_names = [individual_name]
 

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -792,7 +792,7 @@ def from_anipose_file(
     Parameters
     ----------
     file_path : pathlib.Path
-        Path to the Anipose triangulation csv file
+        Path to the Anipose triangulation .csv file
     fps : float, optional
         The number of frames per second in the video. If None (default),
         the ``time`` coordinates will be in frame units.

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -112,7 +112,7 @@ def from_file(
         ``from_slp_file()`` or ``from_lp_file()`` functions. One of these
         these functions will be called internally, based on
         the value of ``source_software``.
-    source_software : "DeepLabCut", "SLEAP" or "LightningPose"
+    source_software : "DeepLabCut", "SLEAP" "LightningPose", or "Anipose"
         The source software of the file.
     fps : float, optional
         The number of frames per second in the video. If None (default),
@@ -739,9 +739,9 @@ def from_anipose_style_df(
     Notes
     -----
     Reshape dataframe with columns keypoint1_x, keypoint1_y, keypoint1_z,
-    keypoint1_confidence_score,keypoint2_x, keypoint2_y, keypoint2_z,
-    keypoint2_confidence_score...to array of positions with dimensions
-    time, space, keypoints, individuals, and array of confidence scores
+    keypoint1_score,keypoint2_x, keypoint2_y, keypoint2_z,
+    keypoint2_score...to array of positions with dimensions
+    time, space, keypoints, individuals, and array of confidence (from scores)
     with dimensions time, keypoints, individuals.
 
     """

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -285,7 +285,7 @@ class ValidAniposeCSV:
                 f"Expected: {expected_headers}.",
             )
 
-        # For all other headers, check they have expected suffixes and base names
+        # For other headers, check they have expected suffixes and base names
         other_headers = [h for h in headers if h not in expected_headers]
         for header in other_headers:
             # Check suffix

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -244,9 +244,7 @@ class ValidAniposeCSV:
 
     @path.validator
     def _file_contains_expected_columns(self, attribute, value):
-        """Ensure that the .csv file contains the expected columns.
-
-        """
+        """Ensure that the .csv file contains the expected columns."""
         expected_column_suffixes = [
             "_x",
             "_y",
@@ -284,7 +282,9 @@ class ValidAniposeCSV:
             )
 
         # For other headers, check they have expected suffixes and base names
-        other_columns = [col for col in columns if col not in expected_non_keypoint_columns]
+        other_columns = [
+            col for col in columns if col not in expected_non_keypoint_columns
+        ]
         for column in other_columns:
             # Check suffix
             if not any(

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -236,20 +236,18 @@ class ValidAniposeCSV:
     Raises
     ------
     ValueError
-        If the .csv file does not contain the expected DeepLabCut index column
-        levels among its top rows.
+        If the .csv file does not contain the expected Anipose columns.
 
     """
 
     path: Path = field(validator=validators.instance_of(Path))
 
     @path.validator
-    def _file_contains_expected_headers(self, attribute, value):
-        """Ensure that the .csv file contains the expected headers.
+    def _file_contains_expected_columns(self, attribute, value):
+        """Ensure that the .csv file contains the expected columns.
 
-        These are to be found among the top 4 rows of the file.
         """
-        expected_header_suffixes = [
+        expected_column_suffixes = [
             "_x",
             "_y",
             "_z",
@@ -257,7 +255,7 @@ class ValidAniposeCSV:
             "_error",
             "_ncams",
         ]
-        expected_headers = [
+        expected_non_keypoint_columns = [
             "fnum",
             "center_0",
             "center_1",
@@ -275,39 +273,39 @@ class ValidAniposeCSV:
 
         # Read the first line of the CSV to get the headers
         with open(value) as f:
-            headers = f.readline().strip().split(",")
+            columns = f.readline().strip().split(",")
 
         # Check that all expected headers are present
-        if not all(h in headers for h in expected_headers):
+        if not all(col in columns for col in expected_non_keypoint_columns):
             raise log_error(
                 ValueError,
-                "CSV file is missing some expected headers."
-                f"Expected: {expected_headers}.",
+                "CSV file is missing some expected columns."
+                f"Expected: {expected_non_keypoint_columns}.",
             )
 
         # For other headers, check they have expected suffixes and base names
-        other_headers = [h for h in headers if h not in expected_headers]
-        for header in other_headers:
+        other_columns = [col for col in columns if col not in expected_non_keypoint_columns]
+        for column in other_columns:
             # Check suffix
             if not any(
-                header.endswith(suffix) for suffix in expected_header_suffixes
+                column.endswith(suffix) for suffix in expected_column_suffixes
             ):
                 raise log_error(
                     ValueError,
-                    f"Header {header} does not have an expected suffix.",
+                    f"Column {column} ends with an unexpected suffix.",
                 )
             # Get base name by removing suffix
-            base = header.rsplit("_", 1)[0]
+            base = column.rsplit("_", 1)[0]
             # Check base name has all expected suffixes
             if not all(
-                f"{base}{suffix}" in headers
-                for suffix in expected_header_suffixes
+                f"{base}{suffix}" in columns
+                for suffix in expected_column_suffixes
             ):
                 raise log_error(
                     ValueError,
-                    f"Base header {base} is missing some expected suffixes."
-                    f"Expected: {expected_header_suffixes};"
-                    f"Got: {headers}.",
+                    f"Keypoint {base} is missing some expected suffixes."
+                    f"Expected: {expected_column_suffixes};"
+                    f"Got: {columns}.",
                 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,6 @@ def pytest_configure():
         paths_dict = fetch_dataset_paths(file_name)
         data_path = paths_dict.get("poses") or paths_dict.get("bboxes")
         pytest.DATA_PATHS[file_name] = data_path
-        print(file_name, data_path)
 
 
 @pytest.fixture(autouse=True)
@@ -198,6 +197,30 @@ def new_csv_file(tmp_path):
 def dlc_style_df():
     """Return a valid DLC-style DataFrame."""
     return pd.read_hdf(pytest.DATA_PATHS.get("DLC_single-wasp.predictions.h5"))
+
+@pytest.fixture
+def missing_keypoint_headers_anipose_csv_file(tmp_path):
+    """Return the file path for a fake single-individual .csv file."""
+    file_path = tmp_path / "missing_keypoint_headers.csv"
+    headers = ["fnum", "center_0", "center_1", "center_2", "M_00", "M_01", "M_02", "M_10", "M_11", "M_12", "M_20", "M_21", "M_22"]
+    headers.extend(["kp0_x", "kp0_y", "kp0_score", "kp0_error", "kp0_ncams"])
+    with open(file_path, "w") as f:
+        f.write(",".join(headers))
+        f.write("\n")
+        f.write(",".join(["1"] * len(headers)))
+    return file_path
+
+@pytest.fixture
+def spurious_header_anipose_csv_file(tmp_path):
+    """Return the file path for a fake single-individual .csv file."""
+    file_path = tmp_path / "spurious_header.csv"
+    headers = ["fnum", "center_0", "center_1", "center_2", "M_00", "M_01", "M_02", "M_10", "M_11", "M_12", "M_20", "M_21", "M_22"]
+    headers.extend(["funny_header"])
+    with open(file_path, "w") as f:
+        f.write(",".join(headers))
+        f.write("\n")
+        f.write(",".join(["1"] * len(headers)))
+    return file_path
 
 
 @pytest.fixture(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,6 +218,7 @@ def missing_keypoint_headers_anipose_csv_file(tmp_path):
         "M_21",
         "M_22",
     ]
+    # Here we are missing kp0_z:
     headers.extend(["kp0_x", "kp0_y", "kp0_score", "kp0_error", "kp0_ncams"])
     with open(file_path, "w") as f:
         f.write(",".join(headers))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,12 +198,26 @@ def dlc_style_df():
     """Return a valid DLC-style DataFrame."""
     return pd.read_hdf(pytest.DATA_PATHS.get("DLC_single-wasp.predictions.h5"))
 
+
 @pytest.fixture
 def missing_keypoint_headers_anipose_csv_file(tmp_path):
     """Return the file path for a fake single-individual .csv file."""
     file_path = tmp_path / "missing_keypoint_headers.csv"
-    headers = ["fnum", "center_0", "center_1", "center_2", "M_00", "M_01", 
-               "M_02", "M_10", "M_11", "M_12", "M_20", "M_21", "M_22"]
+    headers = [
+        "fnum",
+        "center_0",
+        "center_1",
+        "center_2",
+        "M_00",
+        "M_01",
+        "M_02",
+        "M_10",
+        "M_11",
+        "M_12",
+        "M_20",
+        "M_21",
+        "M_22",
+    ]
     headers.extend(["kp0_x", "kp0_y", "kp0_score", "kp0_error", "kp0_ncams"])
     with open(file_path, "w") as f:
         f.write(",".join(headers))
@@ -211,12 +225,26 @@ def missing_keypoint_headers_anipose_csv_file(tmp_path):
         f.write(",".join(["1"] * len(headers)))
     return file_path
 
+
 @pytest.fixture
 def spurious_header_anipose_csv_file(tmp_path):
     """Return the file path for a fake single-individual .csv file."""
     file_path = tmp_path / "spurious_header.csv"
-    headers = ["fnum", "center_0", "center_1", "center_2", "M_00", "M_01", 
-               "M_02", "M_10", "M_11", "M_12", "M_20", "M_21", "M_22"]
+    headers = [
+        "fnum",
+        "center_0",
+        "center_1",
+        "center_2",
+        "M_00",
+        "M_01",
+        "M_02",
+        "M_10",
+        "M_11",
+        "M_12",
+        "M_20",
+        "M_21",
+        "M_22",
+    ]
     headers.extend(["funny_header"])
     with open(file_path, "w") as f:
         f.write(",".join(headers))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -200,10 +200,10 @@ def dlc_style_df():
 
 
 @pytest.fixture
-def missing_keypoint_headers_anipose_csv_file(tmp_path):
+def missing_keypoint_columns_anipose_csv_file(tmp_path):
     """Return the file path for a fake single-individual .csv file."""
-    file_path = tmp_path / "missing_keypoint_headers.csv"
-    headers = [
+    file_path = tmp_path / "missing_keypoint_columns.csv"
+    columns = [
         "fnum",
         "center_0",
         "center_1",
@@ -219,19 +219,19 @@ def missing_keypoint_headers_anipose_csv_file(tmp_path):
         "M_22",
     ]
     # Here we are missing kp0_z:
-    headers.extend(["kp0_x", "kp0_y", "kp0_score", "kp0_error", "kp0_ncams"])
+    columns.extend(["kp0_x", "kp0_y", "kp0_score", "kp0_error", "kp0_ncams"])
     with open(file_path, "w") as f:
-        f.write(",".join(headers))
+        f.write(",".join(columns))
         f.write("\n")
-        f.write(",".join(["1"] * len(headers)))
+        f.write(",".join(["1"] * len(columns)))
     return file_path
 
 
 @pytest.fixture
-def spurious_header_anipose_csv_file(tmp_path):
+def spurious_column_anipose_csv_file(tmp_path):
     """Return the file path for a fake single-individual .csv file."""
-    file_path = tmp_path / "spurious_header.csv"
-    headers = [
+    file_path = tmp_path / "spurious_column.csv"
+    columns = [
         "fnum",
         "center_0",
         "center_1",
@@ -246,11 +246,11 @@ def spurious_header_anipose_csv_file(tmp_path):
         "M_21",
         "M_22",
     ]
-    headers.extend(["funny_header"])
+    columns.extend(["funny_column"])
     with open(file_path, "w") as f:
-        f.write(",".join(headers))
+        f.write(",".join(columns))
         f.write("\n")
-        f.write(",".join(["1"] * len(headers)))
+        f.write(",".join(["1"] * len(columns)))
     return file_path
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ def pytest_configure():
         paths_dict = fetch_dataset_paths(file_name)
         data_path = paths_dict.get("poses") or paths_dict.get("bboxes")
         pytest.DATA_PATHS[file_name] = data_path
+        print(file_name, data_path)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,7 +202,8 @@ def dlc_style_df():
 def missing_keypoint_headers_anipose_csv_file(tmp_path):
     """Return the file path for a fake single-individual .csv file."""
     file_path = tmp_path / "missing_keypoint_headers.csv"
-    headers = ["fnum", "center_0", "center_1", "center_2", "M_00", "M_01", "M_02", "M_10", "M_11", "M_12", "M_20", "M_21", "M_22"]
+    headers = ["fnum", "center_0", "center_1", "center_2", "M_00", "M_01", 
+               "M_02", "M_10", "M_11", "M_12", "M_20", "M_21", "M_22"]
     headers.extend(["kp0_x", "kp0_y", "kp0_score", "kp0_error", "kp0_ncams"])
     with open(file_path, "w") as f:
         f.write(",".join(headers))
@@ -214,7 +215,8 @@ def missing_keypoint_headers_anipose_csv_file(tmp_path):
 def spurious_header_anipose_csv_file(tmp_path):
     """Return the file path for a fake single-individual .csv file."""
     file_path = tmp_path / "spurious_header.csv"
-    headers = ["fnum", "center_0", "center_1", "center_2", "M_00", "M_01", "M_02", "M_10", "M_11", "M_12", "M_20", "M_21", "M_22"]
+    headers = ["fnum", "center_0", "center_1", "center_2", "M_00", "M_01", 
+               "M_02", "M_10", "M_11", "M_12", "M_20", "M_21", "M_22"]
     headers.extend(["funny_header"])
     with open(file_path, "w") as f:
         f.write(",".join(headers))

--- a/tests/test_integration/test_io.py
+++ b/tests/test_integration/test_io.py
@@ -105,15 +105,3 @@ class TestPosesIO:
                 assert file_path.name in f["labels_path"][()].decode()
             else:
                 assert f["labels_path"][()].decode() == ""
-
-    @pytest.mark.parametrize(
-        "file",
-        ["anipose_mouse-paw_anipose-paper.triangulation.csv"],
-    )
-    def test_load_anipose_csv(self, file):
-        """Test that loading pose tracks from an Anipose triangulation
-        csv file returns the same Dataset.
-        """
-        file_path = DATA_PATHS.get(file)
-        ds = load_poses.from_anipose_csv(file_path)
-        print(ds)

--- a/tests/test_integration/test_io.py
+++ b/tests/test_integration/test_io.py
@@ -105,3 +105,15 @@ class TestPosesIO:
                 assert file_path.name in f["labels_path"][()].decode()
             else:
                 assert f["labels_path"][()].decode() == ""
+
+    @pytest.mark.parametrize(
+        "file",
+        ["anipose_mouse-paw_anipose-paper.triangulation.csv"],
+        )
+    def test_load_anipose_csv(self, file):
+        """Test that loading pose tracks from an Anipose triangulation
+        csv file returns the same Dataset.
+        """
+        file_path = DATA_PATHS.get(file)
+        ds = load_poses.from_anipose_csv(file_path)
+        print(ds)

--- a/tests/test_unit/test_load_poses.py
+++ b/tests/test_unit/test_load_poses.py
@@ -318,3 +318,15 @@ def test_from_multiview_files():
     assert isinstance(multi_view_ds, xr.Dataset)
     assert "view" in multi_view_ds.dims
     assert multi_view_ds.view.values.tolist() == view_names
+
+
+def test_load_from_anipose_csv_file():
+    """Test that loading pose tracks from an Anipose triangulation
+    csv file returns the same Dataset.
+    """
+    file_path = DATA_PATHS.get("anipose_mouse-paw_anipose-paper.triangulation.csv")
+    ds = load_poses.from_anipose_csv(file_path)
+    print(ds.position.shape)
+    print(ds.coords["keypoints"].values)
+    assert False
+

--- a/tests/test_unit/test_load_poses.py
+++ b/tests/test_unit/test_load_poses.py
@@ -257,7 +257,14 @@ def test_load_multi_individual_from_lp_file_raises():
 
 
 @pytest.mark.parametrize(
-    "source_software", ["SLEAP", "DeepLabCut", "LightningPose", "Anipose", "Unknown"]
+    "source_software",
+    [
+        "SLEAP",
+        "DeepLabCut",
+        "LightningPose",
+        "Anipose",
+        "Unknown",
+    ],
 )
 @pytest.mark.parametrize("fps", [None, 30, 60.0])
 def test_from_file_delegates_correctly(source_software, fps):

--- a/tests/test_unit/test_load_poses.py
+++ b/tests/test_unit/test_load_poses.py
@@ -324,7 +324,9 @@ def test_load_from_anipose_file():
     """Test that loading pose tracks from an Anipose triangulation
     csv file returns the same Dataset.
     """
-    file_path = DATA_PATHS.get("anipose_mouse-paw_anipose-paper.triangulation.csv")
+    file_path = DATA_PATHS.get(
+        "anipose_mouse-paw_anipose-paper.triangulation.csv"
+    )
     ds = load_poses.from_anipose_file(file_path)
     assert ds.position.shape == (246, 3, 6, 1)
     assert ds.confidence.shape == (246, 6, 1)

--- a/tests/test_unit/test_load_poses.py
+++ b/tests/test_unit/test_load_poses.py
@@ -320,13 +320,22 @@ def test_from_multiview_files():
     assert multi_view_ds.view.values.tolist() == view_names
 
 
-def test_load_from_anipose_csv_file():
+def test_load_from_anipose_file():
     """Test that loading pose tracks from an Anipose triangulation
     csv file returns the same Dataset.
     """
     file_path = DATA_PATHS.get("anipose_mouse-paw_anipose-paper.triangulation.csv")
-    ds = load_poses.from_anipose_csv(file_path)
-    print(ds.position.shape)
-    print(ds.coords["keypoints"].values)
-    assert False
+    ds = load_poses.from_anipose_file(file_path)
+    assert ds.position.shape == (246, 3, 6, 1)
+    assert ds.confidence.shape == (246, 6, 1)
+    assert ds.coords["keypoints"].values.tolist() == [
+        "l-base",
+        "l-edge",
+        "l-middle",
+        "r-base",
+        "r-edge",
+        "r-middle",
+    ]
+
+
 

--- a/tests/test_unit/test_load_poses.py
+++ b/tests/test_unit/test_load_poses.py
@@ -257,7 +257,7 @@ def test_load_multi_individual_from_lp_file_raises():
 
 
 @pytest.mark.parametrize(
-    "source_software", ["SLEAP", "DeepLabCut", "LightningPose", "Unknown"]
+    "source_software", ["SLEAP", "DeepLabCut", "LightningPose", "Anipose", "Unknown"]
 )
 @pytest.mark.parametrize("fps", [None, 30, 60.0])
 def test_from_file_delegates_correctly(source_software, fps):
@@ -268,6 +268,7 @@ def test_from_file_delegates_correctly(source_software, fps):
         "SLEAP": "movement.io.load_poses.from_sleap_file",
         "DeepLabCut": "movement.io.load_poses.from_dlc_file",
         "LightningPose": "movement.io.load_poses.from_lp_file",
+        "Anipose": "movement.io.load_poses.from_anipose_file",
     }
     if source_software == "Unknown":
         with pytest.raises(ValueError, match="Unsupported source"):

--- a/tests/test_unit/test_validators/test_files_validators.py
+++ b/tests/test_unit/test_validators/test_files_validators.py
@@ -216,7 +216,7 @@ def test_anipose_csv_validator_with_invalid_input(
     - error if bboxes IDs are not 1-based integers
     """
     file_path = request.getfixturevalue(invalid_input)
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(error_type) as excinfo:
         ValidAniposeCSV(file_path)
 
     assert log_message in str(excinfo.value)

--- a/tests/test_unit/test_validators/test_files_validators.py
+++ b/tests/test_unit/test_validators/test_files_validators.py
@@ -179,27 +179,24 @@ def test_via_tracks_csv_validator_with_invalid_input(
 
 
 @pytest.mark.parametrize(
-    "invalid_input, error_type, log_message",
+    "invalid_input, log_message",
     [
         (
             "invalid_single_individual_csv_file",
-            ValueError,
             "CSV file is missing some expected headers.",
         ),
         (
             "missing_keypoint_headers_anipose_csv_file",
-            ValueError,
             "Base header kp0 is missing some expected suffixes.",
         ),
         (
             "spurious_header_anipose_csv_file",
-            ValueError,
             "Header funny_header does not have an expected suffix.",
         ),
     ],
 )
 def test_anipose_csv_validator_with_invalid_input(
-    invalid_input, error_type, log_message, request
+    invalid_input, log_message, request
 ):
     """Test that invalid Anipose .csv files raise the appropriate errors.
 
@@ -216,7 +213,7 @@ def test_anipose_csv_validator_with_invalid_input(
     - error if bboxes IDs are not 1-based integers
     """
     file_path = request.getfixturevalue(invalid_input)
-    with pytest.raises(error_type) as excinfo:
+    with pytest.raises(ValueError) as excinfo:
         ValidAniposeCSV(file_path)
 
     assert log_message in str(excinfo.value)

--- a/tests/test_unit/test_validators/test_files_validators.py
+++ b/tests/test_unit/test_validators/test_files_validators.py
@@ -183,15 +183,15 @@ def test_via_tracks_csv_validator_with_invalid_input(
     [
         (
             "invalid_single_individual_csv_file",
-            "CSV file is missing some expected headers.",
+            "CSV file is missing some expected columns.",
         ),
         (
-            "missing_keypoint_headers_anipose_csv_file",
-            "Base header kp0 is missing some expected suffixes.",
+            "missing_keypoint_columns_anipose_csv_file",
+            "Keypoint kp0 is missing some expected suffixes.",
         ),
         (
-            "spurious_header_anipose_csv_file",
-            "Header funny_header does not have an expected suffix.",
+            "spurious_column_anipose_csv_file",
+            "Column funny_column ends with an unexpected suffix.",
         ),
     ],
 )

--- a/tests/test_unit/test_validators/test_files_validators.py
+++ b/tests/test_unit/test_validators/test_files_validators.py
@@ -1,11 +1,11 @@
 import pytest
 
 from movement.validators.files import (
+    ValidAniposeCSV,
     ValidDeepLabCutCSV,
     ValidFile,
     ValidHDF5,
     ValidVIATracksCSV,
-    ValidAniposeCSV,
 )
 
 

--- a/tests/test_unit/test_validators/test_files_validators.py
+++ b/tests/test_unit/test_validators/test_files_validators.py
@@ -203,7 +203,7 @@ def test_anipose_csv_validator_with_invalid_input(
     Errors to check:
     - error if .csv is missing some columns
     - error if .csv misses some of the expected columns for a keypoint
-    - error if .csv has columns that are not expected 
+    - error if .csv has columns that are not expected
     (either common ones or keypoint-specific ones)
     """
     file_path = request.getfixturevalue(invalid_input)

--- a/tests/test_unit/test_validators/test_files_validators.py
+++ b/tests/test_unit/test_validators/test_files_validators.py
@@ -201,16 +201,10 @@ def test_anipose_csv_validator_with_invalid_input(
     """Test that invalid Anipose .csv files raise the appropriate errors.
 
     Errors to check:
-    - error if .csv header is wrong
-    - error if frame number is not defined in the file
-        (frame number extracted either from the filename or from attributes)
-    - error if extracted frame numbers are not 1-based integers
-    - error if region_shape_attributes "name" is not "rect"
-    - error if not all region_attributes have key "track"
-        (i.e., all regions must have an ID assigned)
-    - error if IDs are unique per frame
-        (i.e., bboxes IDs must exist only once per frame)
-    - error if bboxes IDs are not 1-based integers
+    - error if .csv is missing some columns
+    - error if .csv misses some of the expected columns for a keypoint
+    - error if .csv has columns that are not expected 
+    (either common ones or keypoint-specific ones)
     """
     file_path = request.getfixturevalue(invalid_input)
     with pytest.raises(ValueError) as excinfo:


### PR DESCRIPTION
## Description

Adding support to load adipose-triangulated data.

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Currently, adipose-triangulated data cannot be loaded. I love the autocorrect here.

**What does this PR do?**
Implement simple loading function for anipose-generated data. Anipose saves a csv file with x, y, z, score (confidence) plus more info to a `csv` file. Currently, this basic info is parsed. Additional info that is stored in the file, which could be loaded in principle but would not fit any of `movement` boxes atm:
 - number of cameras each key point was triangulated from. This is a useful piece of data; if there's space for arbitrary arrays in the dataset I would add it
 - back projection error: another important metrics that would be useful to pack together.
 - info on the coordinate transformations implemented during triangulation, less important imho - but could also be dumped in. Not sure if we would end up to bloat the DataSet too much

## References
#124 

## How has this PR been tested?
So far just very coarsely tested on some anipose data I am generating. I am no proficient anipose user, and I'm happy to collect example data and feedback from anyone. Will try to dig into example data from the anipose repo to make sure everything can be loaded from there.

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
Maybe once done

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
