### PR TITLE
Fix `compute_signed_angle_2d` using 2D boolean indexing

### DIFF
--- a/movement/utils/vector.py
+++ b/movement/utils/vector.py
@@ -254,7 +254,7 @@ def compute_signed_angle_2d(
     angles = np.arctan2(cross, dot)
     # arctan2 returns values in [-pi, pi].
     # We need to map -pi angles to pi, to stay in the (-pi, pi] range
-    angles[angles <= -np.pi] = np.pi
+    angles.values[angles <= -np.pi] = np.pi
     return angles
 
 


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

See #428. `xarray.DataArray` objects cannot be indexed with boolean arrays of more than 1 dimension (despite the underlying `numpy` arrays happily being able to do so?) and we are relying on being able to do so in `compute_signed_angle_2d`.

**What does this PR do?**

`compute_signed_angle_2d` now indexes on the `.values` attribute of the `DataArray` when mapping `-np.pi` angles to `np.pi`.

## References

Closes #428 

## How has this PR been tested?

We have a new test to catch this issue, which simulates the addition of "extra" dimensions (IE non space/time) to a DataArray, which is then input into `compute_signed_angle_2d`.

Additionally, the [original code that identified the issue](https://github.com/neuroinformatics-unit/movement/issues/428#issue-2868587522) now has returned values of 

```python
>>> angles.shape
(18485, 1)
>>> angles.dims
["time", "individuals"]
>>> angles_squeezed.shape
(18485,)
>>> angles_squeezed.dims
["time"]
```

consistent with the expected behaviour.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
