### PR TITLE
Add keypoints dimension to bboxes dataset

### DIFF
--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -684,7 +684,6 @@ def _ds_from_valid_data(data: ValidBboxesDataset) -> xr.Dataset:
     def add_keypoints_dim(arr):
         return np.expand_dims(arr, axis=-2)
 
-    # breakpoint()
     return xr.Dataset(
         data_vars={
             "position": xr.DataArray(

--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -680,18 +680,29 @@ def _ds_from_valid_data(data: ValidBboxesDataset) -> xr.Dataset:
     # with dimensions ('time', 'space', 'individuals')
     DIM_NAMES = ValidBboxesDataset.DIM_NAMES
     n_space = data.position_array.shape[1]
+
+    def add_keypoints_dim(arr):
+        return np.expand_dims(arr, axis=-2)
+
+    # breakpoint()
     return xr.Dataset(
         data_vars={
-            "position": xr.DataArray(data.position_array, dims=DIM_NAMES),
-            "shape": xr.DataArray(data.shape_array, dims=DIM_NAMES),
+            "position": xr.DataArray(
+                add_keypoints_dim(data.position_array), dims=DIM_NAMES
+            ),
+            "shape": xr.DataArray(
+                add_keypoints_dim(data.shape_array), dims=DIM_NAMES
+            ),
             "confidence": xr.DataArray(
-                data.confidence_array, dims=DIM_NAMES[:1] + DIM_NAMES[2:]
+                add_keypoints_dim(data.confidence_array),
+                dims=tuple(dim for dim in DIM_NAMES if dim != "space"),
             ),
         },
         coords={
             DIM_NAMES[0]: time_coords,
             DIM_NAMES[1]: ["x", "y", "z"][:n_space],
-            DIM_NAMES[2]: data.individual_names,
+            DIM_NAMES[2]: ["centroid"],
+            DIM_NAMES[3]: data.individual_names,
         },
         attrs={
             "fps": data.fps,

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -695,7 +695,8 @@ def _ds_from_valid_data(data: ValidPosesDataset) -> xr.Dataset:
         data_vars={
             "position": xr.DataArray(data.position_array, dims=DIM_NAMES),
             "confidence": xr.DataArray(
-                data.confidence_array, dims=DIM_NAMES[:1] + DIM_NAMES[2:]
+                data.confidence_array,
+                dims=tuple(dim for dim in DIM_NAMES if dim != "space"),
             ),
         },
         coords={

--- a/movement/kinematics.py
+++ b/movement/kinematics.py
@@ -727,11 +727,6 @@ def compute_pairwise_distances(
             "'dim' must be either 'individuals' or 'keypoints', "
             f"but got {dim}.",
         )
-    if dim not in data.dims:
-        raise log_error(
-            ValueError,
-            f"Input data does not contain the dimension '{dim}'.",
-        )
     if isinstance(pairs, str) and pairs != "all":
         raise log_error(
             ValueError,

--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -309,7 +309,7 @@ class ValidBboxesDataset:
         validator=validators.optional(validators.instance_of(str)),
     )
 
-    DIM_NAMES: ClassVar[tuple] = ("time", "space", "individuals")
+    DIM_NAMES: ClassVar[tuple] = ("time", "space", "keypoints", "individuals")
     VAR_NAMES: ClassVar[tuple] = ("position", "shape", "confidence")
 
     # Validators

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -91,18 +91,27 @@ def valid_bboxes_dataset(valid_bboxes_arrays):
 
     n_frames, n_individuals, _ = position_array.shape
 
+    def add_keypoints_dim(arr):
+        return np.expand_dims(arr, axis=-2)
+
     return xr.Dataset(
         data_vars={
-            "position": xr.DataArray(position_array, dims=dim_names),
-            "shape": xr.DataArray(shape_array, dims=dim_names),
+            "position": xr.DataArray(
+                add_keypoints_dim(position_array), dims=dim_names
+            ),
+            "shape": xr.DataArray(
+                add_keypoints_dim(shape_array), dims=dim_names
+            ),
             "confidence": xr.DataArray(
-                confidence_array, dims=dim_names[:1] + dim_names[2:]
+                add_keypoints_dim(confidence_array),
+                dims=dim_names[:1] + dim_names[2:],
             ),
         },
         coords={
             dim_names[0]: np.arange(n_frames),
             dim_names[1]: ["x", "y"],
-            dim_names[2]: [f"id_{id}" for id in range(n_individuals)],
+            dim_names[2]: ["centroid"],
+            dim_names[3]: [f"id_{id}" for id in range(n_individuals)],
         },
         attrs={
             "fps": None,

--- a/tests/test_unit/test_kinematics.py
+++ b/tests/test_unit/test_kinematics.py
@@ -683,6 +683,11 @@ def test_compute_pairwise_distances_with_valid_pairs(
             "keypoints",
             {"id_0": "id_1"},
         ),  # the specified keypoints coordinates do not exist
+        (
+            "valid_bboxes_dataset",
+            "foo",
+            "all",
+        ),  # the dim does not exist
         ("missing_dim_poses_dataset", "keypoints", "all"),  # invalid dataset
         (
             "missing_dim_bboxes_dataset",

--- a/tests/test_unit/test_kinematics.py
+++ b/tests/test_unit/test_kinematics.py
@@ -673,6 +673,16 @@ def test_compute_pairwise_distances_with_valid_pairs(
             "invalid_string",
         ),  # invalid pairs
         ("valid_poses_dataset", "individuals", {}),  # empty pairs
+        (
+            "valid_bboxes_dataset",
+            "keypoints",
+            "all",
+        ),  # cannot compute distance with one keypoint coordinate
+        (
+            "valid_bboxes_dataset",
+            "keypoints",
+            {"id_0": "id_1"},
+        ),  # the specified keypoints coordinates do not exist
         ("missing_dim_poses_dataset", "keypoints", "all"),  # invalid dataset
         (
             "missing_dim_bboxes_dataset",

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -245,7 +245,7 @@ def test_from_file(
 
 
 expected_values_bboxes = {
-    "vars_dims": {"position": 3, "shape": 3, "confidence": 2},
+    "vars_dims": {"position": 4, "shape": 4, "confidence": 3},
     "dim_names": ValidBboxesDataset.DIM_NAMES,
 }
 


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
I noticed we sometimes develop features thinking mostly on the pose datasets, and plan to expand things to bboxes datasets next. A good example is the `napari` plugin. 

If our bboxes and poses datasets were more consistent (or eventually, only one dataset), we would save quite a bit of almost-duplicate work and also potentially reduce cognitive load when planning new features (we wouldn't have to think how things would behave in two different scenarios).

Some options:
1 - One option towards having a unique `movement` dataset could be to add a "keypoints" dimension to the bounding boxes dataset, that is always set to "centroid". This is what is proposed in this PR (but I have no particular preference, I just wanted to gauge how painful it would be to implement).

2- Another option could be to not impose strict constraints on what dimensions are required to define a `movement` dataset. We have discussed this before (do we have an issue? I couldn't find it), and allowed this to accommodate the views arrays

Maybe option 1 could be a first step towards unifying the datasets, and then we reduce the constraints on what dimensions are required?

Relatedly, do we see a `movement` dataset hold both keypoint and bboxes data? For example, with a `position_keypoints`, a `position_bboxes_centroids` and a `position_bboxes_shapes` array. So thinking of bbox data as a set of additional arrays, maybe like we were envisioning for the segmentation masks.


**What does this PR do?**
Adds a "keypoints" dimension to the bboxes dataset.

## References
- #210 
- [Zulip: Singleton dims](https://neuroinformatics.zulipchat.com/#narrow/stream/406001-Movement/topic/Support.20single.20individual.20data.20without.20the.20.60individuals.60.20dim)

## How has this PR been tested?

Tests pass locally and in CI.

## Is this a breaking change?

Yes, the bboxes example in particular would need to be reviewed. I will wait until we decide what to do before addressing this.

## Does this PR require an update to the documentation?

Yes - the documentation re movement datasets would need to be updated. I will wait until we decide what to do though.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ - ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
