### PR TITLE
Updated GUI installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ A Python toolbox for analysing animal body movements across space and time.
 
 ## Quick install
 
-Create and activate a conda environment with movement installed:
-```
-conda create -n movement-env -c conda-forge movement
+Create and activate a conda environment with movement installed (including the GUI):
+```bash
+conda create -n movement-env -c conda-forge movement napari pyqt
 conda activate movement-env
 ```
+
 
 > [!Note]
 > Read the [documentation](https://movement.neuroinformatics.dev) for more information, including [full installation instructions](https://movement.neuroinformatics.dev/user_guide/installation.html) and [examples](https://movement.neuroinformatics.dev/examples/index.html).

--- a/docs/source/user_guide/installation.md
+++ b/docs/source/user_guide/installation.md
@@ -15,19 +15,31 @@ We will use `movement-env` as the environment name, but you can choose any name 
 
 ::::{tab-set}
 :::{tab-item} Conda
-Create and activate an environment with movement installed:
+To create an environment with the core package only:
 ```sh
 conda create -n movement-env -c conda-forge movement
+```
+
+If you wish to use the GUI, which additionally requires [napari](napari:),
+you should instead run:
+```sh
+conda create -n movement-env -c conda-forge movement napari pyqt
 conda activate movement-env
 ```
-This will install all dependencies, including [napari](napari:),
-which provides the GUI for movement.
+You may exchange `pyqt` for `pyside2` if you prefer.
+See [napari's installation guide](napari:tutorials/fundamentals/installation.html)
+for more information on the backends.
+
+To activate the environment:
+```sh
+conda activate movement-env
+```
 :::
+
 :::{tab-item} Pip
 Create and activate an environment with some prerequisites:
 ```sh
 conda create -n movement-env -c conda-forge python=3.12 pytables
-conda activate movement-env
 ```
 Install the core package from the latest release on PyPI:
 ```sh

--- a/docs/source/user_guide/installation.md
+++ b/docs/source/user_guide/installation.md
@@ -24,7 +24,6 @@ If you wish to use the GUI, which additionally requires [napari](napari:),
 you should instead run:
 ```sh
 conda create -n movement-env -c conda-forge movement napari pyqt
-conda activate movement-env
 ```
 You may exchange `pyqt` for `pyside2` if you prefer.
 See [napari's installation guide](napari:tutorials/fundamentals/installation.html)
@@ -40,6 +39,7 @@ conda activate movement-env
 Create and activate an environment with some prerequisites:
 ```sh
 conda create -n movement-env -c conda-forge python=3.12 pytables
+conda activate movement-env
 ```
 Install the core package from the latest release on PyPI:
 ```sh

--- a/docs/source/user_guide/installation.md
+++ b/docs/source/user_guide/installation.md
@@ -48,7 +48,8 @@ pip install movement
 If you wish to use the GUI, which additionally requires [napari](napari:),
 you should instead run:
 ```sh
-pip install movement[napari]
+pip install movement[napari]   # works on most shells
+pip install 'movement[napari]' # works on zsh (default shell on macOS)
 ```
 :::
 ::::

--- a/movement/cli_entrypoint.py
+++ b/movement/cli_entrypoint.py
@@ -66,15 +66,24 @@ def main() -> None:
 
 def info() -> None:
     """Output diagnostic information."""
-    print(
+    text = (
         f"{ASCII_ART}\n"
         f"     movement: {movement.__version__}\n"
         f"     Python: {platform.python_version()}\n"
         f"     NumPy: {np.__version__}\n"
         f"     xarray: {xr.__version__}\n"
         f"     pandas: {pd.__version__}\n"
-        f"     Platform: {platform.platform()}\n"
     )
+
+    try:
+        import napari
+
+        text += f"     napari: {napari.__version__}\n"
+    except ImportError:
+        text += "     napari: not installed\n"
+
+    text += f"     Platform: {platform.platform()}\n"
+    print(text)
 
 
 def launch() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Operating System :: OS Independent",
   "License :: OSI Approved :: BSD License",
+  "Framework :: napari",
 ]
 
 # Entry point for napari plugin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ dependencies = [
   "sleap-io",
   "xarray[accel,viz]",
   "PyYAML",
+  "napari-video",
+  "pyvideoreader>=0.5.3",  # since switching to depend on openCV-headless
+  "qt-niu",  # needed for collapsible widgets
 ]
 
 classifiers = [
@@ -49,9 +52,6 @@ entry-points."napari.manifest".movement = "movement.napari:napari.yaml"
 [project.optional-dependencies]
 napari = [
   "napari[all]>=0.5.0",
-  "napari-video",
-  "pyvideoreader>=0.5.3",  # since switching to depend on openCV-headless
-  "qt-niu",  # needed for collapsible widgets
 ]
 dev = [
   "pytest",

--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -33,7 +33,7 @@ class TestFilteringValidDataset:
     @pytest.mark.parametrize(
         ("filter_func, filter_kwargs"),
         [
-            (median_filter, {"window": 3}),
+            (median_filter, {"window": 3, "print_report": True}),
             (savgol_filter, {"window": 3, "polyorder": 2}),
         ],
     )
@@ -70,7 +70,7 @@ class TestFilteringValidDataset:
     @pytest.mark.parametrize(
         "override_kwargs, expected_exception",
         [
-            ({"mode": "nearest"}, does_not_raise()),
+            ({"mode": "nearest", "print_report": True}, does_not_raise()),
             ({"axis": 1}, pytest.raises(ValueError)),
             ({"mode": "nearest", "axis": 1}, pytest.raises(ValueError)),
         ],
@@ -132,7 +132,10 @@ class TestFilteringValidDatasetWithNaNs:
         for time_unit in ["frames", "seconds"]:
             # interpolate
             position_interp = interpolate_over_time(
-                position[time_unit], method="linear", max_gap=max_gap
+                position[time_unit],
+                method="linear",
+                max_gap=max_gap,
+                print_report=True,
             )
             # count nans
             n_nans_after_per_time_unit[time_unit] = helpers.count_nans(
@@ -204,6 +207,7 @@ def test_filter_by_confidence_on_position(
         valid_input_dataset.position,
         confidence=valid_input_dataset.confidence,
         threshold=0.6,
+        print_report=True,
     )
     # Count number of NaNs in the full array
     n_nans = helpers.count_nans(position_filtered)


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Thanks to a user report, we found out that installing the freshly released `movement v0.1` from conda-forge doesn't include the Qt bindings. As a result, when trying to launch napari you will get:

```sh
ImportError: No Qt bindings could be found.
napari requires either PyQt5 (default) or PySide2 to be installed in the environment.
With pip, you can install either with:
  $ pip install -U 'napari[all]'  # default choice
  $ pip install -U 'napari[pyqt5]'
  $ pip install -U 'napari[pyside2]'
With conda, you need to do:
  $ conda install -c conda-forge pyqt
  $ conda install -c conda-forge pyside2
Our heuristics suggest you are using 'conda' to manage your packages.
```

We considered fixing this by adding pyqt or pyside2 as an explicit dependency on our [conda feedstock](https://github.com/conda-forge/movement-feedstock). However, after [some discussion](https://napari.zulipchat.com/#narrow/channel/309872-plugins/topic/Including.20.60pyqt.60.20as.20a.20conda-forge.20run.20dependency/with/504159665) with `napari` developers, we came up with an alternative solution that should play more nicely with the `napari` ecosystem, see below:

**What does this PR do?**
- Moves `napari-video`, `pyvideoreader`, and `qt-niu` out of the "napari" extras into the core dependencies. All of these are required to use the GUI but none of these packages depends on `napari` itself or its graphical backends. The motivation is to support existing users of `napari` that may want to install `movement` in the same environment. If they have a working `napari` installation, they can just do `pip install movement` (or use the `napari` plugin manager, which amounts to doing the same thing). People that don't already use `napari` (the majority of our users) can still do `pip install movement[napari]`, as before. The same arrangement will be mirrored on the conda-forge side, i.e. we will include the aforementioned 3 packages as conda dependencies, but not `napari` or `pyqt` itself.
- Adds a `napari` trove classifier to the PyPI metadata, so that we become discoverable via the `napari` plugin manager (again, to support the above usecase).
- Updates the installation instructions accordingly. Essentially, if people want to conda install `movement` incl. the GUI, the'd have to explicitly do `conda install -c conda-forge movement napari pyqt`.  This is the option mentioned in the "quick install" section of the README. Let me know if it you think "quick install" should exclude the GUI.
- Adds the `napari` version to the output of the `movement info` command. If it's not installed it says "napari: not installed". This should help us diagnose user installation issues related to the GUI.

## How has this PR been tested?

By pip installing `movement` locally on my MacOS, in fresh environments, with or without `[napari]`.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

It contains updates to the installation instructions.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
