### PR TITLE
Eye movement example

### DIFF
--- a/examples/mouse_eye_movements.py
+++ b/examples/mouse_eye_movements.py
@@ -7,93 +7,278 @@ Look at eye movements caused by the oculo-motor reflex.
 # %%
 # Imports
 # -------
-from pathlib import Path
-
+import numpy as np
 import sleap_io as sio
 from matplotlib import pyplot as plt
 
-# from movement import sample_data
-from movement.io import load_poses
+import movement.kinematics as kin
+from movement import sample_data
 from movement.plots import plot_trajectory
-from movement.utils.vector import compute_norm
 
 # %%
 # Load the data
 # -------------
-# Define the file paths to the data.
-
-data_dir = Path.home() / "Data" / "Sepi-data" / "eye tracking"
-video_path = data_dir / "CA514_C_day2_black.avi"
-dlc_predictions_path = (
-    data_dir
-    / "CA514_C_day2_blackDLC_resnet50_eye-trackingFeb19shuffle1_500000.h5"
+ds_black = sample_data.fetch_dataset(
+    "DLC_rotating-mouse_eye-tracking_stim-black.predictions.h5",
+    with_video=True,
 )
+ds_uniform = sample_data.fetch_dataset(
+    "DLC_rotating-mouse_eye-tracking_stim-uniform.predictions.h5",
+    with_video=True,
+)
+# Save data in a dictionary
+ds = {"black": ds_black, "uniform": ds_uniform}
+
+# %%
+# Explore the data
+# -------------
+video = {}  # To save videos in
+for name, ds_i in ds.items():
+    video[name] = sio.load_video(ds_i.video_path)
+    n_frames, height, width, channels = video[name].shape
+    print(f"Dataset: {name}")
+    print(f"Number of frames: {n_frames}")
+    print(f"Frame size: {width}x{height}")
+    print(f"Number of channels: {channels}\n")
+
+# Both datasets contain videos of a mouse eye under two different conditions.
+# %%
+# Plot first frame with keypoints
+# -------------
+fig, ax = plt.subplots(1, 2, figsize=(10, 4))
+for i, (name, ds_i) in enumerate(ds.items()):
+    ax[i].imshow(video[name][0], cmap="gray")  # plot first video frame
+    for keypoint in ds_i.position.keypoints.values:
+        x = ds_i.position.sel(time=0, space="x", keypoints=keypoint)
+        y = ds_i.position.sel(time=0, space="y", keypoints=keypoint)
+        ax[i].scatter(x, y, label=keypoint)  # plot keypoints
+    ax[i].legend()
+    ax[i].set_title(f"{name} (First Frame)")
+    ax[i].invert_yaxis()  # because the dataset was collected flipped
+plt.tight_layout()
+plt.show()
+
+# %%
+# Pupil trajectory
+# -------------
+# A quick trajectory plot of the trajectory of the centre of the pupil.
+time_points = ds_black.time[slice(50, 1000)]
+da = ds_black.position.sel(time=time_points)  # data array to plot
+fig, ax = plot_trajectory(da, keypoints=["pupil-L", "pupil-R"])
+fig.show()
+
+# %%
+# Pupil trajectories on top of video frame
+# -------------
+# Plot pupil trajectories for both 'black' and 'uniform' datasets
+fig, ax = plt.subplots(1, 2, figsize=(11, 3))
+for i, (ds_name, ds_i) in enumerate(ds.items()):
+    ax[i].imshow(
+        video[ds_name][100], cmap="Greys_r"
+    )  # Frame 100 as background
+    time_points = ds_i.time[slice(50, 1000)]
+    plot_trajectory(
+        ds_i.position.sel(time=time_points),
+        ax=ax[i],
+        keypoints=["pupil-L", "pupil-R"],
+        alpha=0.5,
+        s=3,
+    )
+    ax[i].invert_yaxis()
+    ax[i].set_title(f"Pupil Trajectory ({ds_name})")
+plt.show()
 
 
 # %%
-# Lazy-load the video using sleap_io
-
-video = sio.load_video(video_path)
-n_frames, height, width, channels = video.shape
-
-print(f"Number of frames: {n_frames}")
-print(f"Frame size: {width}x{height}")
-print(f"Number of channels: {channels}")
-
-# %%
-# Load the data into movement
-
-ds = load_poses.from_dlc_file(dlc_predictions_path, fps=40)
-ds
-
-# %%
-# Plot the trajectory of pupil midpoint
-
-fig, ax = plt.subplots()
-# Load the 100-th frame of the video as background
-ax.imshow(video[100], cmap="Greys_r")
-plot_trajectory(ds.position, ax=ax, keypoints=["pupil-L", "pupil-R"])
-
-
-# %%
-position = ds.position.squeeze()
-
-# %%
-
-
-def quick_plot(da, time=None):
-    selection = dict(space="x")
+# Keypoint positions in x and y over time
+# -------------
+# Helper function to plot the data
+def quick_plot(da, time=None, ax=None, **selection):
     if time:
         selection["time"] = slice(*time)
     da = da.squeeze()
-    da.sel(**selection, drop=True).plot.line(
-        x="time", hue="keypoints", aspect=3, size=3
+    da.sel(**selection, drop=True).plot.line(x="time", ax=ax)
+
+
+frame_slice = slice(350, 1000)  # frame slice to plot
+fig, axes = plt.subplots(2, 2, figsize=(12, 6))
+for i, ds_name in enumerate(["uniform", "black"]):
+    for j, space in enumerate(["y", "x"]):
+        time_points = ds[ds_name].time[frame_slice]
+        da = ds[ds_name].position.sel(time=time_points)
+        quick_plot(
+            da,
+            space=space,
+            ax=axes[i, j],
+        )
+        axes[i, j].set_title(f"{ds_name} - {space} position")
+for ax in axes.flat:
+    ax.set_ylim(100, 500)
+plt.tight_layout()
+plt.show()
+
+# %%
+# Normalise movement to the eye midpoint
+# -------------
+# Normalizing the pupil's position relative to the eye keypoints reduces the
+# impact of head movements or artefacts caused by movement of the camera.
+
+position_norm = {}  # to save the normalised data
+for ds_name, ds_i in ds.items():
+    eye_midpoint = ds_i.position.sel(keypoints=["eye-L", "eye-R"]).mean(
+        "keypoints"
+    )
+    position_norm[ds_name] = ds_i.position - eye_midpoint
+
+# Plot normalized keypoint x and y coordinates over time
+fig, axes = plt.subplots(2, 2, figsize=(12, 6))
+for i, ds_name in enumerate(["uniform", "black"]):
+    for j, space in enumerate(["y", "x"]):
+        time_points = position_norm[ds_name].time[frame_slice]
+        quick_plot(
+            position_norm[ds_name].sel(time=time_points),
+            space=space,
+            ax=axes[i, j],
+        )
+        axes[i, j].set_title(f"{ds_name} (normalized) - {space} position")
+
+# Set the same limits for y-axes
+for ax in axes.flat:
+    ax.set_ylim(-200, 200)
+plt.tight_layout()
+plt.show()
+
+# There is less high frequency noise in the signal now.
+# %%
+# Pupil Centroid
+# -------------
+# Add a pupil centroid keypoint to position norm
+
+pupil_centroid = {}
+for key in ["uniform", "black"]:
+    pupil_centroid[key] = (
+        position_norm[key]
+        .sel(keypoints=["pupil-L", "pupil-R"])
+        .mean("keypoints")
     )
 
+# %%
+# Pupil position over time
+# -------------
+# position_norm from the previous example will be used to look at the centroid
+# of the pupil and the velocity over time.
+
+fig, axes = plt.subplots(2, 1, figsize=(6, 4))
+for i, ds_name in enumerate(["uniform", "black"]):
+    time_points = pupil_centroid[ds_name].time[frame_slice].values
+    pupil_centroid_window = pupil_centroid[ds_name].sel(time=time_points)
+    axes[i].plot(
+        time_points,
+        pupil_centroid_window.sel(space="x"),
+        label="x",
+        color="C0",
+    )
+    axes[i].plot(
+        time_points,
+        pupil_centroid_window.sel(space="y"),
+        label="y",
+        color="C1",
+    )
+    axes[i].set_xlabel("Time (s)")
+    axes[i].set_ylabel("Position")
+    axes[i].set_title(f"Pupil centroid position ({ds_name})")
+    axes[i].legend()
+
+for ax in axes.flat:
+    ax.set_ylim(-30, 65)
+
+plt.tight_layout()
+plt.show()
+# %%
+# Pupil velocity over time
+# -------------
+
+velocity = {
+    ds_name: kin.compute_velocity(pupil_centroid[ds_name])
+    for ds_name in pupil_centroid
+}
+
+fig, axes = plt.subplots(2, 1, figsize=(6, 4))
+for i, ds_name in enumerate(["uniform", "black"]):
+    time_points = velocity[ds_name].time[frame_slice].values
+    axes[i].plot(
+        time_points,
+        velocity[ds_name].sel(space="x", time=time_points),
+        label="x",
+        color="C0",
+    )
+    axes[i].plot(
+        time_points,
+        velocity[ds_name].sel(space="y", time=time_points),
+        label="y",
+        color="C1",
+    )
+    axes[i].set_xlabel("Time (s)")
+    axes[i].set_ylabel("Velocity")
+    axes[i].set_title(f"Pupil velocity ({ds_name})")
+    axes[i].legend()
+
+plt.tight_layout()
+plt.show()
 
 # %%
-eye_midpoint = ds.position.sel(keypoints=["eye-L", "eye-R"]).mean("keypoints")
-ds["position_subtracted"] = ds.position - eye_midpoint
-quick_plot(ds.position)
-quick_plot(ds.position_subtracted)
+# Pupil diameter
+# -------------
+# In these datasets, the distance between the two pupil keypoints
+# is used to quantify the pupil diameter.
 
-# %%
-eye_midpoint = ds.position.sel(keypoints=["eye-L", "eye-R"]).mean("keypoints")
-ds["position_subtracted"] = ds.position - eye_midpoint
-eye_midpoint.squeeze().plot.line(x="time", hue="space", aspect=2, size=2.5)
-quick_plot(ds.position)
-quick_plot(ds.position_subtracted)
+pupil_diameter = {}
+for ds_name, ds_i in ds.items():
+    left_pupil = ds_i.position.sel(keypoints="pupil-L").squeeze()
+    right_pupil = ds_i.position.sel(keypoints="pupil-R").squeeze()
+    dx = right_pupil.sel(space="x") - left_pupil.sel(space="x")  # x difference
+    dy = right_pupil.sel(space="y") - left_pupil.sel(space="y")  # y difference
+    pupil_diameter[ds_name] = (dx**2 + dy**2) ** 0.5  # euclidean distance
 
+fig, ax = plt.subplots(1, 1, figsize=(6, 4))
+for name, da_pupil_diameter in pupil_diameter.items():
+    ax.plot(da_pupil_diameter.time, da_pupil_diameter, label=name)
+    ax.set_xlabel("Time (frames)")
+    ax.set_ylabel("Pupil Diameter (pixels)")
+ax.legend()
+ax.set_title("Pupil Diameter")
+plt.tight_layout()
+plt.show()
 # %%
-eye_length = compute_norm(
-    ds.position.sel(keypoints="eye-L") - ds.position.sel(keypoints="eye-R")
+# Moving Average Filter
+# -------------
+# A filter can be used to smooth out pupil size data. Unlike eye movements,
+# which can be extremely fast, pupil size is unlikely to change rapidly. A
+# Moving Average Filter is used here to smooth the data by averaging a
+# specified number of data points (defined by the window size) to reduce noise.
+
+# TODO: Use movement filter!
+window_size = 150  # number of frames over which the filter is used
+fig, ax = plt.subplots(figsize=(5, 3))
+for name, da in pupil_diameter.items():
+    filtered_data = np.convolve(
+        da, np.ones(window_size) / window_size, mode="same"
+    )
+
+    # remove the first and last timepoints that are distorted by the filter
+    plot_slice = slice(window_size // 2, -window_size // 2)
+    ax.plot(
+        da.coords["time"][plot_slice],
+        filtered_data[plot_slice],
+        label=name + " (filter)",
+    )
+ax.set(
+    xlabel="Time (frames)",
+    ylabel="Pupil Diameter (pixels)",
+    title="Filtered Pupil Diameter",
 )
-
-
-# %%
-pupil_center = ds.position_subtracted.sel(
-    keypoints=["pupil-L", "pupil-R"]
-).mean("keypoints")
-quick_plot(pupil_center, time=(25, 50))
+ax.legend()
+plt.tight_layout()
+plt.show()
 
 # %%

--- a/examples/mouse_eye_movements.py
+++ b/examples/mouse_eye_movements.py
@@ -102,9 +102,9 @@ fig.show()
 # %%
 # Keypoint positions over time
 # ----------------------------
-# For the rest of this example we are interested in the position data only, to
-# make the data easy to combine the arrays into a single array with a new
-# dimension ``lighting``.
+# For the rest of this example we are only interested in the position data.
+# For convenience, We will combine the two position arrays into a single
+# array with a new dimension called ``lighting``.
 positions = xr.concat([ds_black.position, ds_uniform.position], "lighting")
 positions.coords["lighting"] = ["black", "uniform"]
 
@@ -117,20 +117,12 @@ plot_params = {
     "row": "lighting",
     "aspect": 1.5,
     "size": 2.5,
-    "add_legend": False,  # Disable default legend
 }
-legend_params = {
-    "bbox_to_anchor": (1.02, 1),
-    "loc": "upper right",
-}
-
 sel = {"time": slice(8, 25)}
-
 # %%
 # Plot the keypoint positions over time.
-positions.sel(**sel).squeeze().plot.line(**plot_params).add_legend(
-    **legend_params
-)
+positions.sel(**sel).squeeze().plot.line(**plot_params)
+plt.subplots_adjust(right=0.85)  # Make space on the right for the legend
 plt.show()
 # %%
 # Normalised keypoint positions over time
@@ -144,9 +136,8 @@ eye_midpoint = positions.sel(keypoints=["eye-L", "eye-R"]).mean("keypoints")
 positions_norm = positions - eye_midpoint
 # %%
 # We plot the x and y positions again, but now using the normalised data.
-positions_norm.sel(**sel).squeeze().plot.line(**plot_params).add_legend(
-    **legend_params
-)
+positions_norm.sel(**sel).squeeze().plot.line(**plot_params)
+plt.subplots_adjust(right=0.85)
 plt.show()
 # %%
 # Pupil position over time

--- a/examples/mouse_eye_movements.py
+++ b/examples/mouse_eye_movements.py
@@ -208,7 +208,7 @@ plt.show()
 # negative peaks correspond to rapid eye movements to the left.
 
 # %%
-#  Pupil diameter
+# Pupil diameter
 # --------------
 # Here we define the pupil diameter as the distance between the two pupil
 # keypoints. We use ``compute_pairwise_distances`` from ``movement.kinematics``

--- a/examples/mouse_eye_movements.py
+++ b/examples/mouse_eye_movements.py
@@ -278,7 +278,7 @@ plt.show()
 # frames corresponding to half the filter length. Unlike ``np.convolve``, it
 # can be applied to multidimensional data.
 
-mdn_filter = median_filter(pupil_diameter, filter_len, print_report=False)
+mdn_filter = median_filter(pupil_diameter, filter_len)
 mdn_filter.sel(time=time_window).squeeze().plot.line(x="time", hue="lighting")
 plt.show()
 # %%

--- a/examples/mouse_eye_movements.py
+++ b/examples/mouse_eye_movements.py
@@ -1,0 +1,99 @@
+"""Analyse eye movements of a mouse
+===================================
+
+Look at eye movements caused by the oculo-motor reflex.
+"""
+
+# %%
+# Imports
+# -------
+from pathlib import Path
+
+import sleap_io as sio
+from matplotlib import pyplot as plt
+
+# from movement import sample_data
+from movement.io import load_poses
+from movement.plots import plot_trajectory
+from movement.utils.vector import compute_norm
+
+# %%
+# Load the data
+# -------------
+# Define the file paths to the data.
+
+data_dir = Path.home() / "Data" / "Sepi-data" / "eye tracking"
+video_path = data_dir / "CA514_C_day2_black.avi"
+dlc_predictions_path = (
+    data_dir
+    / "CA514_C_day2_blackDLC_resnet50_eye-trackingFeb19shuffle1_500000.h5"
+)
+
+
+# %%
+# Lazy-load the video using sleap_io
+
+video = sio.load_video(video_path)
+n_frames, height, width, channels = video.shape
+
+print(f"Number of frames: {n_frames}")
+print(f"Frame size: {width}x{height}")
+print(f"Number of channels: {channels}")
+
+# %%
+# Load the data into movement
+
+ds = load_poses.from_dlc_file(dlc_predictions_path, fps=40)
+ds
+
+# %%
+# Plot the trajectory of pupil midpoint
+
+fig, ax = plt.subplots()
+# Load the 100-th frame of the video as background
+ax.imshow(video[100], cmap="Greys_r")
+plot_trajectory(ds.position, ax=ax, keypoints=["pupil-L", "pupil-R"])
+
+
+# %%
+position = ds.position.squeeze()
+
+# %%
+
+
+def quick_plot(da, time=None):
+    selection = dict(space="x")
+    if time:
+        selection["time"] = slice(*time)
+    da = da.squeeze()
+    da.sel(**selection, drop=True).plot.line(
+        x="time", hue="keypoints", aspect=3, size=3
+    )
+
+
+# %%
+eye_midpoint = ds.position.sel(keypoints=["eye-L", "eye-R"]).mean("keypoints")
+ds["position_subtracted"] = ds.position - eye_midpoint
+quick_plot(ds.position)
+quick_plot(ds.position_subtracted)
+
+# %%
+eye_midpoint = ds.position.sel(keypoints=["eye-L", "eye-R"]).mean("keypoints")
+ds["position_subtracted"] = ds.position - eye_midpoint
+eye_midpoint.squeeze().plot.line(x="time", hue="space", aspect=2, size=2.5)
+quick_plot(ds.position)
+quick_plot(ds.position_subtracted)
+
+# %%
+eye_length = compute_norm(
+    ds.position.sel(keypoints="eye-L") - ds.position.sel(keypoints="eye-R")
+)
+
+
+# %%
+pupil_center = ds.position_subtracted.sel(
+    keypoints=["pupil-L", "pupil-R"]
+).mean("keypoints")
+quick_plot(pupil_center, time=(25, 50))
+
+# %%

--- a/examples/mouse_eye_movements.py
+++ b/examples/mouse_eye_movements.py
@@ -1,7 +1,7 @@
 """Pupil tracking
 =================
 
-Look at eye movements caused by the oculo-motor reflex.
+Look at eye movements and pupil diameter.
 """
 
 # %%
@@ -20,6 +20,14 @@ from movement.plots import plot_trajectory
 # %%
 # Load the data
 # -------------
+# We will use two datasets from the sample data module. These datasets involve
+# recordings of the eyes of mice placed on a rotating platform with different
+# visual stimuli. The ``uniform`` condition features a uniformly lit surround
+# stimulus, whereas the ``black`` condition was acquired in the dark. These
+# datasets were tracked using DeepLabCut (DLC) and include four keypoints:
+# two on either side of the pupil (``pupil-L`` and ``pupil-R``) and two on
+# either side of the eye (``eye-L`` and ``eye-R``).
+
 ds_black = sample_data.fetch_dataset(
     "DLC_rotating-mouse_eye-tracking_stim-black.predictions.h5",
     with_video=True,
@@ -28,30 +36,31 @@ ds_uniform = sample_data.fetch_dataset(
     "DLC_rotating-mouse_eye-tracking_stim-uniform.predictions.h5",
     with_video=True,
 )
-# Save data in a dictionary
+# Save data in a dictionary.
 ds_dict = {"black": ds_black, "uniform": ds_uniform}
 
 # %%
-# Explore the data
-# ----------------
+# Print the content of one of the datasets.
+print(ds_dict["black"])
+# %%
+# Explore the accompanying videos
+# -------------------------------
 for ds_name, ds in ds_dict.items():
     video = sio.load_video(ds.video_path)
-    # to avoid having to reload the video again we add it to ds as attribute
+    # To avoid having to reload the video again we add it to ds as attribute
     ds_dict[ds_name] = ds.assign_attrs({"video": video})
     n_frames, height, width, channels = video.shape
     print(f"Dataset: {ds_name}")
     print(f"Number of frames: {n_frames}")
     print(f"Frame size: {width}x{height}")
     print(f"Number of channels: {channels}\n")
-
-# Both datasets contain videos of a mouse eye under two different conditions.
 # %%
 # Plot first frame with keypoints
 # -------------------------------
 fig, ax = plt.subplots(1, 2, figsize=(7.5, 4))
 for i, (da_name, ds) in enumerate(ds_dict.items()):
     ax[i].imshow(ds.video[0], cmap="gray")  # plot first video frame
-    for keypoint in ds.position.keypoints.values:
+    for keypoint in ds.keypoints.values:
         x = ds.position.sel(time=0, space="x", keypoints=keypoint)
         y = ds.position.sel(time=0, space="y", keypoints=keypoint)
         ax[i].scatter(x, y, label=keypoint)  # plot keypoints
@@ -64,10 +73,10 @@ plt.show()
 # %%
 # Pupil trajectory
 # ----------------
-# A quick plot of the trajectory of the centre of the pupil
-# using ``plot_trajectory`` function in ``movement.plots``.
-time_points = ds_black.time[slice(50, 1000)]
-position_black = ds_black.position.sel(time=time_points)  # data array to plot
+# A quick plot of the trajectory of the centre of the pupil using the
+# ``plot_trajectory`` function from ``movement.plots``.
+time_window = slice(1, 24)  # seconds
+position_black = ds_black.position.sel(time=time_window)  # data array to plot
 fig, ax = plot_trajectory(position_black, keypoints=["pupil-L", "pupil-R"])
 fig.show()
 
@@ -78,131 +87,111 @@ fig.show()
 fig, ax = plt.subplots(1, 2, figsize=(11, 3))
 for i, (ds_name, ds) in enumerate(ds_dict.items()):
     ax[i].imshow(ds.video[100], cmap="gray")  # Plot frame 100 as background
-
     plot_trajectory(
-        ds.position.sel(time=ds.time[slice(50, 1000)]),  # Select time window
+        ds.position.sel(time=time_window),  # Select time window
         ax=ax[i],
         keypoints=["pupil-L", "pupil-R"],
         alpha=0.5,
         s=3,
     )
-
     ax[i].invert_yaxis()
     ax[i].set_title(f"Pupil Trajectory ({ds_name})")
-plt.show()
+fig.show()
 
 
 # %%
 # Keypoint positions over time
 # ----------------------------
 # For the rest of this example we are interested in the position data only, to
-# make the data easy to access we save it in a ``dict`` with the dataset names
-# as keys.
-position_dict = {"black": ds_black.position, "uniform": ds_uniform.position}
-
-
-# %%
-# We create a function to plot the x and y positions of the keypoints over
-# time, so that we can compare the data before and after normalisation.
-def plot_x_y_keypoints(da_dict, ylim=None, **kwargs):
-    fig, axes = plt.subplots(2, 2, figsize=(12, 6))
-    for i, ds_name in enumerate(list(da_dict.keys())):
-        for j, coord in enumerate(["x", "y"]):
-            # Prepare a data array for plotting (squeeze removes redundant
-            # dimensions and is needed in order to plot the data correctly)
-            da = da_dict[ds_name].sel(space=coord, **kwargs).squeeze()
-            da.plot.line(ax=axes[i, j], x="time")  # Plot data
-            axes[i, j].set_title(f"{ds_name} - {coord} position")
-    if ylim is not None:
-        for ax in axes.flat:
-            ax.set_ylim(ylim)
-    plt.tight_layout()
-    return fig, ax
-
+# make the data easy to combine the arrays into a single array with a new
+# dimension ``lighting``.
+positions = xr.concat([ds_black.position, ds_uniform.position], "lighting")
+positions.coords["lighting"] = ["black", "uniform"]
 
 # %%
-# Using the function created above, we plot the x and y positions in a
-# specified time window (frames 350 to 1000) of the unprocessed data.
-time_points = position_dict["black"].time[slice(350, 1001)]
-fig, ax = plot_x_y_keypoints(position_dict, ylim=(100, 500), time=time_points)
-fig.show()
+#  Define plotting parameters for reuse.
+plot_params = {
+    "x": "time",
+    "hue": "keypoints",
+    "col": "space",
+    "row": "lighting",
+    "aspect": 1.5,
+    "size": 2.5,
+    "add_legend": False,  # Disable default legend
+}
+legend_params = {
+    "bbox_to_anchor": (1.02, 1),
+    "loc": "upper right",
+}
 
+sel = {"time": slice(8, 25)}
+
+# %%
+# Plot the keypoint positions over time.
+positions.sel(**sel).squeeze().plot.line(**plot_params).add_legend(
+    **legend_params
+)
+plt.show()
 # %%
 # Normalised keypoint positions over time
 # ---------------------------------------
 # Normalizing the pupil's position relative to the midpoint of the eye reduces
-# the impact of head movements or artefacts caused by movement of the camera.
+# the impact of head movements or artefacts caused by camera movement. By
+# subtracting the position of the eye's midpoint, we effectively transform the
+# data into a moving coordinate system, with the eye's midpoint as the origin.
 # In the rest of the example, the normalised data will be used.
-position_norm_dict = {}
-for da_name, da in position_dict.items():
-    eye_midpoint = da.sel(keypoints=["eye-L", "eye-R"]).mean("keypoints")
-    position_norm_dict[da_name] = da - eye_midpoint
+eye_midpoint = positions.sel(keypoints=["eye-L", "eye-R"]).mean("keypoints")
+positions_norm = positions - eye_midpoint
 # %%
 # We plot the x and y positions again, but now using the normalised data.
-fig, ax = plot_x_y_keypoints(
-    position_norm_dict, ylim=(-200, 200), time=time_points
+positions_norm.sel(**sel).squeeze().plot.line(**plot_params).add_legend(
+    **legend_params
 )
-fig.show()
+plt.show()
 # %%
 # Pupil position over time
 # ------------------------
-# To look at pupil position, and later also velocity, over time we use the
+# To look at pupil position—and later also velocity—over time, we use the
 # pupil centroid (in this case the midpoint between keypoints ``pupil-L`` and
-# ``pupil-R``). The pupil centroid keypoint ``pupil-C`` is be added to the
-# data array using ``xarray.DataArray.assign_coords`` and ``xarray.concat``.
-for da_name, da in position_norm_dict.items():
-    pupil_centroid = da.sel(keypoints=["pupil-L", "pupil-R"]).mean("keypoints")
-    pupil_centroid = pupil_centroid.assign_coords({"keypoints": "pupil-C"})
-    position_norm_dict[da_name] = xr.concat([da, pupil_centroid], "keypoints")
+# ``pupil-R``). The keypoint ``pupil-C`` is assigned using
+# ``xarray.DataArray.assign_coords``.
 
+pupil_centroid = (
+    positions_norm.sel(keypoints=["pupil-L", "pupil-R"])
+    .mean("keypoints")
+    .assign_coords({"keypoints": "pupil-C"})
+)
+# %%
+# The pupil centroid keypoint ``pupil-C`` is be added to the ``positions_norm``
+# using ``xarray.concat``.
+positions_norm = xr.concat([positions_norm, pupil_centroid], dim="keypoints")
 # %%
 # Now the position of the pupil centroid ``pupil-C`` can be plotted.
-fig, axes = plt.subplots(2, 1, figsize=(6, 4))
-for i, (da_name, da) in enumerate(position_norm_dict.items()):
-    da = da.sel(keypoints="pupil-C", time=time_points)  # select data to plot
-    for coord, color in ["x", "C0"], ["y", "C1"]:
-        axes[i].plot(
-            time_points,
-            da.sel(space=coord),
-            label=coord,
-            color=color,
-        )
-    axes[i].set_xlabel("Time (s)")
-    axes[i].set_ylabel("Position")
-    axes[i].set_title(f"Pupil centroid position ({da_name})")
-    axes[i].legend()
-
-for ax in axes.flat:
-    ax.set_ylim(-30, 65)
-
-plt.tight_layout()
+positions_norm.sel(keypoints="pupil-C", **sel).squeeze().plot.line(
+    x="time", hue="space", row="lighting", aspect=3.5, size=1.5
+)
 plt.show()
 # %%
 # Pupil velocity over time
 # ------------------------
-# We use ``compute_velocity`` from the ``movement.kinematics`` module to
-# calculate the velocity with which the pupil centroid moves.
-velocity_dict = {}
-for da_name, da in position_norm_dict.items():
-    velocity_dict[da_name] = kin.compute_velocity(da.sel(keypoints="pupil-C"))
+# In these experiments, the mouse is being rotated clock- or anti-clock-wise,
+# triggering the vestibulo-ocular reflex. This reflex involves the
+# vestibular system in the inner ear, that detects head motion and adjusts eye
+# position to maintain stable vision.
 
 # %%
-# Now we can plot pupil velocity over time.
-fig, axes = plt.subplots(2, 1, figsize=(6, 4))
-for i, (da_name, da) in enumerate(velocity_dict.items()):
-    for coord, color in ["x", "C0"], ["y", "C1"]:
-        axes[i].plot(
-            time_points,
-            da.sel(space=coord, time=time_points),
-            label=coord,
-            color=color,
-        )
-    axes[i].set_xlabel("Time (s)")
-    axes[i].set_ylabel("Velocity")
-    axes[i].set_title(f"Pupil velocity ({da_name})")
-    axes[i].legend()
-
-plt.tight_layout()
+# When the head turns beyond the range that the vestibulo-ocular reflex
+# can compensate for, a quick, ballistic eye movement is triggered to
+# shift gaze to a new fixation point. These fast eye movements are seen in the
+# previous plot but become even more obvious when the velocity of the pupil
+# centroid is plotted. To do this, we use ``compute_velocity`` from the
+# ``movement.kinematics`` module to calculate the velocity of the eye
+# movements.
+pupil_velocity = kin.compute_velocity(positions_norm.sel(keypoints="pupil-C"))
+pupil_velocity.name = "pupil velocity"
+pupil_velocity.sel(**sel).squeeze().plot.line(
+    x="time", hue="space", row="lighting", aspect=3.5, size=1.5
+)
 plt.show()
 # %%
 # The positive peaks correspond to rapid eye movements to the right, the
@@ -213,36 +202,15 @@ plt.show()
 # --------------
 # Here we define the pupil diameter as the distance between the two pupil
 # keypoints. We use ``compute_pairwise_distances`` from ``movement.kinematics``
-# to calculate the Euclidean distance between "pupil-L" and "pupil-R".
-pupil_diameter_dict = {}
-for da_name, da in position_norm_dict.items():
-    pupil_diameter_dict[da_name] = kin.compute_pairwise_distances(
-        da, "keypoints", {"pupil-L": "pupil-R"}
-    )
-
-
+# to calculate the Euclidean distance between ``pupil-L`` and ``pupil-R``.
+pupil_diameter: xr.DataArray = kin.compute_pairwise_distances(
+    positions_norm, dim="keypoints", pairs={"pupil-L": "pupil-R"}
+)
+pupil_diameter.name = "pupil diameter"
 # %%
-# A function to plot the pupil diameter is created so that we can easily
-# compare the effect of different filters.
-def plot_pupil_diameter(da_dict, **kwargs):
-    fig, ax = plt.subplots(figsize=(5, 3))
-    for da_name, da in da_dict.items():
-        x = da.sel(**kwargs).time  # time points
-        y = da.sel(**kwargs)  # pupil diameter
-        ax.plot(x, y, label=da_name)
-        ax.set_xlabel("Time (s)")
-        ax.set_ylabel("Pupil diameter (pixels)")
-    ax.legend()
-    ax.set_title("Pupil diameter")
-    plt.tight_layout()
-    return fig, ax
-
-
-# %%
-# Now the pupil diameter before filtering can be plotted.
-
-fig, ax = plot_pupil_diameter(pupil_diameter_dict)
-fig.show()
+# Now the pupil diameter can be plotted.
+pupil_diameter.plot.line(x="time", hue="lighting")
+plt.show()
 # %%
 # The plot of the pupil diameter looks noisy. The very steep peaks are
 # unlikely to represent real changes in the pupil size. Unlike eye movements,
@@ -254,47 +222,41 @@ fig.show()
 # -------------------------------
 # A moving average filter is used here to smooth the data by averaging a
 # specified number of data points (``filter_len``)  to reduce noise.
-filter_len = 150
+filter_len = 80
 filter = np.ones(filter_len)
-avg_filter_dict = {}
-for da_name, da in pupil_diameter_dict.items():
-    da_filter = da.copy(deep=True)
-    # Calculate smooth average using numpy.convolve
-    da_filter.data = np.convolve(da_filter, filter / filter_len, mode="same")
-    avg_filter_dict[da_name] = da_filter
+avg_filter = pupil_diameter.copy()
+for lighting in avg_filter.coords["lighting"].values:
+    da = pupil_diameter.sel(lighting=lighting)
+    # numpy.convolve can be used to filter the data, because itexpects
+    # 1-dimensional input arrays we have to loop through the lighting
+    # dimensions to process the data
+    filtered_data = np.convolve(da, filter / filter_len, mode="same")
+    avg_filter.sel(lighting=lighting).loc[:] = filtered_data
 
 # %%
-# The filter distorts the first few and last frames of the pupil
-# diameter data which is why we exclude the first and last number of frames
-# corresponding to half the filter length.
+# The filter distorts the first few and last frames of the pupil diameter data
+# which is why we exclude the first and last number of frames corresponding to
+# half the filter length.
 
-plot_slice = slice(filter_len // 2, -filter_len // 2)
-# Time points from the black dataset are used for both datasets
-time_points = avg_filter_dict["black"].time[plot_slice]
+# In this case both datasets have videos with 40 frames per second.
+fps = ds_dict["black"].attrs["fps"]  # good to double-check in video properties
+exclude_duration = filter_len // 2 / fps  # in seconds
+time_window = slice(exclude_duration, avg_filter.time[-1] - exclude_duration)
 
 # %%
-# Now the average filtered pupil diameter can be plotted.
-fig, ax = plot_pupil_diameter(avg_filter_dict, time=time_points)
-ax.set_title("Pupil diameter (moving average filter)")
-fig.show()
+# Now the filtered pupil diameter can be plotted.
+avg_filter.sel(time=time_window).squeeze().plot.line(x="time", hue="lighting")
+plt.show()
 # %%
 # Median filtered pupil diameter
 # ------------------------------
-# Another way to filter the data is by using ``median_filter``
-# from the ``movement.filtering`` module. The ``median_filter`` function
-# conveniently takes care of creating the filter and excluding the first
-# and last number of frames corresponding to half the filter length.
+# Another way to filter the data is by using ``median_filter`` from the
+# ``movement.filtering`` module. The ``median_filter`` function conveniently
+# takes care of creating the filter and excluding the first and last number of
+# frames corresponding to half the filter length. Unlike ``np.convolve``, it
+# can be applied to multidimensional data.
 
-median_filter_dict = {}
-for da_name, da in pupil_diameter_dict.items():
-    da_filter = da.copy(deep=True)
-    da_filter.data = median_filter(da, filter_len, print_report=False)
-    median_filter_dict[da_name] = da_filter
-
-# %%
-# Now the median filtered pupil diameter can be plotted.
-fig, ax = plot_pupil_diameter(median_filter_dict)
-ax.set_title("Pupil diameter (moving median filter)")
-fig.show()
-
+mdn_filter = median_filter(pupil_diameter, filter_len, print_report=False)
+mdn_filter.sel(time=time_window).squeeze().plot.line(x="time", hue="lighting")
+plt.show()
 # %%

--- a/examples/mouse_eye_movements.py
+++ b/examples/mouse_eye_movements.py
@@ -32,7 +32,7 @@ ds = {"black": ds_black, "uniform": ds_uniform}
 
 # %%
 # Explore the data
-# -------------
+# ----------------
 video = {}  # To save videos in
 for name, ds_i in ds.items():
     video[name] = sio.load_video(ds_i.video_path)
@@ -45,7 +45,7 @@ for name, ds_i in ds.items():
 # Both datasets contain videos of a mouse eye under two different conditions.
 # %%
 # Plot first frame with keypoints
-# -------------
+# -------------------------------
 fig, ax = plt.subplots(1, 2, figsize=(10, 4))
 for i, (name, ds_i) in enumerate(ds.items()):
     ax[i].imshow(video[name][0], cmap="gray")  # plot first video frame
@@ -61,7 +61,7 @@ plt.show()
 
 # %%
 # Pupil trajectory
-# -------------
+# ----------------
 # A quick trajectory plot of the trajectory of the centre of the pupil.
 time_points = ds_black.time[slice(50, 1000)]
 position_black = ds_black.position.sel(time=time_points)  # data array to plot
@@ -70,7 +70,7 @@ fig.show()
 
 # %%
 # Pupil trajectories on top of video frame
-# -------------
+# ----------------------------------------
 # Plot pupil trajectories for both 'black' and 'uniform' datasets
 
 fig, ax = plt.subplots(1, 2, figsize=(11, 3))
@@ -96,7 +96,7 @@ plt.show()
 
 # %%
 # Keypoint positions in x and y over time
-# -------------
+# ---------------------------------------
 # Helper function to plot the data
 def quick_plot(da, time=None, ax=None, **selection):
     if time:
@@ -124,7 +124,7 @@ plt.show()
 
 # %%
 # Normalise movement to the eye midpoint
-# -------------
+# --------------------------------------
 # Normalizing the pupil's position relative to the eye keypoints reduces the
 # impact of head movements or artefacts caused by movement of the camera.
 
@@ -157,7 +157,7 @@ plt.show()
 # There is less high frequency noise in the signal now.
 # %%
 # Pupil Centroid
-# -------------
+# --------------
 # Add a pupil centroid keypoint to the normalised position data
 for da_name, da in position_norm.items():
     pupil_centroid = da.sel(keypoints=["pupil-L", "pupil-R"]).mean("keypoints")
@@ -166,7 +166,7 @@ for da_name, da in position_norm.items():
 
 # %%
 # Pupil position over time
-# -------------
+# ------------------------
 # From the normalised position data, select the pupil-C keypoint we've
 # created and the timepoints to plot.
 da = position_norm[ds_name].sel(keypoints="pupil-C", time=time_points)
@@ -197,7 +197,7 @@ plt.tight_layout()
 plt.show()
 # %%
 # Pupil velocity over time
-# -------------
+# ------------------------
 
 velocity = {
     ds_name: kin.compute_velocity(
@@ -230,7 +230,7 @@ plt.show()
 
 # %%
 # Pupil diameter
-# -------------
+# --------------
 # In these datasets, the distance between the two pupil keypoints
 # is used to quantify the pupil diameter.
 
@@ -253,7 +253,7 @@ plt.tight_layout()
 plt.show()
 # %%
 # Pupil Diameter after filter
-# -------------
+# ---------------------------
 # A filter can be used to smooth out pupil size data. Unlike eye movements,
 # which can be extremely fast, pupil size is unlikely to change rapidly. A
 # Moving Average Filter is used here to smooth the data by averaging a


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other (adds an example)

**Why is this PR needed?**

**What does this PR do?**
Adds an example (using data Sepi provided), analysing pupil movement of a mouse that is rotated on a platform in two different conditions (`black` and `uniform`).

In the example `movement` is used in the following ways:
- Import `movement ` example data (`sample_data`).
- Quickly plot the trajectory of the pupil using `plot_trajectory` from `movement.plots `.
- Quantify the velocity with which the pupil centroid moves using `compute_velocity `from the `movement.kinematics` module
- Quantify the pupil diameter using `compute_pairwise_distances ` from `movement.kinematics` to calculate the Euclidean distances between two keypoints.
- Filtering pupil diameter data using `median_filter `from the `movement.filtering` module. 

## References


## How has this PR been tested?
Looked over the locally generated docs.

## Is this a breaking change?
No.

## Does this PR require an update to the documentation?
It is itself an update to the documentation.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
