### PR TITLE
replace xarray median and mean with numpy

### DIFF
--- a/examples/compute_polar_coordinates.py
+++ b/examples/compute_polar_coordinates.py
@@ -251,16 +251,18 @@ rho_data = head_vector_polar.sel(individuals=mouse_name, space_pol="rho")
 rho_data.plot.hist(bins=50, ax=ax, edgecolor="lightgray", linewidth=0.5)
 
 # add mean
+rho_mean = np.nanmean(rho_data)
 ax.axvline(
-    x=rho_data.mean().values,
+    x=rho_mean,
     c="b",
     linestyle="--",
 )
 
 
 # add median
+rho_median = np.nanmedian(rho_data)
 ax.axvline(
-    x=rho_data.median().values,
+    x=rho_median,
     c="r",
     linestyle="-",
 )
@@ -268,8 +270,8 @@ ax.axvline(
 # add legend
 ax.legend(
     [
-        f"mean = {np.nanmean(rho_data):.2f} pixels",
-        f"median = {np.nanmedian(rho_data):.2f} pixels",
+        f"mean = {rho_mean:.2f} pixels",
+        f"median = {rho_median:.2f} pixels",
     ],
     loc="best",
 )


### PR DESCRIPTION
This PR improves the performance of an example script by replacing xarray's mean() and median() functions with numpy's nanmean() and nanmedian(). The xarray functions apply reductions iteratively over subbranches, making them inefficient for simple statistical calculations. Additionally, the script was redundantly computing mean and median values twice (once for the plot and again for the legend).

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

This change does not affect the main functionality of the toolbox but significantly improves the performance of the example script. It provides a better user experience for those trying out the examples or adapting them to their own datasets, leading to a better impression of the project.


**What does this PR do?**

Replaces xarray's mean() and median() with numpy.nanmean() and numpy.nanmedian().
Removed redundant calculations in the legend.

## How has this PR been tested?

It has been tested on my local machine 

Performance Improvement:

Before: Median computation took 13.41 seconds
After: Median computation now takes 0.00025 seconds

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
