### PR TITLE
Added a general filter function for mean and median filter

### DIFF
--- a/examples/smooth.py
+++ b/examples/smooth.py
@@ -8,13 +8,13 @@ Smooth pose tracks using the median and Savitzky-Golay filters.
 # Imports
 # -------
 
-from matplotlib import pyplot as plt
+import matplotlib.pyplot as plt
 from scipy.signal import welch
 
 from movement import sample_data
 from movement.filtering import (
     interpolate_over_time,
-    median_filter,
+    rolling_filter,
     savgol_filter,
 )
 
@@ -124,7 +124,9 @@ def plot_raw_and_smooth_timeseries_and_psd(
 
 window = int(0.1 * ds_wasp.fps)
 ds_wasp_smooth = ds_wasp.copy()
-ds_wasp_smooth.update({"position": median_filter(ds_wasp.position, window)})
+ds_wasp_smooth.update(
+    {"position": rolling_filter(ds_wasp.position, window, method="median")}
+)
 
 # %%
 # We see from the printed report that the dataset has no missing values
@@ -168,7 +170,9 @@ print(ds_mouse)
 
 window = int(0.1 * ds_mouse.fps)
 ds_mouse_smooth = ds_mouse.copy()
-ds_mouse_smooth.update({"position": median_filter(ds_mouse.position, window)})
+ds_mouse_smooth.update(
+    {"position": rolling_filter(ds_mouse.position, window, method="median")}
+)
 
 # %%
 # The report informs us that the raw data contains NaN values, most of which
@@ -184,7 +188,11 @@ ds_mouse_smooth.update({"position": median_filter(ds_mouse.position, window)})
 # window are sufficient for the median to be calculated. Let's try this.
 
 ds_mouse_smooth.update(
-    {"position": median_filter(ds_mouse.position, window, min_periods=2)}
+    {
+        "position": rolling_filter(
+            ds_mouse.position, window, min_periods=2, method="median"
+        )
+    }
 )
 
 # %%
@@ -207,7 +215,11 @@ plot_raw_and_smooth_timeseries_and_psd(
 
 window = int(2 * ds_mouse.fps)
 ds_mouse_smooth.update(
-    {"position": median_filter(ds_mouse.position, window, min_periods=2)}
+    {
+        "position": rolling_filter(
+            ds_mouse.position, window, min_periods=2, method="median"
+        )
+    }
 )
 
 # %%
@@ -300,7 +312,11 @@ plot_raw_and_smooth_timeseries_and_psd(
 # First, we will apply the median filter.
 window = int(0.1 * ds_mouse.fps)
 ds_mouse_smooth.update(
-    {"position": median_filter(ds_mouse.position, window, min_periods=2)}
+    {
+        "position": rolling_filter(
+            ds_mouse.position, window, min_periods=2, method="median"
+        )
+    }
 )
 
 # Next, let's linearly interpolate over gaps smaller

--- a/movement/filtering.py
+++ b/movement/filtering.py
@@ -152,7 +152,7 @@ def rolling_filter(
     Returns
     -------
     xarray.DataArray
-        The data smoothed using a rolling filter (mean or median) with the provided parameters.
+        The data smoothed using a rolling filter with the provided parameters.
 
     Notes
     -----
@@ -169,20 +169,18 @@ def rolling_filter(
 
     """
     half_window = window // 2
-    data_smoothed = (
-        data.pad(  # Pad the edges to avoid NaNs
-            time=half_window, mode="reflect"
-        )
-        .rolling(  # Take rolling windows across time
-            time=window, center=True, min_periods=min_periods
-        )
+    data_smoothed = data.pad(  # Pad the edges to avoid NaNs
+        time=half_window, mode="reflect"
+    ).rolling(  # Take rolling windows across time
+        time=window, center=True, min_periods=min_periods
     )
-    
-    # Apply the chosen method
+
     if method == "mean":
         data_smoothed = data_smoothed.mean(skipna=True)  # Apply mean filter
     elif method == "median":
-        data_smoothed = data_smoothed.median(skipna=True)  # Apply median filter
+        data_smoothed = data_smoothed.median(
+            skipna=True
+        )  # Apply median filter
     else:
         raise ValueError("Invalid method. Choose 'mean' or 'median'.")
 

--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -6,7 +6,7 @@ import xarray as xr
 from movement.filtering import (
     filter_by_confidence,
     interpolate_over_time,
-    median_filter,
+    rolling_filter,
     savgol_filter,
 )
 
@@ -33,14 +33,15 @@ class TestFilteringValidDataset:
     @pytest.mark.parametrize(
         ("filter_func, filter_kwargs"),
         [
-            (median_filter, {"window": 3}),
+            (rolling_filter, {"window": 3, "method": "median"}),
+            (rolling_filter, {"window": 3, "method": "mean"}),
             (savgol_filter, {"window": 3, "polyorder": 2}),
         ],
     )
     def test_filter_with_nans_on_position(
         self, filter_func, filter_kwargs, valid_dataset, helpers, request
     ):
-        """Test NaN behaviour of the median and SG filters.
+        """Test NaN behaviour of the median, mean and SG filters.
         Both filters should set all values to NaN if one element of the
         sliding window is NaN.
         """
@@ -155,7 +156,7 @@ class TestFilteringValidDatasetWithNaNs:
         "window",
         [3, 5, 6, 10],  # input data has 10 frames
     )
-    @pytest.mark.parametrize("filter_func", [median_filter, savgol_filter])
+    @pytest.mark.parametrize("filter_func", [rolling_filter, savgol_filter])
     def test_filter_with_nans_on_position_varying_window(
         self, valid_dataset_with_nan, window, filter_func, helpers, request
     ):


### PR DESCRIPTION
## Description

**What is this PR**
This PR implements a rolling mean filter and a general filter function rolling_filter that can be used for both mean and median filters. The rolling_filter function has a flexible structure, allowing users to specify the method (mean or median). This PR completely remove the [median_filter](https://github.com/neuroinformatics-unit/movement/blob/main/movement/filtering.py) and replace it with the `rolling_filter` function.

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

**What does this PR do?**
- This PR remove the `median_filter` function and replace it with the `rolling_filter`.
- Applies either a rolling mean or rolling median filter to a given `xarray.DataArray`.


## References

This PR is related to the issue #454 and pull request #429

## How has this PR been tested?

This PR has been tested locally and pass all test cases. This function implemented in this PR has also been tested on PR #429  and generate the similar result as generated in the PR.

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
Yes, this PR require updates to the documentation. Documentation for various examples and API references need to be change. But documentation is not updated yet.

If any features have changed, or have been added. Please explain how the
documentation has been updated.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
