### PR TITLE
Add `make` docs note for PowerShell users

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -289,6 +289,10 @@ cd docs
 ```
 All subsequent commands should be run from this directory.
 
+:::{note}
+Windows PowerShell users should prepend `make` commands with `.\` (e.g. `.\make html`).
+:::
+
 To build the documentation, run:
 
 ```sh


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
This PR closes #407 

**What does this PR do?**
Clarifies build docs guide for Windows PowerShell users by adding a note to ask users to prepend `make` commands with `.\`. 

![image](https://github.com/user-attachments/assets/e12d3367-af7e-4abb-97d2-c6c0b4a0d009)

## References
#407 

## How has this PR been tested?
`.\make` command tested in PowerShell and CMD

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
