### PR TITLE
Update Python versions to adhere to SPEC 0

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: neuroinformatics-unit/actions/build_sphinx_docs@main
         with:
-          python-version: 3.11
+          python-version: 3.12
           use-make: true
 
   deploy_sphinx_docs:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -33,9 +33,9 @@ jobs:
         # Include 1 Intel macos (13) and 1 M1 macos (latest) and 1 Windows run
         include:
         - os: macos-13
-          python-version: "3.12"
+          python-version: "3.13"
         - os: macos-latest
-          python-version: "3.12"
+          python-version: "3.13"
         - os: windows-latest
           python-version: "3.13"
 

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -28,16 +28,16 @@ jobs:
     strategy:
       matrix:
         # Run all supported Python versions on linux
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
         os: [ubuntu-latest]
         # Include 1 Intel macos (13) and 1 M1 macos (latest) and 1 Windows run
         include:
         - os: macos-13
-          python-version: "3.11"
+          python-version: "3.12"
         - os: macos-latest
-          python-version: "3.11"
+          python-version: "3.12"
         - os: windows-latest
-          python-version: "3.11"
+          python-version: "3.13"
 
     steps:
       - name: Cache Test Data

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,3 @@ repos:
       rev: v2.4.1
       hooks:
       - id: codespell
-        additional_dependencies:
-        # tomli dependency can be removed when we drop support for Python 3.10
-        - tomli

--- a/docs/source/environment.yml
+++ b/docs/source/environment.yml
@@ -3,7 +3,7 @@
 channels:
   - conda-forge
 dependencies:
-  - python=3.11
+  - python=3.12
   - pytables
   - pip:
     - movement

--- a/docs/source/user_guide/installation.md
+++ b/docs/source/user_guide/installation.md
@@ -24,7 +24,7 @@ conda activate movement-env
 :::{tab-item} Pip
 Create and activate an environment with some prerequisites:
 ```sh
-conda create -n movement-env -c conda-forge python=3.11 pytables
+conda create -n movement-env -c conda-forge python=3.12 pytables
 conda activate movement-env
 ```
 Install the latest movement release from PyPI:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 description = "Analysis of body movement"
 readme = "README.md"
-requires-python = ">=3.10.0"
+requires-python = ">=3.11.0"
 dynamic = ["version"]
 
 license = { text = "BSD-3-Clause" }
@@ -29,9 +29,9 @@ classifiers = [
   "Development Status :: 3 - Alpha",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Operating System :: OS Independent",
   "License :: OSI Approved :: BSD License",
 ]
@@ -143,14 +143,14 @@ legacy_tox_ini = """
 requires =
     tox-conda
     tox-gh-actions
-envlist = py{310,311,312}
+envlist = py{311,312,313}
 isolated_build = True
 
 [gh-actions]
 python =
-    3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [testenv]
 conda_deps =


### PR DESCRIPTION
## Description

Updates the Python versions to adhere to [SPEC 0](https://scientific-python.org/specs/spec-0000/)

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
`qt-niu` is only available for SPEC 0 Python versions (3.11-3.13). This will break the conda-forge process when it's added as a dependency. Now seemed like a good idea to update the supported versions here, as (as far as I know) all the dependencies support 3.13.

In places where the version wasn't the oldest or newest, I've tried to update it in the same way, e.g. keeping the middle version. 
