### PR TITLE
Added a Widget for drawing region of interest in napari. feature addition disscussed in #378  

### DIFF
--- a/movement/napari/meta_widget.py
+++ b/movement/napari/meta_widget.py
@@ -3,8 +3,9 @@
 from napari.viewer import Viewer
 from qt_niu.collapsible_widget import CollapsibleWidgetContainer
 
-from movement.napari.roi_widget import ROIDrawingWidget
 from movement.napari.loader_widgets import DataLoader
+from movement.napari.roi_widget import ROIDrawingWidget
+
 
 class MovementMetaWidget(CollapsibleWidgetContainer):
     """The widget to rule all ``movement`` napari widgets.

--- a/movement/napari/meta_widget.py
+++ b/movement/napari/meta_widget.py
@@ -4,7 +4,7 @@ from napari.viewer import Viewer
 from qt_niu.collapsible_widget import CollapsibleWidgetContainer
 
 from movement.napari.roi_widget import ROIDrawingWidget
-
+from movement.napari.loader_widgets import DataLoader
 
 class MovementMetaWidget(CollapsibleWidgetContainer):
     """The widget to rule all ``movement`` napari widgets.

--- a/movement/napari/meta_widget.py
+++ b/movement/napari/meta_widget.py
@@ -3,9 +3,7 @@
 from napari.viewer import Viewer
 from qt_niu.collapsible_widget import CollapsibleWidgetContainer
 
-from movement.napari.loader_widgets import PosesLoader
 from movement.napari.roi_widget import ROIDrawingWidget
-
 
 
 class MovementMetaWidget(CollapsibleWidgetContainer):
@@ -35,6 +33,6 @@ class MovementMetaWidget(CollapsibleWidgetContainer):
         # Store references to widgets
         self.loader = self.collapsible_widgets[0]
         self.roi_drawer = self.collapsible_widgets[1]
-        
+
         # Expand the loader widget by default
         self.loader.expand()

--- a/movement/napari/meta_widget.py
+++ b/movement/napari/meta_widget.py
@@ -3,7 +3,9 @@
 from napari.viewer import Viewer
 from qt_niu.collapsible_widget import CollapsibleWidgetContainer
 
-from movement.napari.loader_widgets import DataLoader
+from movement.napari.loader_widgets import PosesLoader
+from movement.napari.roi_widget import ROIDrawingWidget
+
 
 
 class MovementMetaWidget(CollapsibleWidgetContainer):
@@ -17,12 +19,22 @@ class MovementMetaWidget(CollapsibleWidgetContainer):
         """Initialize the meta-widget."""
         super().__init__()
 
-        # Add the data loader widget
         self.add_widget(
             DataLoader(napari_viewer, parent=self),
             collapsible=True,
             widget_title="Load tracked data",
         )
 
+        # Add ROI drawing widget
+        self.add_widget(
+            ROIDrawingWidget(napari_viewer, parent=self),
+            collapsible=True,
+            widget_title="Draw ROIs",
+        )
+
+        # Store references to widgets
         self.loader = self.collapsible_widgets[0]
-        self.loader.expand()  # expand the loader widget by default
+        self.roi_drawer = self.collapsible_widgets[1]
+        
+        # Expand the loader widget by default
+        self.loader.expand()

--- a/movement/napari/roi_widget.py
+++ b/movement/napari/roi_widget.py
@@ -16,6 +16,7 @@ from qtpy.QtWidgets import (
 
 logger = logging.getLogger(__name__)
 
+
 class ROIDrawingWidget(QWidget):
     """Widget for drawing and managing regions of interest in napari."""
 
@@ -111,14 +112,14 @@ class ROIDrawingWidget(QWidget):
     @staticmethod
     def _point_in_rectangle(point: np.ndarray, rectangle: np.ndarray) -> bool:
         """Check if a point is inside a rectangle.
-        
+
         Parameters
         ----------
         point : np.ndarray
             The (x, y) coordinates to check
         rectangle : np.ndarray
             Array of rectangle vertices
-            
+
         Returns
         -------
         bool
@@ -146,7 +147,7 @@ class ROIDrawingWidget(QWidget):
 
     def get_rois(self) -> list[np.ndarray]:
         """Get the list of ROIs as numpy arrays.
-        
+
         Returns
         -------
         list[np.ndarray]
@@ -157,7 +158,7 @@ class ROIDrawingWidget(QWidget):
 
     def get_selected_roi(self) -> np.ndarray | None:
         """Get the currently selected ROI.
-        
+
         Returns
         -------
         np.ndarray | None

--- a/movement/napari/roi_widget.py
+++ b/movement/napari/roi_widget.py
@@ -1,16 +1,17 @@
 """Widget for drawing and managing regions of interest (ROIs) in napari."""
 
 import logging
+from typing import List, Optional, cast
 
 import numpy as np
 from napari.layers import Shapes
 from napari.viewer import Viewer
 from qtpy.QtWidgets import (
-    QHBoxLayout,
-    QLabel,
     QPushButton,
     QVBoxLayout,
     QWidget,
+    QLabel,
+    QHBoxLayout,
 )
 
 logger = logging.getLogger(__name__)
@@ -21,19 +22,18 @@ class ROIDrawingWidget(QWidget):
 
     def __init__(self, napari_viewer: Viewer, parent=None):
         """Initialize the ROI drawing widget.
-
+        
         Parameters
         ----------
         napari_viewer : napari.viewer.Viewer
             The napari viewer instance to use.
         parent : QWidget, optional
             Parent widget, by default None.
-
         """
         super().__init__(parent=parent)
         self.viewer = napari_viewer
-        self.roi_layer: Shapes | None = None
-        self._selected_roi: int | None = None
+        self.roi_layer: Optional[Shapes] = None
+        self._selected_roi: Optional[int] = None
         self._setup_ui()
 
     def _setup_ui(self):
@@ -62,59 +62,53 @@ class ROIDrawingWidget(QWidget):
 
     def _create_roi_layer(self):
         """Create a new shapes layer for ROIs if it doesn't exist."""
-        # if self.roi_layer is None:
-        if True:
-            self.roi_layer = self.viewer.add_shapes(
-                name="ROIs",
-                edge_width=2,
-                edge_color="red",
-                face_color="transparent",
+        if self.roi_layer is None:
+            self.roi_layer = cast(
+                Shapes,
+                self.viewer.add_shapes(
+                    name="ROIs",
+                    edge_width=2,
+                    edge_color="red",
+                    face_color="transparent",
+                )
             )
-            self.roi_layer.mode = "add_rectangle"
-
+            self.roi_layer.mode = 'add_rectangle'
+            
             # Connect mouse event handlers
             self.roi_layer.mouse_press_callbacks.append(self._on_mouse_press)
             self.roi_layer.events.data.connect(self._on_data_change)
+            
+            self.status_label.setText("ROI layer created. Left-click to draw, Right-click to select!")
+        else:
+            self.status_label.setText("ROI layer already exists")
 
-            self.status_label.setText(
-                "ROI layer created. Left-click to draw, Right-click to select!"
-            )
-        # else:
-        #     self.status_label.setText("ROI layer already exists")
-        # Uncomment the if and else statement if we don't want the user to
-        # make multiple ROI Layers
-
-    def _on_mouse_press(self, layer, event):
+    def _on_mouse_press(self, layer: Shapes, event):
         """Handle mouse press events for selection and drawing."""
-        if event.button == 2:  # Right mouse button
+        if event.button == 2 and self.roi_layer is not None:  # Right mouse button
             # Convert mouse position to data coordinates
             pos = np.array(event.position)
-
+            
             # Find which ROI contains the click position
             self._selected_roi = None
             for idx, roi in enumerate(layer.data):
                 if self._point_in_rectangle(pos, roi):
                     self._selected_roi = idx
                     break
-
+            
             if self._selected_roi is not None:
                 layer.selected_data = {self._selected_roi}
-                self.status_label.setText(
-                    f"Selected ROI {self._selected_roi + 1}"
-                )
+                self.status_label.setText(f"Selected ROI {self._selected_roi + 1}")
             else:
                 layer.selected_data = set()
                 self.status_label.setText("No ROI selected")
-
+            
             event.handled = True
 
-    def _point_in_rectangle(
-        self, point: np.ndarray, rectangle: np.ndarray
-    ) -> bool:
+    def _point_in_rectangle(self, point: np.ndarray, rectangle: np.ndarray) -> bool:
         """Check if a point is inside a rectangle."""
         min_coords = np.min(rectangle, axis=0)
         max_coords = np.max(rectangle, axis=0)
-        return np.all(point >= min_coords) and np.all(point <= max_coords)
+        return bool(np.all(point >= min_coords) and np.all(point <= max_coords))
 
     def _clear_rois(self):
         """Clear all ROIs from the layer."""
@@ -125,15 +119,16 @@ class ROIDrawingWidget(QWidget):
 
     def _on_data_change(self, event):
         """Update ROI count display."""
-        n_rois = len(self.roi_layer.data)
-        self.status_label.setText(f"Total ROIs: {n_rois}")
+        if self.roi_layer is not None:
+            n_rois = len(self.roi_layer.data)
+            self.status_label.setText(f"Total ROIs: {n_rois}")
 
-    def get_rois(self) -> list[np.ndarray]:
+    def get_rois(self) -> List[np.ndarray]:
         """Get the list of ROIs as numpy arrays."""
         return list(self.roi_layer.data) if self.roi_layer else []
 
-    def get_selected_roi(self) -> np.ndarray | None:
+    def get_selected_roi(self) -> Optional[np.ndarray]:
         """Get the currently selected ROI."""
-        if self.roi_layer and self._selected_roi is not None:
+        if self.roi_layer is not None and self._selected_roi is not None:
             return self.roi_layer.data[self._selected_roi]
         return None

--- a/movement/napari/roi_widget.py
+++ b/movement/napari/roi_widget.py
@@ -1,17 +1,16 @@
 """Widget for drawing and managing regions of interest (ROIs) in napari."""
 
 import logging
-from typing import List, Optional
 
 import numpy as np
 from napari.layers import Shapes
 from napari.viewer import Viewer
 from qtpy.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
     QPushButton,
     QVBoxLayout,
     QWidget,
-    QLabel,
-    QHBoxLayout,
 )
 
 logger = logging.getLogger(__name__)
@@ -22,18 +21,19 @@ class ROIDrawingWidget(QWidget):
 
     def __init__(self, napari_viewer: Viewer, parent=None):
         """Initialize the ROI drawing widget.
-        
+
         Parameters
         ----------
         napari_viewer : napari.viewer.Viewer
             The napari viewer instance to use.
         parent : QWidget, optional
             Parent widget, by default None.
+
         """
         super().__init__(parent=parent)
         self.viewer = napari_viewer
-        self.roi_layer: Optional[Shapes] = None
-        self._selected_roi: Optional[int] = None
+        self.roi_layer: Shapes | None = None
+        self._selected_roi: int | None = None
         self._setup_ui()
 
     def _setup_ui(self):
@@ -70,13 +70,15 @@ class ROIDrawingWidget(QWidget):
                 edge_color="red",
                 face_color="transparent",
             )
-            self.roi_layer.mode = 'add_rectangle'
-            
+            self.roi_layer.mode = "add_rectangle"
+
             # Connect mouse event handlers
             self.roi_layer.mouse_press_callbacks.append(self._on_mouse_press)
             self.roi_layer.events.data.connect(self._on_data_change)
-            
-            self.status_label.setText("ROI layer created. Left-click to draw, Right-click to select!")
+
+            self.status_label.setText(
+                "ROI layer created. Left-click to draw, Right-click to select!"
+            )
         # else:
         #     self.status_label.setText("ROI layer already exists")
         # Uncomment the if and else statement if we don't want the user to
@@ -87,24 +89,28 @@ class ROIDrawingWidget(QWidget):
         if event.button == 2:  # Right mouse button
             # Convert mouse position to data coordinates
             pos = np.array(event.position)
-            
+
             # Find which ROI contains the click position
             self._selected_roi = None
             for idx, roi in enumerate(layer.data):
                 if self._point_in_rectangle(pos, roi):
                     self._selected_roi = idx
                     break
-            
+
             if self._selected_roi is not None:
                 layer.selected_data = {self._selected_roi}
-                self.status_label.setText(f"Selected ROI {self._selected_roi + 1}")
+                self.status_label.setText(
+                    f"Selected ROI {self._selected_roi + 1}"
+                )
             else:
                 layer.selected_data = set()
                 self.status_label.setText("No ROI selected")
-            
+
             event.handled = True
 
-    def _point_in_rectangle(self, point: np.ndarray, rectangle: np.ndarray) -> bool:
+    def _point_in_rectangle(
+        self, point: np.ndarray, rectangle: np.ndarray
+    ) -> bool:
         """Check if a point is inside a rectangle."""
         min_coords = np.min(rectangle, axis=0)
         max_coords = np.max(rectangle, axis=0)
@@ -122,11 +128,11 @@ class ROIDrawingWidget(QWidget):
         n_rois = len(self.roi_layer.data)
         self.status_label.setText(f"Total ROIs: {n_rois}")
 
-    def get_rois(self) -> List[np.ndarray]:
+    def get_rois(self) -> list[np.ndarray]:
         """Get the list of ROIs as numpy arrays."""
         return list(self.roi_layer.data) if self.roi_layer else []
 
-    def get_selected_roi(self) -> Optional[np.ndarray]:
+    def get_selected_roi(self) -> np.ndarray | None:
         """Get the currently selected ROI."""
         if self.roi_layer and self._selected_roi is not None:
             return self.roi_layer.data[self._selected_roi]

--- a/movement/napari/roi_widget.py
+++ b/movement/napari/roi_widget.py
@@ -1,17 +1,17 @@
 """Widget for drawing and managing regions of interest (ROIs) in napari."""
 
 import logging
-from typing import List, Optional, cast
+from typing import cast
 
 import numpy as np
 from napari.layers import Shapes
 from napari.viewer import Viewer
 from qtpy.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
     QPushButton,
     QVBoxLayout,
     QWidget,
-    QLabel,
-    QHBoxLayout,
 )
 
 logger = logging.getLogger(__name__)
@@ -22,18 +22,19 @@ class ROIDrawingWidget(QWidget):
 
     def __init__(self, napari_viewer: Viewer, parent=None):
         """Initialize the ROI drawing widget.
-        
+
         Parameters
         ----------
         napari_viewer : napari.viewer.Viewer
             The napari viewer instance to use.
         parent : QWidget, optional
             Parent widget, by default None.
+
         """
         super().__init__(parent=parent)
         self.viewer = napari_viewer
-        self.roi_layer: Optional[Shapes] = None
-        self._selected_roi: Optional[int] = None
+        self.roi_layer: Shapes | None = None
+        self._selected_roi: int | None = None
         self._setup_ui()
 
     def _setup_ui(self):
@@ -70,45 +71,55 @@ class ROIDrawingWidget(QWidget):
                     edge_width=2,
                     edge_color="red",
                     face_color="transparent",
-                )
+                ),
             )
-            self.roi_layer.mode = 'add_rectangle'
-            
+            self.roi_layer.mode = "add_rectangle"
+
             # Connect mouse event handlers
             self.roi_layer.mouse_press_callbacks.append(self._on_mouse_press)
             self.roi_layer.events.data.connect(self._on_data_change)
-            
-            self.status_label.setText("ROI layer created. Left-click to draw, Right-click to select!")
+
+            self.status_label.setText(
+                "ROI layer created. Left-click to draw, Right-click to select!"
+            )
         else:
             self.status_label.setText("ROI layer already exists")
 
     def _on_mouse_press(self, layer: Shapes, event):
         """Handle mouse press events for selection and drawing."""
-        if event.button == 2 and self.roi_layer is not None:  # Right mouse button
+        if (
+            event.button == 2 and self.roi_layer is not None
+        ):  # Right mouse button
             # Convert mouse position to data coordinates
             pos = np.array(event.position)
-            
+
             # Find which ROI contains the click position
             self._selected_roi = None
             for idx, roi in enumerate(layer.data):
                 if self._point_in_rectangle(pos, roi):
                     self._selected_roi = idx
                     break
-            
+
             if self._selected_roi is not None:
                 layer.selected_data = {self._selected_roi}
-                self.status_label.setText(f"Selected ROI {self._selected_roi + 1}")
+                self.status_label.setText(
+                    f"Selected ROI {self._selected_roi + 1}"
+                )
             else:
                 layer.selected_data = set()
                 self.status_label.setText("No ROI selected")
-            
+
             event.handled = True
 
-    def _point_in_rectangle(self, point: np.ndarray, rectangle: np.ndarray) -> bool:
+    def _point_in_rectangle(
+        self, point: np.ndarray, rectangle: np.ndarray
+    ) -> bool:
         """Check if a point is inside a rectangle."""
         min_coords = np.min(rectangle, axis=0)
         max_coords = np.max(rectangle, axis=0)
-        return bool(np.all(point >= min_coords) and np.all(point <= max_coords))
+        return bool(
+            np.all(point >= min_coords) and np.all(point <= max_coords)
+        )
 
     def _clear_rois(self):
         """Clear all ROIs from the layer."""
@@ -123,11 +134,11 @@ class ROIDrawingWidget(QWidget):
             n_rois = len(self.roi_layer.data)
             self.status_label.setText(f"Total ROIs: {n_rois}")
 
-    def get_rois(self) -> List[np.ndarray]:
+    def get_rois(self) -> list[np.ndarray]:
         """Get the list of ROIs as numpy arrays."""
         return list(self.roi_layer.data) if self.roi_layer else []
 
-    def get_selected_roi(self) -> Optional[np.ndarray]:
+    def get_selected_roi(self) -> np.ndarray | None:
         """Get the currently selected ROI."""
         if self.roi_layer is not None and self._selected_roi is not None:
             return self.roi_layer.data[self._selected_roi]

--- a/movement/napari/roi_widget.py
+++ b/movement/napari/roi_widget.py
@@ -16,7 +16,6 @@ from qtpy.QtWidgets import (
 
 logger = logging.getLogger(__name__)
 
-
 class ROIDrawingWidget(QWidget):
     """Widget for drawing and managing regions of interest in napari."""
 
@@ -75,8 +74,8 @@ class ROIDrawingWidget(QWidget):
             )
             self.roi_layer.mode = "add_rectangle"
 
-            # Connect mouse event handlers
-            self.roi_layer.mouse_press_callbacks.append(self._on_mouse_press)
+            # Connect modern event handlers
+            self.roi_layer.mouse_drag_callbacks.append(self._on_mouse_press)
             self.roi_layer.events.data.connect(self._on_data_change)
 
             self.status_label.setText(
@@ -87,9 +86,7 @@ class ROIDrawingWidget(QWidget):
 
     def _on_mouse_press(self, layer: Shapes, event):
         """Handle mouse press events for selection and drawing."""
-        if (
-            event.button == 2 and self.roi_layer is not None
-        ):  # Right mouse button
+        if event.button == 2 and self.roi_layer is not None:  # Right click
             # Convert mouse position to data coordinates
             pos = np.array(event.position)
 
@@ -111,10 +108,23 @@ class ROIDrawingWidget(QWidget):
 
             event.handled = True
 
-    def _point_in_rectangle(
-        self, point: np.ndarray, rectangle: np.ndarray
-    ) -> bool:
-        """Check if a point is inside a rectangle."""
+    @staticmethod
+    def _point_in_rectangle(point: np.ndarray, rectangle: np.ndarray) -> bool:
+        """Check if a point is inside a rectangle.
+        
+        Parameters
+        ----------
+        point : np.ndarray
+            The (x, y) coordinates to check
+        rectangle : np.ndarray
+            Array of rectangle vertices
+            
+        Returns
+        -------
+        bool
+            True if point is inside the rectangle, False otherwise
+
+        """
         min_coords = np.min(rectangle, axis=0)
         max_coords = np.max(rectangle, axis=0)
         return bool(
@@ -135,11 +145,25 @@ class ROIDrawingWidget(QWidget):
             self.status_label.setText(f"Total ROIs: {n_rois}")
 
     def get_rois(self) -> list[np.ndarray]:
-        """Get the list of ROIs as numpy arrays."""
+        """Get the list of ROIs as numpy arrays.
+        
+        Returns
+        -------
+        list[np.ndarray]
+            List of ROI coordinates
+
+        """
         return list(self.roi_layer.data) if self.roi_layer else []
 
     def get_selected_roi(self) -> np.ndarray | None:
-        """Get the currently selected ROI."""
+        """Get the currently selected ROI.
+        
+        Returns
+        -------
+        np.ndarray | None
+            Coordinates of the selected ROI or None if none selected
+
+        """
         if self.roi_layer is not None and self._selected_roi is not None:
             return self.roi_layer.data[self._selected_roi]
         return None

--- a/movement/napari/roi_widget.py
+++ b/movement/napari/roi_widget.py
@@ -1,0 +1,133 @@
+"""Widget for drawing and managing regions of interest (ROIs) in napari."""
+
+import logging
+from typing import List, Optional
+
+import numpy as np
+from napari.layers import Shapes
+from napari.viewer import Viewer
+from qtpy.QtWidgets import (
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+    QLabel,
+    QHBoxLayout,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ROIDrawingWidget(QWidget):
+    """Widget for drawing and managing regions of interest in napari."""
+
+    def __init__(self, napari_viewer: Viewer, parent=None):
+        """Initialize the ROI drawing widget.
+        
+        Parameters
+        ----------
+        napari_viewer : napari.viewer.Viewer
+            The napari viewer instance to use.
+        parent : QWidget, optional
+            Parent widget, by default None.
+        """
+        super().__init__(parent=parent)
+        self.viewer = napari_viewer
+        self.roi_layer: Optional[Shapes] = None
+        self._selected_roi: Optional[int] = None
+        self._setup_ui()
+
+    def _setup_ui(self):
+        """Create and arrange the widget UI elements."""
+        layout = QVBoxLayout()
+        self.setLayout(layout)
+
+        # Buttons layout
+        button_layout = QHBoxLayout()
+
+        # Create ROI layer button
+        self.create_layer_btn = QPushButton("Create ROI Layer")
+        self.create_layer_btn.clicked.connect(self._create_roi_layer)
+        button_layout.addWidget(self.create_layer_btn)
+
+        # Clear ROIs button
+        self.clear_btn = QPushButton("Clear ROIs")
+        self.clear_btn.clicked.connect(self._clear_rois)
+        button_layout.addWidget(self.clear_btn)
+
+        layout.addLayout(button_layout)
+
+        # Status label
+        self.status_label = QLabel("")
+        layout.addWidget(self.status_label)
+
+    def _create_roi_layer(self):
+        """Create a new shapes layer for ROIs if it doesn't exist."""
+        # if self.roi_layer is None:
+        if True:
+            self.roi_layer = self.viewer.add_shapes(
+                name="ROIs",
+                edge_width=2,
+                edge_color="red",
+                face_color="transparent",
+            )
+            self.roi_layer.mode = 'add_rectangle'
+            
+            # Connect mouse event handlers
+            self.roi_layer.mouse_press_callbacks.append(self._on_mouse_press)
+            self.roi_layer.events.data.connect(self._on_data_change)
+            
+            self.status_label.setText("ROI layer created. Left-click to draw, Right-click to select!")
+        # else:
+        #     self.status_label.setText("ROI layer already exists")
+        # Uncomment the if and else statement if we don't want the user to
+        # make multiple ROI Layers
+
+    def _on_mouse_press(self, layer, event):
+        """Handle mouse press events for selection and drawing."""
+        if event.button == 2:  # Right mouse button
+            # Convert mouse position to data coordinates
+            pos = np.array(event.position)
+            
+            # Find which ROI contains the click position
+            self._selected_roi = None
+            for idx, roi in enumerate(layer.data):
+                if self._point_in_rectangle(pos, roi):
+                    self._selected_roi = idx
+                    break
+            
+            if self._selected_roi is not None:
+                layer.selected_data = {self._selected_roi}
+                self.status_label.setText(f"Selected ROI {self._selected_roi + 1}")
+            else:
+                layer.selected_data = set()
+                self.status_label.setText("No ROI selected")
+            
+            event.handled = True
+
+    def _point_in_rectangle(self, point: np.ndarray, rectangle: np.ndarray) -> bool:
+        """Check if a point is inside a rectangle."""
+        min_coords = np.min(rectangle, axis=0)
+        max_coords = np.max(rectangle, axis=0)
+        return np.all(point >= min_coords) and np.all(point <= max_coords)
+
+    def _clear_rois(self):
+        """Clear all ROIs from the layer."""
+        if self.roi_layer is not None:
+            self.roi_layer.data = []
+            self._selected_roi = None
+            self.status_label.setText("All ROIs cleared")
+
+    def _on_data_change(self, event):
+        """Update ROI count display."""
+        n_rois = len(self.roi_layer.data)
+        self.status_label.setText(f"Total ROIs: {n_rois}")
+
+    def get_rois(self) -> List[np.ndarray]:
+        """Get the list of ROIs as numpy arrays."""
+        return list(self.roi_layer.data) if self.roi_layer else []
+
+    def get_selected_roi(self) -> Optional[np.ndarray]:
+        """Get the currently selected ROI."""
+        if self.roi_layer and self._selected_roi is not None:
+            return self.roi_layer.data[self._selected_roi]
+        return None

--- a/tests/test_unit/test_napari_plugin/test_meta_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_meta_widget.py
@@ -7,9 +7,15 @@ def test_meta_widget_instantiation(make_napari_viewer_proxy):
     """Test that the meta widget can be properly instantiated."""
     viewer = make_napari_viewer_proxy()
     meta_widget = MovementMetaWidget(viewer)
-
-    assert len(meta_widget.collapsible_widgets) == 1
+    print(len(meta_widget.collapsible_widgets))
+    assert len(meta_widget.collapsible_widgets) == 2
 
     first_widget = meta_widget.collapsible_widgets[0]
+    
+    second_widget = meta_widget.collapsible_widgets[1]
+
     assert first_widget._text == "Load tracked data"
     assert first_widget.isExpanded()
+    # Check that the ROI widget is present and properly labeled
+    assert second_widget._text == "Draw ROIs"
+    

--- a/tests/test_unit/test_napari_plugin/test_meta_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_meta_widget.py
@@ -11,11 +11,10 @@ def test_meta_widget_instantiation(make_napari_viewer_proxy):
     assert len(meta_widget.collapsible_widgets) == 2
 
     first_widget = meta_widget.collapsible_widgets[0]
-    
+
     second_widget = meta_widget.collapsible_widgets[1]
 
     assert first_widget._text == "Load tracked data"
     assert first_widget.isExpanded()
     # Check that the ROI widget is present and properly labeled
     assert second_widget._text == "Draw ROIs"
-    

--- a/tests/test_unit/test_napari_plugin/test_roi_layer.py
+++ b/tests/test_unit/test_napari_plugin/test_roi_layer.py
@@ -1,0 +1,137 @@
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+from napari.layers import Shapes
+
+from movement.napari.roi_widget import ROIDrawingWidget
+
+
+@pytest.fixture
+def viewer_with_widget(make_napari_viewer):
+    viewer = make_napari_viewer()
+    widget = ROIDrawingWidget(viewer)
+    return viewer, widget
+
+def test_create_roi_layer(viewer_with_widget):
+    viewer, widget = viewer_with_widget
+    assert widget.roi_layer is None
+    
+    # First creation
+    widget._create_roi_layer()
+    assert isinstance(widget.roi_layer, Shapes)
+    assert widget.roi_layer.mode == "add_rectangle"
+    assert "ROIs" in viewer.layers
+    
+    # Test duplicate creation
+    widget._create_roi_layer()
+    assert widget.status_label.text() == "ROI layer already exists"
+
+def test_roi_selection(viewer_with_widget):
+    viewer, widget = viewer_with_widget
+    widget._create_roi_layer()
+    
+    # Add proper rectangle (4 points)
+    test_rect = np.array([
+        [10, 10],
+        [10, 20],
+        [30, 20],
+        [30, 10]
+    ])
+    widget.roi_layer.add(test_rect)
+    
+    # Simulate right-click inside ROI
+    mock_event = MagicMock()
+    mock_event.button = 2  # Right click
+    mock_event.position = [15, 15]  # Inside rectangle
+    mock_event.dims_displayed = [0, 1]  # Required for coordinate conversion
+    
+    widget._on_mouse_press(widget.roi_layer, mock_event)
+    assert widget._selected_roi == 0
+    assert widget.status_label.text() == "Selected ROI 1"
+    
+    # Test click outside ROI
+    mock_event.position = [50, 50]
+    widget._on_mouse_press(widget.roi_layer, mock_event)
+    assert widget._selected_roi is None
+
+@pytest.mark.parametrize("point,rectangle,expected", [
+    ((15, 15), [[10, 10], [30, 30]], True),
+    ((10, 10), [[10, 10], [30, 30]], True),
+    ((5, 5), [[10, 10], [30, 30]], False),
+    ((35, 15), [[10, 10], [30, 30]], False)
+])
+def test_point_in_rectangle(point, rectangle, expected):
+    rect = np.array(rectangle)
+    result = ROIDrawingWidget._point_in_rectangle(np.array(point), rect)
+    assert result == expected
+
+def test_clear_rois(viewer_with_widget):
+    viewer, widget = viewer_with_widget
+    widget._create_roi_layer()
+    
+    # Add proper rectangle data
+    widget.roi_layer.add(np.array([
+        [0, 0],
+        [0, 10],
+        [10, 10],
+        [10, 0]
+    ]))
+    widget._clear_rois()
+    
+    assert len(widget.roi_layer.data) == 0
+    assert widget.status_label.text() == "All ROIs cleared"
+
+def test_roi_count_updates(viewer_with_widget):
+    viewer, widget = viewer_with_widget
+    widget._create_roi_layer()
+    
+    # Add first ROI
+    widget.roi_layer.add(np.array([
+        [0, 0],
+        [0, 5],
+        [5, 5],
+        [5, 0]
+    ]))
+    assert widget.status_label.text() == "Total ROIs: 1"
+    
+    # Add second ROI
+    widget.roi_layer.add(np.array([
+        [10, 10],
+        [10, 15],
+        [15, 15],
+        [15, 10]
+    ]))
+    assert widget.status_label.text() == "Total ROIs: 2"
+
+def test_get_rois(viewer_with_widget):
+    viewer, widget = viewer_with_widget
+    widget._create_roi_layer()
+    
+    # Create proper rectangle data
+    test_data = [
+        np.array([
+            [0, 0],
+            [0, 5],
+            [5, 5],
+            [5, 0]
+        ]),
+        np.array([
+            [10, 10],
+            [10, 15],
+            [15, 15],
+            [15, 10]
+        ])
+    ]
+    widget.roi_layer.data = test_data
+    
+    # Verify ROI count
+    assert len(widget.get_rois()) == 2
+    assert widget.get_selected_roi() is None
+    
+    # Test selection comparison
+    widget._selected_roi = 0
+    selected = widget.get_selected_roi()
+    assert selected is not None
+    assert np.array_equal(selected, test_data[0]), \
+        f"Expected:\n{test_data[0]}\nGot:\n{selected}"

--- a/tests/test_unit/test_napari_plugin/test_roi_layer.py
+++ b/tests/test_unit/test_napari_plugin/test_roi_layer.py
@@ -13,125 +13,105 @@ def viewer_with_widget(make_napari_viewer):
     widget = ROIDrawingWidget(viewer)
     return viewer, widget
 
+
 def test_create_roi_layer(viewer_with_widget):
     viewer, widget = viewer_with_widget
     assert widget.roi_layer is None
-    
+
     # First creation
     widget._create_roi_layer()
     assert isinstance(widget.roi_layer, Shapes)
     assert widget.roi_layer.mode == "add_rectangle"
     assert "ROIs" in viewer.layers
-    
+
     # Test duplicate creation
     widget._create_roi_layer()
     assert widget.status_label.text() == "ROI layer already exists"
 
+
 def test_roi_selection(viewer_with_widget):
     viewer, widget = viewer_with_widget
     widget._create_roi_layer()
-    
+
     # Add proper rectangle (4 points)
-    test_rect = np.array([
-        [10, 10],
-        [10, 20],
-        [30, 20],
-        [30, 10]
-    ])
+    test_rect = np.array([[10, 10], [10, 20], [30, 20], [30, 10]])
     widget.roi_layer.add(test_rect)
-    
+
     # Simulate right-click inside ROI
     mock_event = MagicMock()
     mock_event.button = 2  # Right click
     mock_event.position = [15, 15]  # Inside rectangle
     mock_event.dims_displayed = [0, 1]  # Required for coordinate conversion
-    
+
     widget._on_mouse_press(widget.roi_layer, mock_event)
     assert widget._selected_roi == 0
     assert widget.status_label.text() == "Selected ROI 1"
-    
+
     # Test click outside ROI
     mock_event.position = [50, 50]
     widget._on_mouse_press(widget.roi_layer, mock_event)
     assert widget._selected_roi is None
 
-@pytest.mark.parametrize("point,rectangle,expected", [
-    ((15, 15), [[10, 10], [30, 30]], True),
-    ((10, 10), [[10, 10], [30, 30]], True),
-    ((5, 5), [[10, 10], [30, 30]], False),
-    ((35, 15), [[10, 10], [30, 30]], False)
-])
+
+@pytest.mark.parametrize(
+    "point,rectangle,expected",
+    [
+        ((15, 15), [[10, 10], [30, 30]], True),
+        ((10, 10), [[10, 10], [30, 30]], True),
+        ((5, 5), [[10, 10], [30, 30]], False),
+        ((35, 15), [[10, 10], [30, 30]], False),
+    ],
+)
 def test_point_in_rectangle(point, rectangle, expected):
     rect = np.array(rectangle)
     result = ROIDrawingWidget._point_in_rectangle(np.array(point), rect)
     assert result == expected
 
+
 def test_clear_rois(viewer_with_widget):
     viewer, widget = viewer_with_widget
     widget._create_roi_layer()
-    
+
     # Add proper rectangle data
-    widget.roi_layer.add(np.array([
-        [0, 0],
-        [0, 10],
-        [10, 10],
-        [10, 0]
-    ]))
+    widget.roi_layer.add(np.array([[0, 0], [0, 10], [10, 10], [10, 0]]))
     widget._clear_rois()
-    
+
     assert len(widget.roi_layer.data) == 0
     assert widget.status_label.text() == "All ROIs cleared"
+
 
 def test_roi_count_updates(viewer_with_widget):
     viewer, widget = viewer_with_widget
     widget._create_roi_layer()
-    
+
     # Add first ROI
-    widget.roi_layer.add(np.array([
-        [0, 0],
-        [0, 5],
-        [5, 5],
-        [5, 0]
-    ]))
+    widget.roi_layer.add(np.array([[0, 0], [0, 5], [5, 5], [5, 0]]))
     assert widget.status_label.text() == "Total ROIs: 1"
-    
+
     # Add second ROI
-    widget.roi_layer.add(np.array([
-        [10, 10],
-        [10, 15],
-        [15, 15],
-        [15, 10]
-    ]))
+    widget.roi_layer.add(np.array([[10, 10], [10, 15], [15, 15], [15, 10]]))
     assert widget.status_label.text() == "Total ROIs: 2"
+
 
 def test_get_rois(viewer_with_widget):
     viewer, widget = viewer_with_widget
     widget._create_roi_layer()
-    
+
     # Create proper rectangle data
     test_data = [
-        np.array([
-            [0, 0],
-            [0, 5],
-            [5, 5],
-            [5, 0]
-        ]),
-        np.array([
-            [10, 10],
-            [10, 15],
-            [15, 15],
-            [15, 10]
-        ])
+        np.array([[0, 0], [0, 5], [5, 5], [5, 0]]),
+        np.array([[10, 10], [10, 15], [15, 15], [15, 10]]),
     ]
     widget.roi_layer.data = test_data
-    
+
     # Verify ROI count
     assert len(widget.get_rois()) == 2
     assert widget.get_selected_roi() is None
-    
+
     # Test selection comparison
     widget._selected_roi = 0
     selected = widget.get_selected_roi()
     assert selected is not None
-    assert np.array_equal(selected, test_data[0]), \
+    assert np.array_equal(selected, test_data[0]), (
         f"Expected:\n{test_data[0]}\nGot:\n{selected}"
+    )


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/neuroinformatics-unit/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

Added a Few ScreenShots to give everyone idea of what i have implemented. 
**Why is this PR needed?**
This is regarding the feature request in issue #378 , Adding a widget in order to draw region of interest. 
The widget adds a layer where user can draw using the mouse using various shapes. 
**What does this PR do?**
This PR introduces a dedicated widget for creating and managing Regions of Interest (ROIs) within napari, designed for movement analysis workflows.
![Screenshot 2025-03-12 201435](https://github.com/user-attachments/assets/e8d80950-cec8-405c-b796-80746872ba77)
![Screenshot 2025-03-12 210455](https://github.com/user-attachments/assets/424e8fa3-fa38-44e4-969c-b83f24f39b59)

## References

Please reference any existing issues/PRs that relate to this PR.

## How has this PR been tested?
Used the feature on local system trying to break it with all the edges cases.  
Wrote test case as well to check the working of the widget. 

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.

## Is this a breaking change?

If this PR breaks any existing functionality, please explain how and why.
No its a feature addition only 
## Does this PR require an update to the documentation?
It might require as there is entirely new menu on the home screen. 
If any features have changed, or have been added. Please explain how the
documentation has been updated.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
![Screenshot 2025-03-13 152741](https://github.com/user-attachments/assets/217e1cea-9ca1-49a8-9ecf-632c4dd8825f)
