### PR TITLE
Add tests for heading angle

### DIFF
--- a/movement/utils/vector.py
+++ b/movement/utils/vector.py
@@ -1,7 +1,6 @@
 """Utility functions for vector operations."""
 
 import numpy as np
-import numpy.typing as npt
 import xarray as xr
 
 from movement.utils.logging import log_error
@@ -168,42 +167,57 @@ def pol2cart(data: xr.DataArray) -> xr.DataArray:
 
 
 def compute_signed_angle_2d(
-    test_vector: xr.DataArray, reference_vector: xr.DataArray | npt.NDArray
+    u: xr.DataArray,
+    v: xr.DataArray | np.ndarray,
+    v_as_left_operand: bool = False,
 ) -> xr.DataArray:
-    r"""Compute the signed angle between two 2D vectors.
+    r"""Compute the signed angle from the vector ``u`` to the vector ``v``.
 
-    Angles are returned in radians, spanning :math:`(-\pi, \pi]` according to
-    the arctan2 convention. The sign of the angle follows the sign of the 2D
-    cross product ``test_vector``  :math:`\times` ``reference_vector``
-    and depends on the orientation of the coordinate system.
+    The signed angle between ``u`` and ``v`` is the rotation that needs to be
+    applied to ``u`` to have it point in the same direction as ``v`` (see
+    Notes). Angles are returned in radians, spanning :math:`(-\pi, \pi]`
+    according to the ``arctan2`` convention.
 
     Parameters
     ----------
-    test_vector : xarray.DataArray
+    u : xarray.DataArray
         An array of position vectors containing the ``space``
         dimension with only ``"x"`` and ``"y"`` coordinates.
-    reference_vector : xarray.DataArray | numpy.ndarray
+    v : xarray.DataArray | numpy.ndarray
         A 2D vector (or array of 2D vectors) against which to
-        compare ``test_vector``. May either be an xarray
-        DataArray containing the ``space``  dimension or a numpy
+        compare ``u``. May either be an xarray
+        DataArray containing the ``"space"``  dimension or a numpy
         array containing one or more 2D vectors. (See Notes)
+    v_as_left_operand : bool, default False
+        If True, the signed angle between ``v`` and ``u`` is returned, instead
+        of the signed angle between ``u`` and ``v``. This is a convenience
+        wrapper for when one of the two vectors to be used does not have time
+        points, and the other does.
 
     Returns
     -------
     xarray.DataArray :
         An xarray DataArray containing signed angle between
-        ``test_vector`` and ``reference_vector`` for every
-        time-point. Matches the dimensions of ``test_vector``,
-        but without the ``space`` dimension.
+        ``u`` and ``v`` for every time point. Matches the dimensions of
+        ``u``, but without the ``space`` dimension.
 
     Notes
     -----
-    If passed as an xarray DataArray, the reference vector must
-    have the spatial coordinates ``x`` and ``y`` only, and must
-    have a ``time`` dimension matching that of the test vector.
+    Given two vectors :math:`u = (u_x, u_y)` and :math:`v = (v_x, v_y)`,
+    the signed angle :math:`\alpha` between ``u`` and ``v`` is computed as
 
-    If passed as a numpy array, the reference vector must have
-    one of three shapes:
+    .. math::
+        \alpha &= \mathrm{arctan2}(u \times v, u\cdot v) \\
+        &= \mathrm{arctan2}(u_x v_y - u_y v_x, u_x v_x + u_y v_y),
+
+    which corresponds to the rotation that needs to be applied to ``u`` for it
+    to point in the direction of ``v``.
+
+    If ``v`` is passed as an ``xarray.DataArray``, ``v`` must have the spatial
+    coordinates ``"x"`` and ``"y"`` only, and must have a ``time`` dimension
+    matching that of ``u``.
+
+    If passed as a numpy array, the ``v`` must have one of three shapes:
 
     - ``(2,)``: where dimension ``0`` contains spatial
       coordinates (x,y), and no time dimension is specified.
@@ -212,35 +226,29 @@ def compute_signed_angle_2d(
       coordinates (x,y).
     - ``(n,2)``: where dimension ``0`` corresponds to
       time and dimension ``1`` contains spatial coordinates
-      (x,y), and where ``n == len(test_vector.time)``.
+      (x,y), and where ``n == len(u.time)``.
 
-    Reference vectors containing more dimensions, or with shapes
-    otherwise different from those defined above are considered
-    invalid.
+    Vectors given as ``v`` that contain more dimensions, or have shapes
+    otherwise different from those defined above are considered invalid.
 
     """
-    # test_vector checks
-    validate_dims_coords(test_vector, {"space": ["x", "y"]}, exact_coords=True)
+    validate_dims_coords(u, {"space": ["x", "y"]}, exact_coords=True)
+    # ensure v can be broadcast over u
+    v_with_matching_dims = validate_reference_vector(v, u)
 
-    # reference_vector checks
-    reference_vector_xr = validate_reference_vector(
-        reference_vector, test_vector
-    )
+    u_unit = convert_to_unit(u)
+    u_x = u_unit.sel(space="x")
+    u_y = u_unit.sel(space="y")
 
-    test_unit = convert_to_unit(test_vector)
-    test_x = test_unit.sel(space="x")
-    test_y = test_unit.sel(space="y")
+    v_unit = convert_to_unit(v_with_matching_dims)
+    v_x = v_unit.sel(space="x")
+    v_y = v_unit.sel(space="y")
 
-    ref_unit = convert_to_unit(reference_vector_xr)
-    ref_x = ref_unit.sel(space="x")
-    ref_y = ref_unit.sel(space="y")
-
-    signed_angles = np.arctan2(
-        test_y * ref_x - test_x * ref_y,  # cross product test x ref
-        test_x * ref_x + test_y * ref_y,  # dot product   test . ref
-    )
-
-    return signed_angles
+    cross = u_x * v_y - u_y * v_x
+    if v_as_left_operand:
+        cross *= -1.0
+    dot = u_x * v_x + u_y * v_y
+    return np.arctan2(cross, dot)
 
 
 def _raise_error_for_missing_spatial_dim() -> None:

--- a/movement/utils/vector.py
+++ b/movement/utils/vector.py
@@ -6,6 +6,7 @@ import xarray as xr
 
 from movement.utils.logging import log_error
 from movement.validators.arrays import validate_dims_coords
+from movement.validators.vector import validate_reference_vector
 
 
 def compute_norm(data: xr.DataArray) -> xr.DataArray:
@@ -222,7 +223,7 @@ def compute_signed_angle_2d(
     validate_dims_coords(test_vector, {"space": ["x", "y"]}, exact_coords=True)
 
     # reference_vector checks
-    reference_vector_xr = _validate_reference_vector(
+    reference_vector_xr = validate_reference_vector(
         reference_vector, test_vector
     )
 
@@ -247,101 +248,4 @@ def _raise_error_for_missing_spatial_dim() -> None:
         ValueError,
         "Input data array must contain either 'space' or 'space_pol' "
         "as dimensions.",
-    )
-
-
-def _validate_reference_vector(
-    reference_vector: xr.DataArray | np.ndarray,
-    test_vector: xr.DataArray,
-) -> xr.DataArray:
-    """Validate the reference vector.
-
-    Parameters
-    ----------
-    reference_vector : xarray.DataArray | numpy.ndarray
-        The reference vector to validate, and convert if necessary.
-    test_vector : xarray.DataArray
-        The test vector to compare against. The reference vector must have
-        the same number of time points as the test vector.
-
-    Returns
-    -------
-    xarray.DataArray
-        A validated xarray DataArray.
-
-    Raises
-    ------
-    ValueError
-        If shape or dimensions do not match the expected form.
-    TypeError
-        If reference_vector is neither a NumPy array nor an xarray DataArray.
-
-    """
-    if isinstance(reference_vector, np.ndarray):
-        # Check shape: must be 1D or 2D
-        if reference_vector.ndim > 2:
-            raise log_error(
-                ValueError,
-                "Reference vector must be 1D or 2D, but got "
-                f"{reference_vector.ndim}D array.",
-            )
-        # Reshape 1D -> (1, -1) so axis 0 can be 'time'
-        if reference_vector.ndim == 1:
-            reference_vector = reference_vector.reshape(1, -1)
-
-        # If multiple time points, must match test_vector time length
-        if (
-            reference_vector.shape[0] > 1
-            and reference_vector.shape[0] != test_vector.sizes["time"]
-        ):
-            raise log_error(
-                ValueError,
-                "Reference vector must have the same number of time "
-                "points as the test vector.",
-            )
-
-        # Decide whether we have (time, space) or just (space)
-        if reference_vector.shape[0] == 1:
-            coords = {"space": ["x", "y"]}
-        else:
-            coords = {
-                "time": test_vector.get("time", None),
-                "space": ["x", "y"],
-            }
-
-        return xr.DataArray(
-            reference_vector, dims=list(coords.keys()), coords=coords
-        )
-
-    elif isinstance(reference_vector, xr.DataArray):
-        # Must contain exactly 'x' and 'y' in the space dimension
-        validate_dims_coords(
-            reference_vector, {"space": ["x", "y"]}, exact_coords=True
-        )
-
-        # If it has a time dimension, time size must match
-        if (
-            "time" in reference_vector.dims
-            and reference_vector.sizes["time"] != test_vector.sizes["time"]
-        ):
-            raise log_error(
-                ValueError,
-                "Reference vector must have the same number of time "
-                "points as the test vector.",
-            )
-
-        # Only 'time' and 'space' are allowed
-        if any(d not in {"time", "space"} for d in reference_vector.dims):
-            raise log_error(
-                ValueError,
-                "Only dimensions 'time' and 'space' dimensions "
-                "are allowed in reference_vector.",
-            )
-        return reference_vector
-
-    # If it's neither a DataArray nor a NumPy array
-    raise log_error(
-        TypeError,
-        "Reference vector must be an xarray.DataArray or np.ndarray, "
-        f"but got {type(reference_vector)}.",
     )

--- a/movement/validators/vector.py
+++ b/movement/validators/vector.py
@@ -1,0 +1,110 @@
+"""Validators for vector or vector-castable objects."""
+
+import numpy as np
+import xarray as xr
+
+from movement.utils.logging import log_error
+from movement.validators.arrays import validate_dims_coords
+
+
+def validate_reference_vector(
+    reference_vector: xr.DataArray | np.ndarray,
+    test_vector: xr.DataArray,
+) -> xr.DataArray:
+    """Validate a reference vector being used in a calculation.
+
+    Reference vectors must contain the same number of time points as the
+    `test_vector`, in order to be used in computations with them.
+    Vector-like objects that are passed in are converted into `xr.DataArray`s
+    and inherit the `test_vector`s `time` axes.
+
+    Parameters
+    ----------
+    reference_vector : xarray.DataArray | numpy.ndarray
+        The reference vector to validate, and convert if necessary.
+    test_vector : xarray.DataArray
+        The test vector to compare against. The reference vector must have
+        the same number of time points as the test vector.
+
+    Returns
+    -------
+    xarray.DataArray
+        A validated xarray DataArray.
+
+    Raises
+    ------
+    ValueError
+        If shape or dimensions do not match the expected form.
+    TypeError
+        If reference_vector is neither a NumPy array nor an xarray DataArray.
+
+    """
+    if isinstance(reference_vector, np.ndarray):
+        # Check shape: must be 1D or 2D
+        if reference_vector.ndim > 2:
+            raise log_error(
+                ValueError,
+                "Reference vector must be 1D or 2D, but got "
+                f"{reference_vector.ndim}D array.",
+            )
+        # Reshape 1D -> (1, -1) so axis 0 can be 'time'
+        if reference_vector.ndim == 1:
+            reference_vector = reference_vector.reshape(1, -1)
+
+        # If multiple time points, must match test_vector time length
+        if (
+            reference_vector.shape[0] > 1
+            and reference_vector.shape[0] != test_vector.sizes["time"]
+        ):
+            raise log_error(
+                ValueError,
+                "Reference vector must have the same number of time "
+                "points as the test vector.",
+            )
+
+        # Decide whether we have (time, space) or just (space)
+        if reference_vector.shape[0] == 1:
+            coords = {"space": ["x", "y"]}
+            # reference_vector = reference_vector.squeeze()
+        else:
+            coords = {
+                "time": test_vector.get("time", None),
+                "space": ["x", "y"],
+            }
+
+        return xr.DataArray(
+            reference_vector, dims=list(coords.keys()), coords=coords
+        )
+
+    elif isinstance(reference_vector, xr.DataArray):
+        # Must contain exactly 'x' and 'y' in the space dimension
+        validate_dims_coords(
+            reference_vector, {"space": ["x", "y"]}, exact_coords=True
+        )
+
+        # If it has a time dimension, time size must match
+        if (
+            "time" in reference_vector.dims
+            and reference_vector.sizes["time"] != test_vector.sizes["time"]
+        ):
+            raise log_error(
+                ValueError,
+                "Reference vector must have the same number of time "
+                "points as the test vector.",
+            )
+
+        # Only 'time' and 'space' are allowed
+        if any(d not in {"time", "space"} for d in reference_vector.dims):
+            raise log_error(
+                ValueError,
+                "Only dimensions 'time' and 'space' dimensions "
+                "are allowed in reference_vector.",
+            )
+        return reference_vector
+
+    # If it's neither a DataArray nor a NumPy array
+    raise log_error(
+        TypeError,
+        "Reference vector must be an xarray.DataArray or np.ndarray, "
+        f"but got {type(reference_vector)}.",
+    )

--- a/movement/validators/vector.py
+++ b/movement/validators/vector.py
@@ -65,10 +65,10 @@ def validate_reference_vector(
         # Decide whether we have (time, space) or just (space)
         if reference_vector.shape[0] == 1:
             coords = {"space": ["x", "y"]}
-            # reference_vector = reference_vector.squeeze()
+            reference_vector = reference_vector.squeeze()
         else:
             coords = {
-                "time": test_vector.get("time", None),
+                "time": test_vector["time"],
                 "space": ["x", "y"],
             }
 

--- a/tests/test_unit/test_validators/test_vector_validators.py
+++ b/tests/test_unit/test_validators/test_vector_validators.py
@@ -17,55 +17,127 @@ def x_axis() -> xr.DataArray:
     )
 
 
+def x_axis_over_time(n_time_pts: int = 10) -> xr.DataArray:
+    """Return the x-axis as a constant DataArray,
+    with as many time points as requested.
+    """
+    return xr.DataArray(
+        data=np.tile(np.array([1.0, 0.0]).reshape(1, -1), [n_time_pts, 1]),
+        dims=["time", "space"],
+        coords={"time": np.arange(n_time_pts), "space": ["x", "y"]},
+    )
+
+
 @pytest.mark.parametrize(
-    ["ref_vector", "expected_result"],
+    ["ref_vector", "test_vector", "expected_result"],
     [
         pytest.param(
             np.array([1.0, 0.0]),
-            xr.DataArray(
-                data=np.array([1.0, 0.0]),
-                coords={"space": ["x", "y"]},
-            ),
-            id="(2,)-numpy array",
+            x_axis_over_time(),
+            "x_axis",
+            id="(2,) numpy array vs (n, 2) DataArray",
         ),
-        pytest.param("x_axis", "x_axis", id="(2,) DataArray"),
         pytest.param(
-            "x_axis_over_time", "x_axis_over_time", id="(n, 2) DataArray"
+            np.array([1.0, 0.0]),
+            "x_axis",
+            "x_axis",
+            id="(2,) numpy array vs (1, 2) DataArray",
+        ),
+        pytest.param(
+            np.array([1.0, 0.0]).reshape(1, -1),
+            x_axis_over_time(),
+            "x_axis",
+            id="(1, 2) numpy array vs (n, 2) DataArray",
+        ),
+        pytest.param(
+            "x_axis",
+            x_axis_over_time(),
+            "x_axis",
+            id="(1, 2) DataArray vs (n, 2) DataArray",
+        ),
+        pytest.param(
+            x_axis_over_time(),
+            x_axis_over_time(),
+            x_axis_over_time(),
+            id="(n, 2) DataArray vs (n, 2) DataArray",
+        ),
+        pytest.param(
+            np.tile(np.array([1.0, 0.0]).reshape(1, -1), [10, 1]),
+            x_axis_over_time(),
+            x_axis_over_time(),
+            id="(n, 2) numpy array vs (n, 2) DataArray",
+        ),
+        pytest.param(
+            x_axis_over_time(5),
+            x_axis_over_time(),
+            ValueError(
+                "Reference vector must have the same number "
+                "of time points as the test vector."
+            ),
+            id="Too few time points (numpy)",
+        ),
+        pytest.param(
+            np.tile(np.array([1.0, 0.0]).reshape(1, -1), [5, 1]),
+            x_axis_over_time(),
+            ValueError(
+                "Reference vector must have the same number "
+                "of time points as the test vector."
+            ),
+            id="Too few time points (DataArray)",
+        ),
+        pytest.param(
+            np.ones(shape=(2, 2, 2)),
+            x_axis_over_time(),
+            ValueError("Reference vector must be 1D or 2D, but got 3D array."),
+            id="Too many dimensions",
+        ),
+        pytest.param(
+            xr.DataArray(
+                data=np.ones(shape=(10, 2, 1)),
+                dims=["time", "space", "elephants"],
+                coords={
+                    "time": np.arange(10),
+                    "space": ["x", "y"],
+                    "elephants": ["e"],
+                },
+            ),
+            x_axis_over_time(10),
+            ValueError(
+                "Only dimensions 'time' and 'space' dimensions "
+                "are allowed in reference_vector.",
+            ),
+            id="Extra dimension in reference vector",
+        ),
+        pytest.param(
+            np.pi,
+            "x_axis",
+            TypeError(
+                "Reference vector must be an xarray.DataArray or np.ndarray, "
+                "but got <class 'float'>."
+            ),
+            id="Wrong input type",
         ),
     ],
 )
 def test_validate_reference_vector(
     ref_vector: xr.DataArray | np.ndarray,
+    test_vector: xr.DataArray,
     expected_result: xr.DataArray | Exception,
     request,
 ) -> None:
     """Test that reference vectors or objects that can be cast to reference
     vectors, are cast correctly.
-
-    For the purpose of testing this function, the only part of the
-    `test_vector` that matters is the size of the `time` axis.
-    As such, the `test_vector` will be assembled by calling
-    `np.arange(0, 10, 1)`, and assigning this to the
-    `time` axis.
-    Therefore, it always has 10 entries, so acceptable reference vector
-    shapes are thus
-    - (2,)
-    - (1, 2)
-    - (10, 2)
     """
     if isinstance(ref_vector, str):
         ref_vector = request.getfixturevalue(ref_vector)
+    if isinstance(test_vector, str):
+        test_vector = request.getfixturevalue(test_vector)
     if isinstance(expected_result, str):
         expected_result = request.getfixturevalue(expected_result)
 
-    n_time_pts = 10
-    test_vector = xr.DataArray(
-        data=np.arange(0, n_time_pts, 1, dtype=float), dims="time"
-    )
-
     if isinstance(expected_result, Exception):
         with pytest.raises(
-            expected_result, match=re.escape(str(expected_result))
+            type(expected_result), match=re.escape(str(expected_result))
         ):
             validate_reference_vector(
                 reference_vector=ref_vector, test_vector=test_vector

--- a/tests/test_unit/test_validators/test_vector_validators.py
+++ b/tests/test_unit/test_validators/test_vector_validators.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import re
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from movement.validators.vector import validate_reference_vector
+
+
+@pytest.fixture
+def x_axis() -> xr.DataArray:
+    return xr.DataArray(
+        data=np.array([1.0, 0.0]),
+        coords={"space": ["x", "y"]},
+    )
+
+
+@pytest.mark.parametrize(
+    ["ref_vector", "expected_result"],
+    [
+        pytest.param(
+            np.array([1.0, 0.0]),
+            xr.DataArray(
+                data=np.array([1.0, 0.0]),
+                coords={"space": ["x", "y"]},
+            ),
+            id="(2,)-numpy array",
+        ),
+        pytest.param("x_axis", "x_axis", id="(2,) DataArray"),
+        pytest.param(
+            "x_axis_over_time", "x_axis_over_time", id="(n, 2) DataArray"
+        ),
+    ],
+)
+def test_validate_reference_vector(
+    ref_vector: xr.DataArray | np.ndarray,
+    expected_result: xr.DataArray | Exception,
+    request,
+) -> None:
+    """Test that reference vectors or objects that can be cast to reference
+    vectors, are cast correctly.
+
+    For the purpose of testing this function, the only part of the
+    `test_vector` that matters is the size of the `time` axis.
+    As such, the `test_vector` will be assembled by calling
+    `np.arange(0, 10, 1)`, and assigning this to the
+    `time` axis.
+    Therefore, it always has 10 entries, so acceptable reference vector
+    shapes are thus
+    - (2,)
+    - (1, 2)
+    - (10, 2)
+    """
+    if isinstance(ref_vector, str):
+        ref_vector = request.getfixturevalue(ref_vector)
+    if isinstance(expected_result, str):
+        expected_result = request.getfixturevalue(expected_result)
+
+    n_time_pts = 10
+    test_vector = xr.DataArray(
+        data=np.arange(0, n_time_pts, 1, dtype=float), dims="time"
+    )
+
+    if isinstance(expected_result, Exception):
+        with pytest.raises(
+            expected_result, match=re.escape(str(expected_result))
+        ):
+            validate_reference_vector(
+                reference_vector=ref_vector, test_vector=test_vector
+            )
+    else:
+        returned_vector = validate_reference_vector(
+            reference_vector=ref_vector, test_vector=test_vector
+        )
+
+        xr.testing.assert_allclose(returned_vector, expected_result)

--- a/tests/test_unit/test_vector.py
+++ b/tests/test_unit/test_vector.py
@@ -188,3 +188,102 @@ class TestVector:
             expected_unit_pol.loc[{"space_pol": "rho"}] = 1
             expected_unit_pol = expected_unit_pol.where(~expected_nan_idxs)
             xr.testing.assert_allclose(unit_pol, expected_unit_pol)
+
+
+class TestComputeSignedAngle:
+    """Tests for the compute_signed_angle_2d method."""
+
+    x_axis = np.array([1.0, 0.0])
+    y_axis = np.array([0.0, 1.0])
+    coord_axes_array = np.array([x_axis, y_axis, -x_axis, -y_axis])
+
+    @pytest.mark.parametrize(
+        ["left_vector", "right_vector", "expected_angles"],
+        [
+            pytest.param(
+                x_axis.reshape(1, 2),
+                x_axis,
+                [0.0],
+                id="x-axis to x-axis",
+            ),
+            pytest.param(
+                coord_axes_array,
+                x_axis,
+                [0.0, -np.pi / 2.0, np.pi, np.pi / 2.0],
+                id="+/- axes to x-axis",
+            ),
+            pytest.param(
+                coord_axes_array,
+                -x_axis,
+                [np.pi, np.pi / 2.0, 0.0, -np.pi / 2.0],
+                id="+/- axes to -ve x-axis",
+            ),
+            pytest.param(
+                np.array([[1.0, 1.0], [-1.0, 1.0], [-1.0, -1.0], [1.0, -1.0]]),
+                coord_axes_array,
+                [-np.pi / 4.0] * 4,
+                id="-pi/4 trailing axes",
+            ),
+            pytest.param(
+                xr.DataArray(
+                    data=coord_axes_array,
+                    dims=["time", "space"],
+                    coords={
+                        "time": np.arange(coord_axes_array.shape[0]),
+                        "space": ["x", "y"],
+                    },
+                ),
+                xr.DataArray(
+                    data=-1.0 * coord_axes_array,
+                    dims=["time", "space"],
+                    coords={
+                        "time": np.arange(coord_axes_array.shape[0]),
+                        "space": ["x", "y"],
+                    },
+                ),
+                [np.pi] * 4,
+                id="Two DataArrays given",
+            ),
+        ],
+    )
+    def test_compute_signed_angle_2d(
+        self,
+        left_vector: xr.DataArray | np.ndarray,
+        right_vector: xr.DataArray | np.ndarray,
+        expected_angles: xr.DataArray,
+    ) -> None:
+        """Test computed angles are what we expect.
+
+        This test also checks the antisymmetry of the function in question.
+        Swapping the ``u`` and ``v`` arguments should produce an array of
+        angles with the same magnitude but opposite signs.
+        """
+        if not isinstance(left_vector, xr.DataArray):
+            left_vector = xr.DataArray(
+                data=left_vector,
+                dims=["time", "space"],
+                coords={
+                    "time": np.arange(left_vector.shape[0]),
+                    "space": ["x", "y"],
+                },
+            )
+        if not isinstance(expected_angles, xr.DataArray):
+            expected_angles = xr.DataArray(
+                data=np.array(expected_angles),
+                dims=["time"],
+                coords={"time": left_vector["time"]}
+                if "time" in left_vector.dims
+                else None,
+            )
+
+        computed_angles = vector.compute_signed_angle_2d(
+            left_vector, right_vector
+        )
+        computed_angles_reversed = vector.compute_signed_angle_2d(
+            left_vector, right_vector, v_as_left_operand=True
+        )
+
+        xr.testing.assert_allclose(computed_angles, expected_angles)
+        xr.testing.assert_allclose(
+            computed_angles, -1.0 * computed_angles_reversed
+        )


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Builds on top of #376, adding the necessary tests as well as reorganising the functionality that the base branch intends to introduce.

**What does this PR do?**

- Adds tests for the `validate_reference_vector` function
- "Mathmaticises" the `compute_signed_angle_2d` function, turning it into a mathematical implementation that is designed to be wrapped by higher-level, user-friendly functions.
  - The definition of the signed angle is also standardised and clearly stated in the function docstring, to minimise confusion.
  - Tests for this function are added.
- Adjusts the call signature of the higher-level `compute_forward_vector_angle` (called `compute_heading_angle` in the base branch) to accommodate the possibility of different conventions for the angle sign.

## References

Builds on #376, with a view to merging the quoted PR after this one.

## How has this PR been tested?

- Local test suite updated and passing.
- Pre-commit is happy.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
