### PR TITLE
Correct confidence_array shape in from_numpy example docstring

### DIFF
--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -76,7 +76,7 @@ def from_numpy(
     >>> from movement.io import load_poses
     >>> ds = load_poses.from_numpy(
     ...     position_array=np.random.rand(100, 2, 3, 2),
-    ...     confidence_array=np.ones((100, 2, 3)),
+    ...     confidence_array=np.ones((100, 3, 2)),
     ...     individual_names=["Alice", "Bob"],
     ...     keypoint_names=["snout", "centre", "tail_base"],
     ...     fps=30,


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**

The example in the from_numpy docstring contained an incorrect confidence_array shape, which could cause errors when used.

**What does this PR do?**

This PR fixes an incorrect array shape in the example usage of from_numpy within the docstring. The confidence_array was mistakenly defined with the shape (n_frames, n_individuals, n_keypoints), but the function expects (n_frames, n_keypoints, n_individuals).

## References

None

## How has this PR been tested?

Manually verified that the corrected example runs without errors.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
