### PR TITLE
Tiny fix in docstrings for `configure_logging`

### DIFF
--- a/movement/utils/logging.py
+++ b/movement/utils/logging.py
@@ -25,7 +25,7 @@ def configure_logging(
     Parameters
     ----------
     log_level : int, optional
-        The logging level to use. Defaults to logging.INFO.
+        The logging level to use. Defaults to logging.DEBUG.
     logger_name : str, optional
         The name of the logger to configure.
         Defaults to "movement".


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
The docstring states the default level is `logging.INFO` but in the function signature it is `logging.DEBUG`.

**What does this PR do?**
Makes the docstring match the signature.

## References

\

## How has this PR been tested?

Tests pass on CI.

## Is this a breaking change?

\

## Does this PR require an update to the documentation?

\

## Checklist:

- [x] The code has been tested locally
- [ n/a ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
