### PR TITLE
Extend napari plugin to bboxes' centroids

### DIFF
--- a/docs/source/user_guide/gui.md
+++ b/docs/source/user_guide/gui.md
@@ -122,7 +122,7 @@ as a single 2D frame without a slider.
 
 ## Load the poses dataset
 
-Now you are ready to load some pose tracks over your chosen background layer.
+Now you are ready to load some motion tracks over your chosen background layer.
 
 On the right-hand side of the window you should see
 an expanded `Load poses` menu. To load pose data in napari:
@@ -149,7 +149,8 @@ You will see a view similar to the one below:
 
 The keypoints are represented as points, colour-coded by
 keypoint ID for single-individual datasets, or by individual ID for
-multi-individual datasets. These IDs can be also displayed as text
+multi-individual datasets. In bounding boxes datasets, since there are no keypoints,
+the points are colour-coded by individual ID. The value for each point's colour can be displayed as text
 next to the points by enabling the `display text` option from the
 layer controls panel.
 
@@ -168,7 +169,4 @@ in sync.
 Though the display style of the points layer is currently fixed, we are
 working on adding more customisation options in future releases, such as
 enabling you to change the point size, colour, or shape.
-
-We are also working on enabling the visualisation of
-[bounding boxes datasets](target-poses-and-bboxes-dataset) in the plugin.
 :::

--- a/docs/source/user_guide/gui.md
+++ b/docs/source/user_guide/gui.md
@@ -148,11 +148,11 @@ You will see a view similar to the one below:
 ![napari widget with poses dataset loaded](../_static/napari_plugin_with_poses_as_points.png)
 
 The keypoints are represented as points, colour-coded by
-keypoint ID for single-individual datasets, or by individual ID for
-multi-individual datasets. In bounding boxes datasets, since there are no keypoints,
-the points are colour-coded by individual ID. If we enable the `display_text` option in the
+keypoint for single-individual datasets, or by individual for
+multi-individual datasets. In datasets with one or no keypoints per individual,
+the points are always colour-coded by individual. If we enable the `display_text` option in the
 layer controls panel, the keypoint name will be displayed on the lower right corner of each point. If the
-dataset has no keypoint dimension, the individual name is shown.
+dataset has no keypoint dimension, the individual name is shown instead.
 
 Hovering with your mouse over a point
 (with the points layer selected) will

--- a/docs/source/user_guide/gui.md
+++ b/docs/source/user_guide/gui.md
@@ -4,7 +4,7 @@
 The `movement` graphical user interface (GUI), powered by our custom plugin for
 [napari](napari:), makes it easy to view and explore `movement`
 motion tracks. Currently, you can use it to
-visualise 2D [poses datasets](target-poses-and-bboxes-dataset)
+visualise 2D [movement datasets](target-poses-and-bboxes-dataset)
 as points overlaid on video frames.
 
 :::{warning}
@@ -45,7 +45,7 @@ Below, we'll explain how to do this.
 Though this is not strictly necessary, it is usually informative to
 view the keypoints overlaid on a background that provides
 some spatial context. You can either [load the video](target-load-video)
-corresponding to the poses dataset, or a [single image](target-load-frame),
+corresponding to the dataset, or a [single image](target-load-frame),
 e.g., a still frame derived from that video.
 You can do this by dragging and dropping the corresponding file onto the
 `napari` window or by using the `File > Open File(s)` menu option.
@@ -120,15 +120,15 @@ Dragging and dropping the image file onto the `napari` window
 (or opening it via the `File` menu) will load the image
 as a single 2D frame without a slider.
 
-## Load the poses dataset
+## Load the tracked dataset
 
 Now you are ready to load some motion tracks over your chosen background layer.
 
 On the right-hand side of the window you should see
-an expanded `Load poses` menu. To load pose data in napari:
+an expanded `Load tracked data` menu. To load tracked data in napari:
 1. Select the `source software` from the dropdown menu.
-2. Set the `fps`  (frames per second) of the video the pose data refers to. Note this will only affect the units of the time variable shown when hovering over a keypoint. If the `fps` is not known, you can set it to 1, which will effectively make the time variable equal to the frame number.
-3. Select the file containing the predicted poses. The path can be directly pasted or you can use the file browser button.
+2. Set the `fps`  (frames per second) of the video the data refers to. Note this will only affect the units of the time variable shown when hovering over a keypoint. If the `fps` is not known, you can set it to 1, which will effectively make the time variable equal to the frame number.
+3. Select the file containing the tracked data. The path can be directly pasted or you can use the file browser button.
 4. Click `Load`.
 
 The data should be loaded into the viewer as a

--- a/docs/source/user_guide/gui.md
+++ b/docs/source/user_guide/gui.md
@@ -150,9 +150,9 @@ You will see a view similar to the one below:
 The keypoints are represented as points, colour-coded by
 keypoint ID for single-individual datasets, or by individual ID for
 multi-individual datasets. In bounding boxes datasets, since there are no keypoints,
-the points are colour-coded by individual ID. The value for each point's colour can be displayed as text
-next to the points by enabling the `display text` option from the
-layer controls panel.
+the points are colour-coded by individual ID. If we enable the `display_text` option in the
+layer controls panel, the keypoint name will be displayed on the lower right corner of each point. If the
+dataset has no keypoint dimension, the individual name is shown.
 
 Hovering with your mouse over a point
 (with the points layer selected) will

--- a/movement/napari/convert.py
+++ b/movement/napari/convert.py
@@ -12,24 +12,30 @@ logger = logging.getLogger(__name__)
 
 def _construct_properties_dataframe(ds: xr.Dataset) -> pd.DataFrame:
     """Construct a properties DataFrame from a ``movement`` dataset."""
-    return pd.DataFrame(
-        {
-            "individual": ds.coords["individuals"].values,
-            "keypoint": ds.coords["keypoints"].values,
-            "time": ds.coords["time"].values,
-            "confidence": ds["confidence"].values.flatten(),
-        }
-    )
+    data = {
+        "individual": ds.coords["individuals"].values,
+        "time": ds.coords["time"].values,
+        "confidence": ds["confidence"].values.flatten(),
+    }
+    desired_order = list(data.keys())
+    if "keypoints" in ds.coords:
+        data["keypoint"] = ds.coords["keypoints"].values
+        desired_order.insert(1, "keypoint")
+
+    # sort
+    return pd.DataFrame(data).reindex(columns=desired_order)
 
 
-def poses_to_napari_tracks(ds: xr.Dataset) -> tuple[np.ndarray, pd.DataFrame]:
-    """Convert poses dataset to napari Tracks array and properties.
+def movement_ds_to_napari_tracks(
+    ds: xr.Dataset,
+) -> tuple[np.ndarray, pd.DataFrame]:
+    """Convert ``movement`` dataset to napari Tracks array and properties.
 
     Parameters
     ----------
     ds : xr.Dataset
-        ``movement`` dataset containing pose tracks, confidence scores,
-        and associated metadata.
+        ``movement`` dataset containing pose or bounding box tracks,
+        confidence scores, and associated metadata.
 
     Returns
     -------
@@ -54,20 +60,27 @@ def poses_to_napari_tracks(ds: xr.Dataset) -> tuple[np.ndarray, pd.DataFrame]:
     """
     n_frames = ds.sizes["time"]
     n_individuals = ds.sizes["individuals"]
-    n_keypoints = ds.sizes["keypoints"]
+    n_keypoints = ds.sizes.get("keypoints", 1)
     n_tracks = n_individuals * n_keypoints
+
     # Construct the napari Tracks array
     # Reorder axes to (individuals, keypoints, frames, xy)
-    yx_cols = np.transpose(ds.position.values, (3, 2, 0, 1)).reshape(-1, 2)[
+    axes_reordering = (3, 2, 0, 1) if "keypoints" in ds.coords else (2, 0, 1)
+    yx_cols = np.transpose(ds.position.values, axes_reordering).reshape(-1, 2)[
         :, [1, 0]  # swap x and y columns
     ]
+
     # Each keypoint of each individual is a separate track
     track_id_col = np.repeat(np.arange(n_tracks), n_frames).reshape(-1, 1)
     time_col = np.tile(np.arange(n_frames), (n_tracks)).reshape(-1, 1)
     data = np.hstack((track_id_col, time_col, yx_cols))
+
     # Construct the properties DataFrame
     # Stack 3 dimensions into a new single dimension named "tracks"
-    ds_ = ds.stack(tracks=("individuals", "keypoints", "time"))
+    dimensions_to_stack: tuple[str, ...] = ("individuals", "time")
+    if "keypoints" in ds.coords:
+        dimensions_to_stack = dimensions_to_stack + ("keypoints",)
+    ds_ = ds.stack(tracks=sorted(dimensions_to_stack))
     properties = _construct_properties_dataframe(ds_)
 
     return data, properties

--- a/movement/napari/convert.py
+++ b/movement/napari/convert.py
@@ -26,7 +26,7 @@ def _construct_properties_dataframe(ds: xr.Dataset) -> pd.DataFrame:
     return pd.DataFrame(data).reindex(columns=desired_order)
 
 
-def movement_ds_to_napari_tracks(
+def ds_to_napari_tracks(
     ds: xr.Dataset,
 ) -> tuple[np.ndarray, pd.DataFrame]:
     """Convert ``movement`` dataset to napari Tracks array and properties.

--- a/movement/napari/convert.py
+++ b/movement/napari/convert.py
@@ -69,8 +69,8 @@ def movement_ds_to_napari_tracks(
     if "keypoints" in ds.coords:
         axes_reordering = (3,) + axes_reordering
     yx_cols = np.transpose(
-        ds.position.values,
-        axes_reordering,
+        ds.position.values,  # from: frames, xy, keypoints, individuals
+        axes_reordering,  # to: individuals, keypoints, frames, xy
     ).reshape(-1, 2)[:, [1, 0]]  # swap x and y columns
 
     # Each keypoint of each individual is a separate track
@@ -79,11 +79,13 @@ def movement_ds_to_napari_tracks(
     data = np.hstack((track_id_col, time_col, yx_cols))
 
     # Construct the properties DataFrame
-    # Stack 3 dimensions into a new single dimension named "tracks"
+    # Stack individuals, time and keypoints (if present) dimensions
+    # into a new single dimension named "tracks"
     dimensions_to_stack: tuple[str, ...] = ("individuals", "time")
     if "keypoints" in ds.coords:
         dimensions_to_stack += ("keypoints",)  # add last
     ds_ = ds.stack(tracks=sorted(dimensions_to_stack))
+
     properties = _construct_properties_dataframe(ds_)
 
     return data, properties

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -27,13 +27,13 @@ logger = logging.getLogger(__name__)
 
 # Allowed file suffixes for each supported source software
 SUPPORTED_POSES_FILES = {
-    "DeepLabCut": ["*.h5", "*.csv"],
-    "LightningPose": ["*.csv"],
-    "SLEAP": ["*.h5", "*.slp"],
+    "DeepLabCut": ["h5", "csv"],
+    "LightningPose": ["csv"],
+    "SLEAP": ["h5", "slp"],
 }
 
 SUPPORTED_BBOXES_FILES = {
-    "VIA-tracks": ["*.csv"],
+    "VIA-tracks": ["csv"],
 }
 
 SUPPORTED_DATA_FILES = {
@@ -113,9 +113,12 @@ class DataLoader(QWidget):
 
     def _on_browse_clicked(self):
         """Open a file dialog to select a file."""
-        file_suffixes = SUPPORTED_DATA_FILES[
-            self.source_software_combo.currentText()
-        ]
+        file_suffixes = (
+            "*." + suffix
+            for suffix in SUPPORTED_DATA_FILES[
+                self.source_software_combo.currentText()
+            ]
+        )
 
         file_path, _ = QFileDialog.getOpenFileName(
             self,

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -20,7 +20,7 @@ from qtpy.QtWidgets import (
 )
 
 from movement.io import load_bboxes, load_poses
-from movement.napari.convert import movement_ds_to_napari_tracks
+from movement.napari.convert import ds_to_napari_tracks
 from movement.napari.layer_styles import PointsStyle
 
 logger = logging.getLogger(__name__)
@@ -152,7 +152,7 @@ class DataLoader(QWidget):
         ds = loader.from_file(file_path, source_software, fps)
 
         # Convert to napari Tracks array
-        self.data, self.props = movement_ds_to_napari_tracks(ds)
+        self.data, self.props = ds_to_napari_tracks(ds)
         logger.info("Converted dataset to a napari Tracks array.")
         logger.debug(f"Tracks array shape: {self.data.shape}")
 

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -143,10 +143,12 @@ class DataLoader(QWidget):
         if file_path == "":
             show_warning("No file path specified.")
             return
-        elif source_software in SUPPORTED_POSES_FILES:
-            ds = load_poses.from_file(file_path, source_software, fps)
-        elif source_software in SUPPORTED_BBOXES_FILES:
-            ds = load_bboxes.from_file(file_path, source_software, fps)
+
+        if source_software in SUPPORTED_POSES_FILES:
+            loader = load_poses
+        else:
+            loader = load_bboxes
+        ds = loader.from_file(file_path, source_software, fps)
 
         # Convert to napari Tracks array
         self.data, self.props = movement_ds_to_napari_tracks(ds)

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -146,7 +146,6 @@ class DataLoader(QWidget):
             ds = load_bboxes.from_file(file_path, source_software, fps)
 
         # Convert to napari Tracks array
-        # self.data, self.props = poses_to_napari_tracks(ds)
         self.data, self.props = movement_ds_to_napari_tracks(ds)
 
         logger.info("Converted dataset to a napari Tracks array.")

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -19,33 +19,44 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from movement.io import load_poses
-from movement.napari.convert import poses_to_napari_tracks
+from movement.io import load_bboxes, load_poses
+from movement.napari.convert import movement_ds_to_napari_tracks
 from movement.napari.layer_styles import PointsStyle
 
 logger = logging.getLogger(__name__)
 
-# Allowed poses file suffixes for each supported source software
+# Allowed file suffixes for each supported source software
 SUPPORTED_POSES_FILES = {
     "DeepLabCut": ["*.h5", "*.csv"],
     "LightningPose": ["*.csv"],
     "SLEAP": ["*.h5", "*.slp"],
 }
 
+SUPPORTED_BBOXES_FILES = {
+    "VIA-tracks": ["*.csv"],
+}
 
-class PosesLoader(QWidget):
-    """Widget for loading movement poses datasets from file."""
+SUPPORTED_DATA_FILES = {
+    **SUPPORTED_POSES_FILES,
+    **SUPPORTED_BBOXES_FILES,
+}
+
+
+class DataLoader(QWidget):
+    """Widget for loading movement datasets from file."""
 
     def __init__(self, napari_viewer: Viewer, parent=None):
         """Initialize the loader widget."""
         super().__init__(parent=parent)
         self.viewer = napari_viewer
         self.setLayout(QFormLayout())
+
         # Create widgets
         self._create_source_software_widget()
         self._create_fps_widget()
         self._create_file_path_widget()
         self._create_load_button()
+
         # Enable layer tooltips from napari settings
         self._enable_layer_tooltips()
 
@@ -53,7 +64,7 @@ class PosesLoader(QWidget):
         """Create a combo box for selecting the source software."""
         self.source_software_combo = QComboBox()
         self.source_software_combo.setObjectName("source_software_combo")
-        self.source_software_combo.addItems(SUPPORTED_POSES_FILES.keys())
+        self.source_software_combo.addItems(SUPPORTED_DATA_FILES.keys())
         self.layout().addRow("source software:", self.source_software_combo)
 
     def _create_fps_widget(self):
@@ -86,6 +97,7 @@ class PosesLoader(QWidget):
         self.browse_button = QPushButton("Browse")
         self.browse_button.setObjectName("browse_button")
         self.browse_button.clicked.connect(self._on_browse_clicked)
+
         # Layout for line edit and button
         self.file_path_layout = QHBoxLayout()
         self.file_path_layout.addWidget(self.file_path_edit)
@@ -101,14 +113,14 @@ class PosesLoader(QWidget):
 
     def _on_browse_clicked(self):
         """Open a file dialog to select a file."""
-        file_suffixes = SUPPORTED_POSES_FILES[
+        file_suffixes = SUPPORTED_DATA_FILES[
             self.source_software_combo.currentText()
         ]
 
         file_path, _ = QFileDialog.getOpenFileName(
             self,
-            caption="Open file containing predicted poses",
-            filter=f"Poses files ({' '.join(file_suffixes)})",
+            caption="Open file containing tracked data",
+            filter=f"Valid data files ({' '.join(file_suffixes)})",
         )
 
         # A blank string is returned if the user cancels the dialog
@@ -123,35 +135,46 @@ class PosesLoader(QWidget):
         fps = self.fps_spinbox.value()
         source_software = self.source_software_combo.currentText()
         file_path = self.file_path_edit.text()
+
+        # Load data
         if file_path == "":
             show_warning("No file path specified.")
             return
-        ds = load_poses.from_file(file_path, source_software, fps)
+        elif source_software in SUPPORTED_POSES_FILES:
+            ds = load_poses.from_file(file_path, source_software, fps)
+        elif source_software in SUPPORTED_BBOXES_FILES:
+            ds = load_bboxes.from_file(file_path, source_software, fps)
 
-        self.data, self.props = poses_to_napari_tracks(ds)
-        logger.info("Converted poses dataset to a napari Tracks array.")
+        # Convert to napari Tracks array
+        # self.data, self.props = poses_to_napari_tracks(ds)
+        self.data, self.props = movement_ds_to_napari_tracks(ds)
+
+        logger.info("Converted dataset to a napari Tracks array.")
         logger.debug(f"Tracks array shape: {self.data.shape}")
 
         self.file_name = Path(file_path).name
         self._add_points_layer()
 
     def _add_points_layer(self):
-        """Add the predicted poses to the viewer as a Points layer."""
+        """Add the tracked data to the viewer as a Points layer."""
         # Find rows in data array that do not contain NaN values
         bool_not_nan = ~np.any(np.isnan(self.data), axis=1)
 
         # Style properties for the napari Points layer
         points_style = PointsStyle(
-            name=f"poses: {self.file_name}",
+            name=f"data: {self.file_name}",
             properties=self.props.iloc[bool_not_nan, :],
         )
 
         # Color the points by individual if there are multiple individuals
         # Otherwise, color by keypoint
-        n_individuals = len(self.props["individual"].unique())
-        points_style.set_color_by(
-            prop="individual" if n_individuals > 1 else "keypoint"
-        )
+        color_prop = "individual"
+        if (
+            len(self.props["individual"].unique()) == 1
+            and "keypoint" in self.props
+        ):
+            color_prop = "keypoint"
+        points_style.set_color_by(prop=color_prop)
         # Add the points layer to the viewer
         self.viewer.add_points(
             self.data[bool_not_nan, 1:],  # columns:(track_id, frame_idx, y, x)
@@ -166,7 +189,7 @@ class PosesLoader(QWidget):
                 expected_frame_range,
             ) + self.viewer.dims.range[1:]
 
-        logger.info("Added poses dataset as a napari Points layer.")
+        logger.info("Added tracked dataset as a napari Points layer.")
 
     @staticmethod
     def _enable_layer_tooltips():

--- a/movement/napari/meta_widget.py
+++ b/movement/napari/meta_widget.py
@@ -17,6 +17,7 @@ class MovementMetaWidget(CollapsibleWidgetContainer):
         """Initialize the meta-widget."""
         super().__init__()
 
+        # Add the data loader widget
         self.add_widget(
             DataLoader(napari_viewer, parent=self),
             collapsible=True,

--- a/movement/napari/meta_widget.py
+++ b/movement/napari/meta_widget.py
@@ -3,7 +3,7 @@
 from napari.viewer import Viewer
 from qt_niu.collapsible_widget import CollapsibleWidgetContainer
 
-from movement.napari.loader_widgets import PosesLoader
+from movement.napari.loader_widgets import DataLoader
 
 
 class MovementMetaWidget(CollapsibleWidgetContainer):
@@ -18,9 +18,9 @@ class MovementMetaWidget(CollapsibleWidgetContainer):
         super().__init__()
 
         self.add_widget(
-            PosesLoader(napari_viewer, parent=self),
+            DataLoader(napari_viewer, parent=self),
             collapsible=True,
-            widget_title="Load poses",
+            widget_title="Load data",
         )
 
         self.loader = self.collapsible_widgets[0]

--- a/movement/napari/meta_widget.py
+++ b/movement/napari/meta_widget.py
@@ -21,7 +21,7 @@ class MovementMetaWidget(CollapsibleWidgetContainer):
         self.add_widget(
             DataLoader(napari_viewer, parent=self),
             collapsible=True,
-            widget_title="Load data",
+            widget_title="Load tracked data",
         )
 
         self.loader = self.collapsible_widgets[0]

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -77,13 +77,18 @@ def test_valid_dataset_to_napari_tracks(ds_name, request):
         "individual": np.repeat(
             ds.individuals.values.repeat(n_keypoints), n_frames
         ),
+        **(
+            {
+                "keypoint": np.repeat(
+                    np.tile(ds.keypoints.values, n_individuals), n_frames
+                )
+            }
+            if "keypoints" in ds
+            else {}
+        ),
         "time": expected_frame_ids,
         "confidence": confidence,
     }
-    if "keypoints" in ds:
-        expected_props_dict["keypoint"] = np.repeat(
-            np.tile(ds.keypoints.values, n_individuals), n_frames
-        )
     expected_props = pd.DataFrame(expected_props_dict)
 
     # Assert that the data array matches the expected data

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -33,14 +33,14 @@ def confidence_with_all_nan(valid_poses_dataset):
         "confidence_with_all_nan",
     ],
 )
-def test_valid_poses_to_napari_tracks(ds_name, request):
-    """Test that the conversion from movement poses dataset to napari
+def test_valid_dataset_to_napari_tracks(ds_name, request):
+    """Test that the conversion from movement dataset to napari
     tracks returns the expected data and properties.
     """
     ds = request.getfixturevalue(ds_name)
     n_frames = ds.sizes["time"]
     n_individuals = ds.sizes["individuals"]
-    n_keypoints = ds.sizes["keypoints"]
+    n_keypoints = ds.sizes.get("keypoints", 1)
     n_tracks = n_individuals * n_keypoints  # total tracked points
 
     data, props = movement_ds_to_napari_tracks(ds)

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
-from movement.napari.convert import poses_to_napari_tracks
+from movement.napari.convert import movement_ds_to_napari_tracks
 
 
 @pytest.fixture
@@ -43,7 +43,7 @@ def test_valid_poses_to_napari_tracks(ds_name, request):
     n_keypoints = ds.sizes["keypoints"]
     n_tracks = n_individuals * n_keypoints  # total tracked points
 
-    data, props = poses_to_napari_tracks(ds)
+    data, props = movement_ds_to_napari_tracks(ds)
 
     # Prepare expected y, x positions and corresponding confidence values.
     # Assume values are extracted from the dataset in a specific way,
@@ -101,4 +101,4 @@ def test_invalid_poses_to_napari_tracks(ds_name, expected_exception, request):
     """
     ds = request.getfixturevalue(ds_name)
     with pytest.raises(expected_exception):
-        poses_to_napari_tracks(ds)
+        movement_ds_to_napari_tracks(ds)

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
-from movement.napari.convert import movement_ds_to_napari_tracks
+from movement.napari.convert import ds_to_napari_tracks
 
 
 @pytest.fixture
@@ -43,7 +43,7 @@ def test_valid_dataset_to_napari_tracks(ds_name, request):
     n_keypoints = ds.sizes.get("keypoints", 1)
     n_tracks = n_individuals * n_keypoints  # total tracked points
 
-    data, props = movement_ds_to_napari_tracks(ds)
+    data, props = ds_to_napari_tracks(ds)
 
     # Prepare expected y, x positions and corresponding confidence values.
     # Assume values are extracted from the dataset in a specific way,
@@ -113,4 +113,4 @@ def test_invalid_poses_to_napari_tracks(ds_name, expected_exception, request):
     """
     ds = request.getfixturevalue(ds_name)
     with pytest.raises(expected_exception):
-        movement_ds_to_napari_tracks(ds)
+        ds_to_napari_tracks(ds)

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -230,7 +230,7 @@ def test_dimension_slider_matches_frames(
 
     # Load the poses loader widget
     viewer = make_napari_viewer_proxy()
-    poses_loader_widget = PosesLoader(viewer)
+    poses_loader_widget = DataLoader(viewer)
 
     # Read sample data with a NaN at the specified
     # location (start, middle, or end)

--- a/tests/test_unit/test_napari_plugin/test_layer_styles.py
+++ b/tests/test_unit/test_napari_plugin/test_layer_styles.py
@@ -7,6 +7,7 @@ from movement.napari.layer_styles import (
     DEFAULT_COLORMAP,
     LayerStyle,
     PointsStyle,
+    _sample_colormap,
 )
 
 
@@ -50,7 +51,11 @@ def default_style_attributes(sample_properties):
             "face_color": None,
             "face_color_cycle": None,
             "face_colormap": DEFAULT_COLORMAP,
-            "text": {"visible": False},
+            "text": {
+                "visible": False,
+                "anchor": "lower_left",
+                "translation": 5,
+            },
         },
     }
 
@@ -94,21 +99,82 @@ def test_layer_style_as_kwargs(sample_layer_style, default_style_attributes):
         ("value", 5),
     ],
 )
+@pytest.mark.parametrize(
+    "points_style_text_dict",
+    [
+        "default",
+        "with_color_key",
+    ],
+)
 def test_points_style_set_color_by(
-    sample_layer_style, prop, expected_n_colors
+    sample_layer_style, points_style_text_dict, prop, expected_n_colors
 ):
-    """Test that set_color_by updates face_color and face_color_cycle."""
+    """Test that set_color_by updates the color and color cycle of
+    the point markers and the text.
+    """
+    # Create a points style object with predefined properties
     points_style = sample_layer_style(PointsStyle)
 
-    points_style.set_color_by(prop=prop)
-    # Check that face_color and text are updated correctly
-    assert points_style.face_color == prop
-    assert points_style.text == {"visible": False, "string": prop}
+    # add a color key to the text dictionary if required
+    if points_style_text_dict == "with_color_key":
+        points_style.text = {"color": {"fallback": "white"}}
 
-    # Check that face_color_cycle has the correct number of colors
+    # Color markers and text by the property "prop"
+    points_style.set_color_by(prop=prop)
+
+    # Check that the markers and the text color follow "prop"
+    assert points_style.face_color == prop
+    assert "color" in points_style.text
+    assert points_style.text["color"]["feature"] == prop
+
+    # Check the color cycle
+    color_cycle = _sample_colormap(
+        len(points_style.properties[prop].unique()),
+        cmap_name=DEFAULT_COLORMAP,
+    )
+    assert points_style.face_color_cycle == color_cycle
+    assert points_style.text["color"]["colormap"] == color_cycle
+
+    # Check number of colors is as expected
     assert len(points_style.face_color_cycle) == expected_n_colors
+    assert len(points_style.text["color"]["colormap"]) == expected_n_colors
+
     # Check that all colors are tuples of length 4 (RGBA)
     assert all(
         isinstance(c, tuple) and len(c) == 4
         for c in points_style.face_color_cycle
+    )
+
+
+@pytest.mark.parametrize(
+    "property",
+    [
+        "category",
+        "value",
+    ],
+)
+def test_points_style_set_text_by(
+    property, sample_layer_style, default_style_attributes
+):
+    """Test that set_text_by updates the text property of the points layer."""
+    # Create a points style object with predefined properties
+    points_style = sample_layer_style(PointsStyle)
+
+    # Get the default attributes
+    default_points_style = default_style_attributes[PointsStyle]
+
+    # Check there is no text set
+    assert (
+        "string" not in points_style.text
+        or points_style.text["string"] != property
+    )
+
+    # Set text by the property "category"
+    points_style.set_text_by(prop=property)
+
+    # Check that the text properties are as expected
+    assert points_style.text["string"] == property
+    assert all(
+        points_style.text[attr] == default_points_style["text"][attr]
+        for attr in default_points_style["text"]
     )

--- a/tests/test_unit/test_napari_plugin/test_meta_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_meta_widget.py
@@ -11,5 +11,5 @@ def test_meta_widget_instantiation(make_napari_viewer_proxy):
     assert len(meta_widget.collapsible_widgets) == 1
 
     first_widget = meta_widget.collapsible_widgets[0]
-    assert first_widget._text == "Load data"
+    assert first_widget._text == "Load tracked data"
     assert first_widget.isExpanded()

--- a/tests/test_unit/test_napari_plugin/test_meta_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_meta_widget.py
@@ -11,5 +11,5 @@ def test_meta_widget_instantiation(make_napari_viewer_proxy):
     assert len(meta_widget.collapsible_widgets) == 1
 
     first_widget = meta_widget.collapsible_widgets[0]
-    assert first_widget._text == "Load poses"
+    assert first_widget._text == "Load data"
     assert first_widget.isExpanded()


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
To support visualising bbox datasets in napari

**What does this PR do?**
- Extends the napari movement widget to load bboxes centroids 
- Expands tests to bboxes cases
- Updates the user guide

The support for bboxes shapes will be dealt with in a separate PR.

## References
Somewhat relates to the propsal in #435 since if we make both datasets more similar we wouldn't need to duplicate efforts. I realise that is a bit longer term discussion, but happy to hear thoughts on this if any.

## How has this PR been tested?
Tests pass locally and in CI.

## Is this a breaking change?
No.

## Does this PR require an update to the documentation?
Yes, the napari user guide has been updated.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
