### PR TITLE
Remove Intel Macs from CI workflow

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -30,10 +30,8 @@ jobs:
         # Run all supported Python versions on linux
         python-version: ["3.11", "3.12", "3.13"]
         os: [ubuntu-latest]
-        # Include 1 Intel macos (13) and 1 M1 macos (latest) and 1 Windows run
+        # Include 1 MacOS Silicon (latest) and 1 Windows run
         include:
-        - os: macos-13
-          python-version: "3.13"
         - os: macos-latest
           python-version: "3.13"
         - os: windows-latest


### PR DESCRIPTION
Closes #448.

Some of our dependencies are no longer providing wheels for Intel MacOS on new (3.13) versions of Python. This problem is only going to get worse, as Silicon Macs completely replace Intel Macs over tine.

This PRs removes `macos-13` (Intel Mac) runners from our CI workflow, so we will no longer test on those.
