### PR TITLE
Remove toggles for signed angle computations

### DIFF
--- a/movement/kinematics.py
+++ b/movement/kinematics.py
@@ -362,10 +362,7 @@ def compute_forward_vector_angle(
     right_keypoint: Hashable,
     reference_vector: xr.DataArray | ArrayLike = (1, 0),
     camera_view: Literal["top_down", "bottom_up"] = "top_down",
-    in_radians: bool = False,
-    angle_rotates: Literal[
-        "ref to forward", "forward to ref"
-    ] = "ref to forward",
+    in_degrees: bool = False,
 ) -> xr.DataArray:
     r"""Compute the signed angle between a forward and reference vector.
 
@@ -401,12 +398,9 @@ def compute_forward_vector_angle(
         upwards direction is [0, 0, -1]), or ``"bottom_up"`` (where the
         upwards direction is [0, 0, 1]). If left unspecified, the camera
         view is assumed to be ``"top_down"``.
-    in_radians : bool, optional
-        If true, the returned heading array is given in radians.
-        If false, the array is given in degrees. False by default.
-    angle_rotates : Literal["ref to forward", "forward to ref"], optional
-        Determines the sign convention for the returned signed angle.
-        (See Notes).
+    in_degrees : bool
+        If ``True``, the returned heading array is given in degrees.
+        Otherwise, the array is given in radians. Default ``False``.
 
     Returns
     -------
@@ -415,36 +409,16 @@ def compute_forward_vector_angle(
         with dimensions matching the input data array,
         but without the ``keypoints`` and ``space`` dimensions.
 
-    Notes
-    -----
-    There are different conventions for the sign of the forward vector angle.
-    The ``angle_rotates`` argument can be used to select which behaviour the
-    function should use.
-
-    By default, ``angle_rotates`` is set to ``"ref to forward"``, which
-    results in the signed angle between the reference vector and the forward
-    vector being returned. That is, the angle which the reference vector would
-    need to be rotated by, to align with the forward vector.
-    Setting ``angle_rotates`` to ``"forward to ref"`` reverses this convention,
-    returning the signed angle between the forward vector and the reference
-    vector; that is, the rotation that would need to be applied to the forward
-    vector to return the reference vector.
-
     See Also
     --------
-    movement.utils.vector.compute_signed_angle_2d : The underlying
-        function used to compute the signed angle between two 2D vectors.
-    movement.kinematics.compute_forward_vector : The function used
-        to compute the forward vector.
+    movement.utils.vector.compute_signed_angle_2d :
+        The underlying function used to compute the signed angle between two
+        2D vectors. Also see this function for a definition of the signed
+        angle between two vectors.
+    movement.kinematics.compute_forward_vector :
+        The function used to compute the forward vector.
 
     """
-    if angle_rotates.lower() == "ref to forward":
-        ref_is_left_operand = True
-    elif angle_rotates.lower() == "forward to ref":
-        ref_is_left_operand = False
-    else:
-        raise ValueError(f"Unknown angle convention: '{angle_rotates}'")
-
     # Convert reference vector to np.array if not already a valid array
     if not isinstance(reference_vector, np.ndarray | xr.DataArray):
         reference_vector = np.array(reference_vector)
@@ -455,12 +429,10 @@ def compute_forward_vector_angle(
     )
 
     # Compute signed angle between forward vector and reference vector
-    heading_array = compute_signed_angle_2d(
-        forward_vector, reference_vector, v_as_left_operand=ref_is_left_operand
-    )
+    heading_array = compute_signed_angle_2d(forward_vector, reference_vector)
 
     # Convert to degrees
-    if not in_radians:
+    if in_degrees:
         heading_array = np.rad2deg(heading_array)
 
     return heading_array

--- a/movement/kinematics.py
+++ b/movement/kinematics.py
@@ -413,7 +413,7 @@ def compute_forward_vector_angle(
     --------
     movement.utils.vector.compute_signed_angle_2d :
         The underlying function used to compute the signed angle between two
-        2D vectors. Also see this function for a definition of the signed
+        2D vectors. See this function for a definition of the signed
         angle between two vectors.
     movement.kinematics.compute_forward_vector :
         The function used to compute the forward vector.

--- a/movement/kinematics.py
+++ b/movement/kinematics.py
@@ -370,8 +370,8 @@ def compute_forward_vector_angle(
     <movement.utils.vector.compute_signed_angle_2d>`
     between the reference vector and the animal's :func:`forward vector\
     <movement.kinematics.compute_forward_vector>`.
-    The returned angles are in degrees, spanning the range :math:`(-180, 180]`,
-    unless ``in_radians`` is set to ``True``.
+    The returned angles are in radians, spanning the range :math:`(-\pi, \pi]`,
+    unless ``in_degrees`` is set to ``True``.
 
     Parameters
     ----------

--- a/movement/roi/base.py
+++ b/movement/roi/base.py
@@ -113,7 +113,6 @@ class BaseRegionOfInterest:
         how_to_compute_vector_to_region: Callable[
             [xr.DataArray], xr.DataArray
         ],
-        angle_rotates: Literal["vec to ref", "ref to vec"] = "vec to ref",
         in_degrees: bool = False,
     ) -> xr.DataArray:
         """Perform a boundary angle computation.
@@ -145,30 +144,14 @@ class BaseRegionOfInterest:
             "vector to the region".
         how_to_compute_vector_to_region : Callable
             How to compute the "vector to the region" from ``position``.
-        angle_rotates : Literal["vec to ref", "ref to vec"]
-            Convention for the returned signed angle. ``"vec to ref"`` returns
-            the signed angle between the "vector to the region" and the
-            ``reference_vector``. ``"ref to vec"`` returns the opposite.
-            Default is ``"vec to ref"``
         in_degrees : bool
             If ``True``, angles are returned in degrees. Otherwise angles are
             returned in radians. Default ``False``.
 
         """
-        if angle_rotates == "vec to ref":
-            ref_is_left_operand = False
-        elif angle_rotates == "ref to vec":
-            ref_is_left_operand = True
-        else:
-            raise ValueError(f"Unknown angle convention: {angle_rotates}")
-
         vec_to_segment = how_to_compute_vector_to_region(position)
 
-        angles = compute_signed_angle_2d(
-            vec_to_segment,
-            reference_vector,
-            v_as_left_operand=ref_is_left_operand,
-        )
+        angles = compute_signed_angle_2d(vec_to_segment, reference_vector)
         if in_degrees:
             angles = np.rad2deg(angles)
         return angles
@@ -440,9 +423,6 @@ class BaseRegionOfInterest:
     def compute_allocentric_angle_to_nearest_point(
         self,
         position: xr.DataArray,
-        angle_rotates: Literal[
-            "approach to ref", "ref to approach"
-        ] = "approach to ref",
         boundary_only: bool = False,
         in_degrees: bool = False,
         reference_vector: np.ndarray | xr.DataArray = None,
@@ -462,9 +442,6 @@ class BaseRegionOfInterest:
         ----------
         position : xarray.DataArray
             ``DataArray`` of spatial positions.
-        angle_rotates : Literal["approach to ref", "ref to approach"]
-            Direction of the signed angle returned. Default is
-            ``"approach to ref"``.
         boundary_only : bool
             If ``True``, the allocentric angle to the closest boundary point of
             the region is computed. Default ``False``.
@@ -500,7 +477,6 @@ class BaseRegionOfInterest:
                 ),
                 "vector to",
             ),
-            angle_rotates=angle_rotates.replace("approach", "vec"),  # type: ignore
             in_degrees=in_degrees,
         )
 
@@ -508,9 +484,6 @@ class BaseRegionOfInterest:
         self,
         direction: xr.DataArray,
         position: xr.DataArray,
-        angle_rotates: Literal[
-            "approach to direction", "direction to approach"
-        ] = "approach to direction",
         boundary_only: bool = False,
         in_degrees: bool = False,
     ) -> xr.DataArray:
@@ -532,9 +505,6 @@ class BaseRegionOfInterest:
         position : xarray.DataArray
             `DataArray` of spatial positions, considered the origin of the
             ``direction`` vector.
-        angle_rotates : {"approach to direction", "direction to approach"}
-            Direction of the signed angle returned. Default is
-            ``"approach to direction"``.
         boundary_only : bool
             Passed to ``compute_approach_vector`` (see Notes). Default
             ``False``.
@@ -562,9 +532,6 @@ class BaseRegionOfInterest:
                     p, boundary_only=boundary_only, unit=False
                 ),
                 "vector to",
-            ),
-            angle_rotates=angle_rotates.replace("approach", "vec").replace(  # type: ignore
-                "direction", "ref"
             ),
             in_degrees=in_degrees,
         )

--- a/movement/roi/line.py
+++ b/movement/roi/line.py
@@ -1,7 +1,5 @@
 """1-dimensional lines of interest."""
 
-from typing import Literal
-
 import numpy as np
 import xarray as xr
 from numpy.typing import ArrayLike
@@ -118,12 +116,12 @@ class LineOfInterest(BaseRegionOfInterest):
         self,
         direction: xr.DataArray,
         position: xr.DataArray,
-        angle_rotates: Literal[
-            "direction to normal", "normal to direction"
-        ] = "normal to direction",
         in_degrees: bool = False,
     ) -> xr.DataArray:
         """Compute the angle between the normal to the segment and a direction.
+
+        The returned angle is the signed angle between the normal directed
+        toward the segment and the ``direction`` provided.
 
         Parameters
         ----------
@@ -132,12 +130,14 @@ class LineOfInterest(BaseRegionOfInterest):
             e.g., the forward vector(s).
         position : xr.DataArray
             Spatial positions, considered the origin of the ``direction``.
-        angle_rotates : Literal["direction to normal", "normal to direction"]
-            Sign convention of the angle returned. Default is
-            ``"normal to direction"``.
         in_degrees : bool
             If ``True``, angles are returned in degrees. Otherwise angles are
             returned in radians. Default ``False``.
+
+        See Also
+        --------
+        movement.utils.vector.compute_signed_angle_2d :
+            For the definition of the signed angle between two vectors.
 
         """
         return self._boundary_angle_computation(
@@ -145,9 +145,6 @@ class LineOfInterest(BaseRegionOfInterest):
             reference_vector=direction,
             how_to_compute_vector_to_region=lambda p: self._reassign_space_dim(
                 -1.0 * self.normal(p), "normal"
-            ),
-            angle_rotates=angle_rotates.replace("direction", "ref").replace(  # type: ignore
-                "normal", "vec"
             ),
             in_degrees=in_degrees,
         )

--- a/movement/roi/line.py
+++ b/movement/roi/line.py
@@ -120,8 +120,8 @@ class LineOfInterest(BaseRegionOfInterest):
     ) -> xr.DataArray:
         """Compute the angle between the normal to the segment and a direction.
 
-        The returned angle is the signed angle between the normal directed
-        toward the segment and the ``direction`` provided.
+        The returned angle is the signed angle between the normal to the
+        segment and the ``direction`` vector(s) provided.
 
         Parameters
         ----------

--- a/movement/utils/vector.py
+++ b/movement/utils/vector.py
@@ -219,7 +219,7 @@ def compute_signed_angle_2d(
     coordinates ``"x"`` and ``"y"`` only, and must have a ``time`` dimension
     matching that of ``u``.
 
-    If passed as a numpy array, the ``v`` must have one of three shapes:
+    If passed as a numpy array, ``v`` must have one of three shapes:
 
     - ``(2,)``: where dimension ``0`` contains spatial
       coordinates (x,y), and no time dimension is specified.

--- a/tests/test_unit/test_kinematics.py
+++ b/tests/test_unit/test_kinematics.py
@@ -808,6 +808,31 @@ class TestForwardVectorAngle:
             with_orientations_swapped, expected_orientations
         )
 
+    def test_in_degrees_toggle(
+        self, spinning_on_the_spot: xr.DataArray
+    ) -> None:
+        """Test that angles can be returned in degrees or radians."""
+        reference_vector = self.x_axis
+        left_keypoint = "left"
+        right_keypoint = "right"
+
+        in_radians = kinematics.compute_forward_vector_angle(
+            data=spinning_on_the_spot,
+            left_keypoint=left_keypoint,
+            right_keypoint=right_keypoint,
+            reference_vector=reference_vector,
+            in_degrees=False,
+        )
+        in_degrees = kinematics.compute_forward_vector_angle(
+            data=spinning_on_the_spot,
+            left_keypoint=left_keypoint,
+            right_keypoint=right_keypoint,
+            reference_vector=reference_vector,
+            in_degrees=True,
+        )
+
+        xr.testing.assert_allclose(in_degrees, np.rad2deg(in_radians))
+
     @pytest.mark.parametrize(
         ["transformation"],
         [pytest.param("scale"), pytest.param("translation")],

--- a/tests/test_unit/test_roi/test_angles.py
+++ b/tests/test_unit/test_roi/test_angles.py
@@ -298,7 +298,7 @@ def test_angle_to_normal(
     segment_of_y_equals_x: LineOfInterest,
     points_around_segment: xr.DataArray,
 ) -> None:
-    """Test the angle_to_support_plane method.
+    """Test the angle with normal vector computation.
 
     This method checks two things:
 


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

See #438 - simplifies the call signature of functions that compute angles between vectors, and allows us to use precise language in our doc-strings when describing these quantities.

Also see #427.

Both of these issues were raised in #416, but were shifted to issues to reduce the PR complexity. Now that #416 is merged, we can apply these changes. Have tagged the original, hard-working reviewers from that PR here (but probably only one pair of eyes needed) :sweat_smile: 

**What does this PR do?**

Removes the option to toggle the "angle direction" in (high-level) functions that compute signed angles between two vectors, in some capacity. Specifically;

- `compute_forward_vector_angle` - this function has also had it's default angle unit switched to radians (previously degrees) to address #427,
- `compute_angle_to_normal`,
- `compute_{ego,allo}centric_angle_to_nearest_point`.

The above functions already adhered to a consistent convention when their default values were used, which has been made the definition and standard.

The lower-level `compute_signed_angle_2d` function, that these functions all depend on, has retained it's `v_as_left_operand` argument. This is because the function is asymmetric in its arguments, and there may be cases where we really do want to swap the roles of the input `u` and `v`.

#### Small Test Suite Changes

[One error-case](https://github.com/neuroinformatics-unit/movement/pull/445/files#diff-1965f150d17334bc39fc66e32e2f4e2327ae59b7fb047cfbd115d0d290a81609L894) test has been removed, since this is actually tested by `compute_signed_angle_2d` anyway - and in fact the error that is checked-for is raised within that function.

A test that the `in_degrees` toggle for `compute_forward_vector_angle` has been added, since CodeCov was complaining.

## References

Closes #427.
Closes #438.

## How has this PR been tested?

Since this is just removal of a feature, the now-irrelevant parts of the test suite have been removed. All other tests still pass with the adoption of the new convention.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
