### PR TITLE
Fix mypy error in py3.12

### DIFF
--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -682,11 +682,13 @@ def _ds_from_valid_data(data: ValidPosesDataset) -> xr.Dataset:
     n_frames = data.position_array.shape[0]
     n_space = data.position_array.shape[1]
     # Create the time coordinate, depending on the value of fps
-    time_coords = np.arange(n_frames, dtype=int)
-    time_unit = "frames"
     if data.fps is not None:
-        time_coords = time_coords / data.fps
+        time_coords = np.arange(n_frames, dtype=float) / data.fps
         time_unit = "seconds"
+    else:
+        time_coords = np.arange(n_frames, dtype=int)
+        time_unit = "frames"
+
     DIM_NAMES = ValidPosesDataset.DIM_NAMES
     # Convert data to an xarray.Dataset
     return xr.Dataset(


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

`mypy` was complaining on CI, see [this failure](https://github.com/neuroinformatics-unit/movement/actions/runs/12359173332/job/34491303857#step:2:236).

This started happening after https://github.com/neuroinformatics-unit/actions/pull/71 was merged and a new NIU actions release was made. Basically, `mypy` now runs on Python 3.12 instead of 3.10, so it sees some additional errors (in our case, just 1 error). I was able to reproduce the error in a Python 3.12 environment locally.

**What does this PR do?**

It fixed the issue `mypy` was complaining about, by ensuring that `time_coords` doesn't undergo a type change.

## References

https://github.com/neuroinformatics-unit/actions/pull/71

## How has this PR been tested?

Locally running `pre-commit` and `pytest`.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [n/a] Tests have been added to cover all new functionality
- [n/a] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
