### PR TITLE
Add a rolling mean filter

### DIFF
--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -6,6 +6,7 @@ import xarray as xr
 from movement.filtering import (
     filter_by_confidence,
     interpolate_over_time,
+    mean_filter,
     median_filter,
     savgol_filter,
 )
@@ -28,19 +29,22 @@ list_all_valid_datasets = (
     list_all_valid_datasets,
 )
 class TestFilteringValidDataset:
-    """Test median and savgol filtering on valid datasets with/without NaNs."""
+    """Test median, mean and savgol filtering on valid datasets
+    with/without NaNs.
+    """
 
     @pytest.mark.parametrize(
         ("filter_func, filter_kwargs"),
         [
             (median_filter, {"window": 3}),
+            (mean_filter, {"window": 3}),
             (savgol_filter, {"window": 3, "polyorder": 2}),
         ],
     )
     def test_filter_with_nans_on_position(
         self, filter_func, filter_kwargs, valid_dataset, helpers, request
     ):
-        """Test NaN behaviour of the median and SG filters.
+        """Test NaN behaviour of the median, mean and SG filters.
         Both filters should set all values to NaN if one element of the
         sliding window is NaN.
         """
@@ -155,7 +159,9 @@ class TestFilteringValidDatasetWithNaNs:
         "window",
         [3, 5, 6, 10],  # input data has 10 frames
     )
-    @pytest.mark.parametrize("filter_func", [median_filter, savgol_filter])
+    @pytest.mark.parametrize(
+        "filter_func", [median_filter, mean_filter, savgol_filter]
+    )
     def test_filter_with_nans_on_position_varying_window(
         self, valid_dataset_with_nan, window, filter_func, helpers, request
     ):

--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -45,7 +45,7 @@ class TestFilteringValidDataset:
         self, filter_func, filter_kwargs, valid_dataset, helpers, request
     ):
         """Test NaN behaviour of the median, mean and SG filters.
-        Both filters should set all values to NaN if one element of the
+        All filters should set all values to NaN if one element of the
         sliding window is NaN.
         """
         # Expected number of nans in the position array per individual


### PR DESCRIPTION
## Description
This PR adds a rolling mean filter to movement.
The mean filter is in line with the median filter and does padding of the time
axis using "reflection".

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
This PR adds rolling mean filtering functionality to movement.

**What does this PR do?**
Adds the ability to smooth a data array using the local mean within a window, whose size is passed as an input parameter. 

## References
[https://github.com/neuroinformatics-unit/movement/issues/454](issue #454 )

## How has this PR been tested?

A user test program was written which does the following:

- Loads VIA_multiple-crabs_5-frames_labels.csv from the movement sample_data.
- Run mean_filter on the shape and position DataArrays of the loaded dataset
- Members of the smoothed DataArray were randomly verified against the input DataArray and its neighborhood.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

Yes. example code base can be augmented to use the mean_filter.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
