### PR TITLE
Sp/417 bug fix plot trajectory

### DIFF
--- a/examples/broadcasting_your_own_methods.py
+++ b/examples/broadcasting_your_own_methods.py
@@ -67,6 +67,8 @@ for mouse_name, col in zip(
     )
 ax.invert_yaxis()
 ax.set_title("Trajectories")
+ax.set_xlabel("x (pixels)")
+ax.set_ylabel("y (pixels)")
 ax.legend()
 
 # %%

--- a/examples/compute_kinematics.py
+++ b/examples/compute_kinematics.py
@@ -77,7 +77,6 @@ for mouse_name, col in zip(
         label=mouse_name,
     )
     ax.legend().set_alpha(1)
-ax.title.set_text("Trajectories of three mice")
 fig.show()
 
 # %%
@@ -98,6 +97,10 @@ for mouse_name, ax in zip(position.individuals.values, axes, strict=False):
         ax=ax,
         s=2,
     )
+    ax.set_title(f"Trajectory {mouse_name}")
+    ax.set_xlabel("x (pixels)")
+    ax.set_ylabel("y (pixels)")
+    ax.collections[0].colorbar.set_label("Time (frames)")
 fig.tight_layout()
 fig.show()
 

--- a/examples/compute_polar_coordinates.py
+++ b/examples/compute_polar_coordinates.py
@@ -115,6 +115,9 @@ fig, ax = plot_trajectory(
 )
 # Adjust title
 ax.set_title("Head trajectory (individual_0)")
+ax.set_xlabel("x (pixels)")
+ax.set_ylabel("y (pixels)")
+ax.collections[0].colorbar.set_label("Time (frames)")
 fig.show()
 
 # %%

--- a/movement/plots/trajectory.py
+++ b/movement/plots/trajectory.py
@@ -61,8 +61,6 @@ def plot_trajectory(
         else:
             selection["individuals"] = individual
 
-    title_suffix = f" of {individual}" if "individuals" in da.dims else ""
-
     if "keypoints" in da.dims:
         if keypoints is None:
             selection["keypoints"] = da.keypoints.values
@@ -102,7 +100,7 @@ def plot_trajectory(
     ax.set_xlabel(f"x ({space_unit})")
     ax.set_ylabel(f"y ({space_unit})")
     ax.axis("equal")
-    ax.set_title(f"Trajectory{title_suffix}")
+    ax.set_title("Trajectory")
 
     # Add 'colorbar' for time dimension if no colour was provided by user
     time_unit = da.attrs.get("time_unit")

--- a/movement/plots/trajectory.py
+++ b/movement/plots/trajectory.py
@@ -96,15 +96,13 @@ def plot_trajectory(
         **kwargs,
     )
 
-    space_unit = da.attrs.get("space_unit", "pixels")
-    ax.set_xlabel(f"x ({space_unit})")
-    ax.set_ylabel(f"y ({space_unit})")
+    ax.set_xlabel("x")
+    ax.set_ylabel("y")
     ax.axis("equal")
     ax.set_title("Trajectory")
 
     # Add 'colorbar' for time dimension if no colour was provided by user
-    time_unit = da.attrs.get("time_unit")
-    time_label = f"time ({time_unit})" if time_unit else "time steps (frames)"
+    time_label = "Time"
     fig.colorbar(sc, ax=ax, label=time_label).solids.set(
         alpha=1.0
     ) if colorbar else None


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Misleading plot titles when plotting several individuals on the same axis and incorrect defaulting of `x` and `y` `label ` units to `pixels` and `frames` when units have been set as attributes to the `Dataset`.

**What does this PR do?**
Fix minor bugs in plot_trajectory as suggested by @niksirbi  in #417.

> **1. Misleading Titles**
> Use a generic title that's always true (e.g., "Trajectory").
> **2. Erroneous Time/Space Units**
> Stop attempting to infer units
> As a quick hotfix, simply label plot axes as "x", "y", and "Time" without specifying units. This avoids misleading labels until we have a more comprehensive solution.

## References
#417
Please reference any existing issues/PRs that relate to this PR.

## How has this PR been tested?
Visually checking expected plotting behaviour for different cases.

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
Updated examples. 

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
