### PR TITLE
Clarify error raised by ValidHDF5

### DIFF
--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -169,7 +169,8 @@ class ValidHDF5:
                     raise log_error(
                         ValueError,
                         f"Could not find the expected dataset(s) {diff} "
-                        f"in file: {value}. ",
+                        f"in file: {value}. Make sure that the file "
+                        "matches the expected source software format.",
                     )
 
 


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other: clarifying an existing error message

**Why is this PR needed?**

See [PR review](https://github.com/neuroinformatics-unit/movement/pull/393#pullrequestreview-2623540244) by @willGraham01  and @sfmig's [comment](https://github.com/neuroinformatics-unit/movement/pull/393#issuecomment-2668262241) (copy pasted below):

> > > That error message indicates that you may have tried to load a file output by SLEAP, using the DeepLabCut loader (becasue "df_with_missing" is a dataset within DeepLabCut .h5 output files). Can you try again loading the same file but with source software set to SLEAP?
> > 
> > 
> > Can confirm, this was indeed the problem 😅 Data loaded OK when I switched.
> 
> Maybe we can make the error message a bit more clear? 👀 (I encountered this and was surprised because generally movement has crystal clear messages)


The above error is thrown by the `ValidHDF5` validator, when the hdf5 file doesn't contain a dataset with the expected name.
This commonly occurs if the user has mis-specified the source software.

**What does this PR do?**

Add an extra sentence to the error message, making it more informative. The new error message reads:

```python
raise log_error(
    ValueError,
    f"Could not find the expected dataset(s) {diff} "
    f"in file: {value}. Make sure that the file "
    "matches the expected source software format.",
)
```

## How has this PR been tested?

No. We could update existing test to exactly match the new message, but this is an overkill imo.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [n/a] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
