### PR TITLE
Fix dims and coords returned by `compute_forward_vector`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,12 +29,12 @@ repos:
         - id: rst-directive-colons
         - id: rst-inline-touching-normal
     - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.8.1
+      rev: v0.8.6
       hooks:
         - id: ruff
         - id: ruff-format
     - repo: https://github.com/pre-commit/mirrors-mypy
-      rev: v1.13.0
+      rev: v1.14.1
       hooks:
           - id: mypy
             additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,12 +29,12 @@ repos:
         - id: rst-directive-colons
         - id: rst-inline-touching-normal
     - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.8.6
+      rev: v0.8.1
       hooks:
         - id: ruff
         - id: ruff-format
     - repo: https://github.com/pre-commit/mirrors-mypy
-      rev: v1.14.1
+      rev: v1.13.0
       hooks:
           - id: mypy
             additional_dependencies:

--- a/movement/kinematics.py
+++ b/movement/kinematics.py
@@ -297,7 +297,7 @@ def compute_forward_vector(
     # (right-to-left) cross (forward) = up
     forward_vector = xr.cross(
         right_to_left_vector, upward_vector, dim="space"
-    )[:, -1, :]  # keep only the first 2 dimensions of the result
+    )[:, :, :-1]  # keep only the first 2 dimensions of the result
     # Return unit vector
     return forward_vector / compute_norm(forward_vector)
 

--- a/movement/kinematics.py
+++ b/movement/kinematics.py
@@ -297,7 +297,7 @@ def compute_forward_vector(
     # (right-to-left) cross (forward) = up
     forward_vector = xr.cross(
         right_to_left_vector, upward_vector, dim="space"
-    )[:, :, :-1]  # keep only the first 2 dimensions of the result
+    )[:, -1, :]  # keep only the first 2 dimensions of the result
     # Return unit vector
     return forward_vector / compute_norm(forward_vector)
 

--- a/movement/kinematics.py
+++ b/movement/kinematics.py
@@ -292,12 +292,17 @@ def compute_forward_vector(
     upward_vector = xr.DataArray(
         np.tile(upward_vector.reshape(1, -1), [len(data.time), 1]),
         dims=["time", "space"],
+        coords={
+            "space": ["x", "y", "z"],
+        },
     )
     # Compute forward direction as the cross product
     # (right-to-left) cross (forward) = up
     forward_vector = xr.cross(
         right_to_left_vector, upward_vector, dim="space"
-    )[:, :, :-1]  # keep only the first 2 dimensions of the result
+    ).drop_sel(
+        space="z"
+    )  # keep only the first 2 spatal dimensions of the result
     # Return unit vector
     return forward_vector / compute_norm(forward_vector)
 

--- a/tests/test_unit/test_kinematics.py
+++ b/tests/test_unit/test_kinematics.py
@@ -462,11 +462,14 @@ def test_compute_forward_vector(valid_data_array_for_forward_vector):
     )
     known_vectors = np.array([[[0, -1]], [[1, 0]], [[0, 1]], [[-1, 0]]])
 
-    assert (
-        isinstance(forward_vector, xr.DataArray)
-        and ("space" in forward_vector.dims)
-        and ("keypoints" not in forward_vector.dims)
-    )
+    for output_array in [forward_vector, forward_vector_flipped, head_vector]:
+        assert isinstance(output_array, xr.DataArray)
+        for preserved_coord in ["time", "space", "individuals"]:
+            assert np.all(
+                output_array[preserved_coord]
+                == valid_data_array_for_forward_vector[preserved_coord]
+            )
+        assert set(output_array["space"].values) == {"x", "y"}
     assert np.equal(forward_vector.values, known_vectors).all()
     assert np.equal(forward_vector_flipped.values, known_vectors * -1).all()
     assert head_vector.equals(forward_vector)
@@ -535,6 +538,7 @@ def test_nan_behavior_forward_vector(
             forward_vector[preserved_coord]
             == valid_data_array_for_forward_vector_with_nans[preserved_coord]
         )
+    assert set(forward_vector["space"].values) == {"x", "y"}
     # Should have NaN values in the forward vector at time 1 and left_ear
     nan_values = forward_vector.sel(time=nan_time)
     assert nan_values.shape == (1, 2)


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

See #381 

**What does this PR do?**

The function concerned, `compute_forward_vector`, has [been changed](https://github.com/neuroinformatics-unit/movement/blob/fc30b5a982bd39fb2750090f989d4025d35e0db4/movement/kinematics.py#L292-L300) to now explicitly construct the `upwards_vector` with appropriate labelling, and then the result has the extra spatial dimension dropped to ensure we always drop the correct axis.

The existing unit tests have been given a similar treatment.
- The invalid inputs test has not been touched - this still passes since (functionally) nothing was wrong originally
- The [input/output test](https://github.com/neuroinformatics-unit/movement/blob/fc30b5a982bd39fb2750090f989d4025d35e0db4/tests/test_unit/test_kinematics.py#L441) that was already present has largely stayed the same, save for the addition of additional checks that the coordinates we expect to be preserved, are indeed preserved. The existing numerical computations were valid, so have been left as part of the test.
- The [test involving `nan` values](https://github.com/neuroinformatics-unit/movement/blob/fc30b5a982bd39fb2750090f989d4025d35e0db4/tests/test_unit/test_kinematics.py#L520) has been reworked to use the more precise `sel` and `isnull` method(s) to pull expected / unexpected `NaN` values out of the result, check that the appropriate `time`, `space`, and `individuals` axes are preserved, AND to force a comparison of the shape of the sub-array that contains `NaN` values against that which is expected. Previously this test did not actually check if the returned array was empty (which it was), so the `np.isnan(...).all()` and `not np.isnan(...).any()` were comparing to the empty container, this always returning `True`.

## References

Closes #381 

## How has this PR been tested?

Local test suite passes, both prior to and with the additions mentioned above.

In the case of the old `nan` test, the old version of the test passed with the updates to the code (though this was to be expected due to the aforementioned empty-array bug), before being replaced.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

If any features have changed, or have been added. Please explain how the
documentation has been updated.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
