### PR TITLE
Added Support for loading time co-ordinates

### DIFF
--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -667,7 +667,10 @@ def _ds_from_valid_data(data: ValidBboxesDataset) -> xr.Dataset:
     # if fps is provided:
     # time_coords is expressed in seconds, with the time origin
     # set as frame 0 == time 0 seconds
-    if data.fps:
+    if data.timestamps:
+        time_coords = data.timestamps
+        time_unit = "seconds"
+    elif data.timestamps is None and data.fps is not None:
         # Compute elapsed time from frame 0.
         # Ignoring type error because `data.frame_array` is not None after
         # ValidBboxesDataset.__attrs_post_init__()  # type: ignore
@@ -695,6 +698,7 @@ def _ds_from_valid_data(data: ValidBboxesDataset) -> xr.Dataset:
         },
         attrs={
             "fps": data.fps,
+            "timestamps": data.timestamps,
             "time_unit": time_unit,
             "source_software": data.source_software,
             "source_file": None,

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -682,7 +682,10 @@ def _ds_from_valid_data(data: ValidPosesDataset) -> xr.Dataset:
     n_frames = data.position_array.shape[0]
     n_space = data.position_array.shape[1]
     # Create the time coordinate, depending on the value of fps
-    if data.fps is not None:
+    if data.timestamps is not None:
+        time_coords = data.timestamps
+        time_unit = "seconds"
+    elif data.timestamps is None and data.fps is not None:
         time_coords = np.arange(n_frames, dtype=float) / data.fps
         time_unit = "seconds"
     else:
@@ -706,6 +709,7 @@ def _ds_from_valid_data(data: ValidPosesDataset) -> xr.Dataset:
         },
         attrs={
             "fps": data.fps,
+            "timestamps": data.timestamps,
             "time_unit": time_unit,
             "source_software": data.source_software,
             "source_file": None,

--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -107,6 +107,9 @@ class ValidPosesDataset:
         etc.
     fps : float, optional
         Frames per second of the video. Defaults to None.
+    timestamps : np.ndarray, optional
+        Array of shape (n_frames) corresponding to the timestamp of each
+        frame in chronological order.
     source_software : str, optional
         Name of the software from which the poses were loaded.
         Defaults to None.
@@ -138,6 +141,7 @@ class ValidPosesDataset:
             converters.optional(float), _convert_fps_to_none_if_invalid
         ),
     )
+    timestamps: np.ndarray | None = field(default=None)
     source_software: str | None = field(
         default=None,
         validator=validators.optional(validators.instance_of(str)),
@@ -274,6 +278,9 @@ class ValidBboxesDataset:
     fps : float, optional
         Frames per second defining the sampling rate of the data.
         Defaults to None.
+    timestamps : np.ndarray, optional
+        Array of shape (n_frames) corresponding to the timestamp of each
+        frame in chronological order.
     source_software : str, optional
         Name of the software that generated the data. Defaults to None.
 
@@ -304,6 +311,7 @@ class ValidBboxesDataset:
             converters.optional(float), _convert_fps_to_none_if_invalid
         ),
     )
+    timestamps: np.ndarray | None = field(default=None)
     source_software: str | None = field(
         default=None,
         validator=validators.optional(validators.instance_of(str)),


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/neuroinformatics-unit/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
This PR fixes issue #473 

**What does this PR do?**
This PR adds support for loading time co-ordinates in the form of a vector.

## References

Please reference any existing issues/PRs that relate to this PR.

Issue #473 

## How has this PR been tested?

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.

I have run all the pre-commit hooks and so far there seems to be no issues. I have not added validators for the new timesteps argument though. Also, I have not added any new tests for this enhancement.

## Is this a breaking change?

If this PR breaks any existing functionality, please explain how and why.

## Does this PR require an update to the documentation?

If any features have changed, or have been added. Please explain how the
documentation has been updated.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
