### PR TITLE
Pass kwargs to `interpolate_over_time`

### DIFF
--- a/examples/filter_and_interpolate.py
+++ b/examples/filter_and_interpolate.py
@@ -75,11 +75,13 @@ ds.confidence.squeeze().plot.line(
 # %%
 # Filter out points with low confidence
 # -------------------------------------
-# Using the :func:`movement.filtering.filter_by_confidence` function from the
-# :mod:`movement.filtering` module, we can filter out points with confidence
-# scores below a certain threshold. This function takes ``position`` and
-# ``confidence`` as required arguments, and accepts an optional ``threshold``
-# parameter, which defaults to ``threshold=0.6`` unless specified otherwise.
+# Using the
+# :func:`filter_by_confidence()<movement.filtering.filter_by_confidence>`
+# function from the :mod:`movement.filtering` module,
+# we can filter out points with confidence scores below a certain threshold.
+# This function takes ``position`` and ``confidence`` as required arguments,
+# and accepts an optional ``threshold`` parameter,
+# which defaults to ``threshold=0.6`` unless specified otherwise.
 # The function will also report the number of NaN values in the dataset before
 # and after the filtering operation by default, but you can disable this
 # by passing ``print_report=False``.
@@ -106,10 +108,11 @@ ds.position.squeeze().plot.line(
 # %%
 # Interpolate over missing values
 # -------------------------------
-# Using the :func:`movement.filtering.interpolate_over_time` function from the
-# :mod:`movement.filtering` module, we can interpolate over gaps
-# we've introduced in the pose tracks.
-# Here we use the default linear interpolation method (``method=linear``)
+# Using the
+# :func:`interpolate_over_time()<movement.filtering.interpolate_over_time>`
+# function from the :mod:`movement.filtering` module, we can interpolate over
+# gaps we've introduced in the pose tracks.
+# Here we use the default linear interpolation method (``method="linear"``)
 # and interpolate over gaps of 40 frames or less (``max_gap=40``).
 # The default ``max_gap=None`` would interpolate over all gaps, regardless of
 # their length, but this should be used with caution as it can introduce
@@ -118,13 +121,25 @@ ds.position.squeeze().plot.line(
 ds.update({"position": interpolate_over_time(ds.position, max_gap=40)})
 
 # %%
-# We see that all NaN values have disappeared, meaning that all gaps were
-# indeed shorter than 40 frames.
+# We see that most, but not all, NaN values have disappeared, meaning that
+# most gaps were indeed shorter than 40 frames.
 # Let's visualise the interpolated pose tracks.
 
 ds.position.squeeze().plot.line(
     x="time", row="keypoints", hue="space", aspect=2, size=2.5
 )
+
+# %%
+# .. note::
+#   By default, interpolation does not apply to gaps at either end of the time
+#   series. In our case, the last few frames removed by filtering were not
+#   replaced by interpolation. Passing ``fill_value="extrapolate"`` to the
+#   :func:`interpolate_over_time()<movement.filtering.interpolate_over_time>`
+#   function would extrapolate the data to also fill the gaps at either end.
+#
+#   In general, you may pass any keyword arguments that are accepted by
+#   :meth:`xarray.DataArray.interpolate_na` and its underlying methods.
+
 
 # %%
 # Log of processing steps

--- a/examples/filter_and_interpolate.py
+++ b/examples/filter_and_interpolate.py
@@ -75,9 +75,7 @@ ds.confidence.squeeze().plot.line(
 # %%
 # Filter out points with low confidence
 # -------------------------------------
-# Using the
-# :func:`filter_by_confidence()<movement.filtering.filter_by_confidence>`
-# function from the :mod:`movement.filtering` module,
+# Using :func:`movement.filtering.filter_by_confidence`,
 # we can filter out points with confidence scores below a certain threshold.
 # This function takes ``position`` and ``confidence`` as required arguments,
 # and accepts an optional ``threshold`` parameter,
@@ -108,9 +106,8 @@ ds.position.squeeze().plot.line(
 # %%
 # Interpolate over missing values
 # -------------------------------
-# Using the
-# :func:`interpolate_over_time()<movement.filtering.interpolate_over_time>`
-# function from the :mod:`movement.filtering` module, we can interpolate over
+# Using  :func:`movement.filtering.interpolate_over_time`,
+# we can interpolate over
 # gaps we've introduced in the pose tracks.
 # Here we use the default linear interpolation method (``method="linear"``)
 # and interpolate over gaps of 40 frames or less (``max_gap=40``).

--- a/examples/filter_and_interpolate.py
+++ b/examples/filter_and_interpolate.py
@@ -70,7 +70,8 @@ ds.confidence.squeeze().plot.line(
 # %%
 # Encouragingly, some of the drops in confidence scores do seem to correspond
 # to the implausible jumps and spikes we had seen in the position.
-# We can use that to our advantage.
+# We can use that to our advantage, by leveraging functions from the
+# :mod:`movement.filtering` module.
 
 # %%
 # Filter out points with low confidence
@@ -106,9 +107,8 @@ ds.position.squeeze().plot.line(
 # %%
 # Interpolate over missing values
 # -------------------------------
-# Using  :func:`movement.filtering.interpolate_over_time`,
-# we can interpolate over
-# gaps we've introduced in the pose tracks.
+# Using  :func:`movement.filtering.interpolate_over_time`, we can
+# interpolate over gaps we've introduced in the pose tracks.
 # Here we use the default linear interpolation method (``method="linear"``)
 # and interpolate over gaps of 40 frames or less (``max_gap=40``).
 # The default ``max_gap=None`` would interpolate over all gaps, regardless of
@@ -134,9 +134,9 @@ ds.position.squeeze().plot.line(
 #   :func:`interpolate_over_time()<movement.filtering.interpolate_over_time>`
 #   function would extrapolate the data to also fill the gaps at either end.
 #
-#   In general, you may pass any keyword arguments that are accepted by
-#   :meth:`xarray.DataArray.interpolate_na` and its underlying methods.
-
+#   In general, you may pass any keyword arguments that are acceptable as
+#   ``**kwargs`` by :meth:`xarray.DataArray.interpolate_na`, which in turn
+#   passes them to its underlying interpolation methods.
 
 # %%
 # Log of processing steps

--- a/examples/smooth.py
+++ b/examples/smooth.py
@@ -82,7 +82,9 @@ def plot_raw_and_smooth_timeseries_and_psd(
         )
 
         # interpolate data to remove NaNs in the PSD calculation
-        pos_interp = interpolate_over_time(pos, print_report=False)
+        pos_interp = interpolate_over_time(
+            pos, print_report=False, fill_value="extrapolate"
+        )
 
         # compute and plot the PSD
         freq, psd = welch(pos_interp, fs=ds.fps, nperseg=256)

--- a/movement/filtering.py
+++ b/movement/filtering.py
@@ -60,20 +60,24 @@ def filter_by_confidence(
 @log_to_attrs
 def interpolate_over_time(
     data: xr.DataArray,
+    method: str = "linear",
     max_gap: int | None = None,
     print_report: bool = True,
     **kwargs: dict | None,
 ) -> xr.DataArray:
     """Fill in NaN values by interpolating over the ``time`` dimension.
 
-    This method uses :meth:`xarray.DataArray.interpolate_na` under the
-    hood and can pass additional keyword arguments to it, such as ``method``.
-    See the xarray documentation for more details on these arguments.
+    This function calls :meth:`xarray.DataArray.interpolate_na` and can pass
+    additional keyword arguments to it, depending on the chosen ``method``.
+    See the xarray documentation for more details.
 
     Parameters
     ----------
     data : xarray.DataArray
         The input data to be interpolated.
+    method : str
+        String indicating which method to use for interpolation.
+        Default is ``linear``.
     max_gap : int, optional
         Maximum size of gap, a continuous sequence of missing observations
         (represented as NaNs), to fill.
@@ -84,8 +88,8 @@ def interpolate_over_time(
         Whether to print a report on the number of NaNs in the dataset
         before and after interpolation. Default is ``True``.
     **kwargs : dict
-        Additional keyword arguments are passed verbatim to
-        :meth:`xarray.DataArray.interpolate_na` and its underlying
+        Any ``**kwargs`` accepted by :meth:`xarray.DataArray.interpolate_na`,
+        which in turn passes them verbatim to the underlying
         interpolation methods.
 
     Returns
@@ -104,6 +108,7 @@ def interpolate_over_time(
     """
     data_interpolated = data.interpolate_na(
         dim="time",
+        method=method,
         use_coordinate=False,
         max_gap=max_gap + 1 if max_gap is not None else None,
         **kwargs,

--- a/movement/filtering.py
+++ b/movement/filtering.py
@@ -60,31 +60,33 @@ def filter_by_confidence(
 @log_to_attrs
 def interpolate_over_time(
     data: xr.DataArray,
-    method: str = "linear",
     max_gap: int | None = None,
     print_report: bool = True,
+    **kwargs: dict | None,
 ) -> xr.DataArray:
     """Fill in NaN values by interpolating over the ``time`` dimension.
 
     This method uses :meth:`xarray.DataArray.interpolate_na` under the
-    hood and passes the ``method`` and ``max_gap`` parameters to it.
-    See the xarray documentation for more details on these parameters.
+    hood and can pass additional keyword arguments to it, such as ``method``.
+    See the xarray documentation for more details on these arguments.
 
     Parameters
     ----------
     data : xarray.DataArray
         The input data to be interpolated.
-    method : str
-        String indicating which method to use for interpolation.
-        Default is ``linear``.
     max_gap : int, optional
         Maximum size of gap, a continuous sequence of missing observations
         (represented as NaNs), to fill.
         The default value is ``None`` (no limit).
-        Gap size is defined as the number of consecutive NaNs.
+        Gap size is defined as the number of consecutive NaNs
+        (see Notes for more information).
     print_report : bool
         Whether to print a report on the number of NaNs in the dataset
         before and after interpolation. Default is ``True``.
+    **kwargs : dict
+        Additional keyword arguments are passed verbatim to
+        :meth:`xarray.DataArray.interpolate_na` and its underlying
+        interpolation methods.
 
     Returns
     -------
@@ -102,10 +104,9 @@ def interpolate_over_time(
     """
     data_interpolated = data.interpolate_na(
         dim="time",
-        method=method,
         use_coordinate=False,
         max_gap=max_gap + 1 if max_gap is not None else None,
-        fill_value="extrapolate",
+        **kwargs,
     )
     if print_report:
         print(report_nan_values(data, "input"))

--- a/tests/test_integration/test_filtering.py
+++ b/tests/test_integration/test_filtering.py
@@ -68,8 +68,13 @@ def test_nan_propagation_through_filters(sample_dataset, window, helpers):
     # Check that the increase in nans is below the expected threshold
     assert n_total_nans_savgol - n_total_nans_input <= max_nans_increase
 
-    # Interpolate data (without max_gap) and check it eliminates all NaNs
+    # Interpolate data (without max_gap) and with extrapolation
+    # and check it eliminates all NaNs
     sample_dataset.update(
-        {"position": interpolate_over_time(sample_dataset.position)}
+        {
+            "position": interpolate_over_time(
+                sample_dataset.position, fill_value="extrapolate"
+            )
+        }
     )
     assert helpers.count_nans(sample_dataset.position) == 0


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Change in default behaviour

**Why is this PR needed?**

See #379

**What does this PR do?**

- Adds `**kwargs` to the `interpolate_over_time()` function, so that additional keyword arguments can be passed to underlying methods.
- `fill_value="extrapolate"` is no longer hard-coded, instead the user may alter this parameter via the aforementioned `**kwargs`. Henceworth, gaps at the edges of time series will not be filled by default.
- Removes the `method` argument from `interpolate_over_time()` function signature, as this is passed verbatim to underlying functions.
- Retains the `max_gap` argument, as its meaning is slightly different from `DataArray.interpolate_na()`.
- Adjusts the function's docstring accordingly.
- Modifies some of the examples accordingly.

## How has this PR been tested?

The aforementioned changes broke the filtering integration test, because that test was expecting `interpolate_over_time()` to eliminate all missing values. I altered that test by explicitly passing `fill_value="extrapolate"` to it, which made it pass; this additionally acts as an implicit test that kwargs are indeed being forwarded.

## Is this a breaking change?

No, as previous syntaxes will still work, but it changes the default expected behaviour. 

## Does this PR require an update to the documentation?

Yes, the `filter_and_interpolate.py` and the `smooth.py` examples have been updated accordingly. API docs are automatically refreshed due to the changes in the docstring.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
