### PR TITLE
Collapse dimensions common functionality for plot wrappers

### DIFF
--- a/movement/utils/dimensions.py
+++ b/movement/utils/dimensions.py
@@ -1,0 +1,79 @@
+"""Utilities for manipulating dimensions of ``xarray.DataArray`` objects."""
+
+from collections.abc import Iterable
+
+import xarray as xr
+
+
+def collapse_extra_dimensions(
+    da: xr.DataArray,
+    preserve_dims: Iterable[int | str] = ("time", "space"),
+    **selection: int | str,
+) -> xr.DataArray:
+    """Collapse a ``DataArray``, preserving only the specified dimensions.
+
+    By default, dimensions that are collapsed retain the corresponding 'slice'
+    along their 0th index of those dimensions, unless a particular index for is
+    given in the ``selection``.
+
+    Parameters
+    ----------
+    da : xarray.DataArray
+        DataArray of multiple dimensions, which is to be collapsed.
+    preserve_dims : Iterable[int | str]
+        The dimensions of ``da`` that should not be collapsed.
+    selection : int | str
+        Mapping from dimension names to a particular index in that dimension.
+        Dimensions that appear with an index in ``selection`` retain that index
+        slice when collapsed, rather than the default 0th index slice.
+
+    Returns
+    -------
+    xarray.DataArray
+        DataArray whose shape is the same as the shape of the preserved
+        dimensions of ``da``, containing the data obtained from a slice along
+        the collapsed dimensions.
+
+    Examples
+    --------
+    Collapse a ``DataArray`` down to just a ``"time"``-``"space"`` slice.
+
+    >>> import xarray as xr
+    >>> import numpy as np
+    >>> shape = (7, 2, 3, 4)
+    >>> da = xr.DataArray(
+    ...     data=np.arange(np.prod(shape)).reshape(shape),
+    ...     dims=["time", "space", "dim_to_collapse_0", "dim_to_collapse_1"],
+    ... )
+    >>> space_time = collapse_extra_dimensions(da)
+    >>> print(space_time.shape)
+    (7, 2)
+
+    The call to ``collapse_extra_dimensions`` above is equivalent to
+    ``da.sel(dim_to_collapse_0=0, dim_to_collapse_1=0)``. We can change which
+    slice we take from the collapsed dimensions by passing them as keyword
+    arguments.
+
+    >>> # Equivalent to da.sel(dim_to_collapse_0=2, dim_to_collapse_1=1)
+    >>> space_time_different_slice = collapse_extra_dimensions(
+    ...     da, dim_to_collapse_0=2, dim_to_collapse_1=1
+    ... )
+    >>> print(space_time_different_slice.shape)
+    (7, 2)
+
+    We can also change which dimensions are to be preserved.
+
+    >>> time_only = collapse_extra_dims(da, preserve_dims=["time"])
+    >>> print(time_only.shape)
+    (7,)
+
+    """
+    data = da.copy(deep=True)
+    dims_to_collapse = [d for d in data.dims if d not in preserve_dims]
+
+    for d in dims_to_collapse:
+        index_to_keep = selection.pop(d, 0)
+        if isinstance(index_to_keep, int):
+            index_to_keep = getattr(data, d)[index_to_keep]
+        data = data.sel({d: index_to_keep})
+    return data

--- a/movement/utils/dimensions.py
+++ b/movement/utils/dimensions.py
@@ -54,15 +54,16 @@ def collapse_extra_dimensions(
     (7, 2)
 
     The call to ``collapse_extra_dimensions`` above is equivalent to
-    ``da.sel(keypoints="head", individuals="Alice")`` (indexing by label).
+    ``da.isel(keypoints=0, individuals=0)`` (indexing by integer) and to
+    ``da.sel(keypoints="nose", individuals="Alice")`` (indexing by label).
     We can change which slice we take from the collapsed dimensions by passing
     them as keyword arguments.
 
-    >>> # Equivalent to da.sel(dim_to_collapse_0=2, dim_to_collapse_1=1)
-    >>> space_time_different_slice = collapse_extra_dimensions(
-    ...     da, dim_to_collapse_0=2, dim_to_collapse_1=1
+    >>> # Equivalent to da.sel(keypoints="right_ear", individuals="Bob")
+    >>> space_time_bob_right_ear = collapse_extra_dimensions(
+    ...     da, keypoints="right_ear", individuals="Bob"
     ... )
-    >>> print(space_time_different_slice.shape)
+    >>> print(space_time_bob_right_ear.shape)
     (7, 2)
 
     We can also change which dimensions are to be preserved.

--- a/tests/test_unit/test_collapse_dimensions.py
+++ b/tests/test_unit/test_collapse_dimensions.py
@@ -1,0 +1,122 @@
+import re
+from typing import Any
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from movement.utils.dimensions import (
+    collapse_extra_dimensions,
+    coord_of_dimension,
+)
+
+
+@pytest.fixture
+def shape() -> tuple[int, ...]:
+    return (7, 2, 3, 4)
+
+
+@pytest.fixture
+def da(shape: tuple[int, ...]) -> xr.DataArray:
+    return xr.DataArray(
+        data=np.arange(np.prod(shape)).reshape(shape),
+        dims=["time", "space", "individuals", "keypoints"],
+        coords={
+            "space": ["x", "y"],
+            "individuals": ["a", "b", "c"],
+            "keypoints": ["head", "shoulders", "knees", "toes"],
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    ["pass_to_function", "equivalent_to_sel"],
+    [
+        pytest.param(
+            {},
+            {"individuals": "a", "keypoints": "head"},
+            id="Default preserve time-space",
+        ),
+        pytest.param(
+            {"preserve_dims": ["space"]},
+            {"time": 0, "individuals": "a", "keypoints": "head"},
+            id="Keep space only",
+        ),
+        pytest.param(
+            {"individuals": 1},
+            {"individuals": "b", "keypoints": "head"},
+            id="Request non-default slice",
+        ),
+        pytest.param(
+            {"individuals": "c"},
+            {"individuals": "c", "keypoints": "head"},
+            id="Request by coordinate",
+        ),
+        pytest.param(
+            {
+                "individuals": 1,
+                "elephants": "this is a non-existent dimension",
+                "crabs": 42,
+            },
+            {"individuals": "b", "keypoints": "head"},
+            id="Selection ignores dimensions that don't exist",
+        ),
+        pytest.param(
+            {"preserve_dims": []},
+            {"time": 0, "space": "x", "individuals": "a", "keypoints": "head"},
+            id="Collapse everything",
+        ),
+    ],
+)
+def test_collapse_dimensions(
+    da: xr.DataArray,
+    pass_to_function: dict[str, Any],
+    equivalent_to_sel: dict[str, int | str],
+) -> None:
+    result_from_collapsing = collapse_extra_dimensions(da, **pass_to_function)
+
+    # We should be equivalent to this method
+    expected_result = da.sel(**equivalent_to_sel)
+
+    assert result_from_collapsing.shape == expected_result.values.shape
+    xr.testing.assert_allclose(result_from_collapsing, expected_result)
+
+
+@pytest.mark.parametrize(
+    ["args_to_fn", "expected"],
+    [
+        pytest.param(
+            {"dimension": "individuals", "coord_index": 1},
+            "b",
+            id="Fetch coord from index",
+        ),
+        pytest.param(
+            {"dimension": "time", "coord_index": 6},
+            6,
+            id="Dimension with no coordinates",
+        ),
+        pytest.param(
+            {"dimension": "space", "coord_index": "x"},
+            "x",
+            id="Fetch coord from name",
+        ),
+        pytest.param(
+            {"dimension": "keypoints", "coord_index": 10},
+            IndexError("index 10 is out of bounds for axis 0 with size 4"),
+            id="Out of bounds index",
+        ),
+        pytest.param(
+            {"dimension": "keypoints", "coord_index": "arms"},
+            KeyError("arms"),
+            id="Non existent coord name",
+        ),
+    ],
+)
+def test_coord_of_dimension(
+    da: xr.DataArray, args_to_fn: dict[str, Any], expected: str | Exception
+) -> None:
+    if isinstance(expected, Exception):
+        with pytest.raises(type(expected), match=re.escape(str(expected))):
+            coord_of_dimension(da, **args_to_fn)
+    else:
+        assert expected == coord_of_dimension(da, **args_to_fn)


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

See the [discussion on Zulip](https://neuroinformatics.zulipchat.com/#narrow/channel/406001-Movement/topic/Standards.20for.20wrapping.20matplotlib).

**What does this PR do?**

- Introduces the `collapse_extra_dimensions` function that can be used by the plotting wrappers to "remove" superfluous dimensions prior to creating plots.
- Also introduces the `coord_of_dimension` function which is a short wrapper that saves us from writing the same logic in each of our plotting wrappers when asking the user to identify one individual, or one keypoint (etc). The user may specify this either by its index (slice-style) or coordinate (`DataArray.sel` style), and this small tidbit of code was appearing in a number of places across the plotting wrappers. Now we can run `individual = coord_of_dim(da, "individuals", individual)` to ensure that `da.sel(individuals=individual)` will work.

## References

- [Zulip discussion](https://neuroinformatics.zulipchat.com/#narrow/channel/406001-Movement/topic/Standards.20for.20wrapping.20matplotlib).
- PRs #403, #402, and #394 will need to merge in this method to use the functionality it introduces.

## How has this PR been tested?

Local tests added and are passing.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
