### PR TITLE
Ensure dataset attributes are not set to None

### DIFF
--- a/docs/source/user_guide/input_output.md
+++ b/docs/source/user_guide/input_output.md
@@ -111,7 +111,7 @@ import numpy as np
 
 ds = load_poses.from_numpy(
     position_array=np.random.rand(100, 2, 3, 2),
-    confidence_array=np.ones((100, 2, 3)),
+    confidence_array=np.ones((100, 3, 2)),
     individual_names=["Alice", "Bob"],
     keypoint_names=["snout", "centre", "tail_base"],
     fps=30,
@@ -313,7 +313,7 @@ ds = sample_data.fetch_dataset(filename, with_video=True)
 
 If available, the video file is downloaded and its path is stored
 in the `video_path` attribute of the dataset (i.e., `ds.video_path`).
-The value of this attribute is `None` if no video file is
+This attribute will not be set if no video is
 available for this dataset, or if you did not request it.
 
 Some datasets also include a sample frame file, which is a single
@@ -322,7 +322,7 @@ still frame extracted from the video. This can be useful for visualisation
 this file is always downloaded when fetching the dataset,
 and its path is stored in the `frame_path` attribute
 (i.e., `ds.frame_path`). If no frame file is available for the dataset,
- `ds.frame_path=None`.
+the `frame_path` attribute will not be set.
 
 :::{dropdown} Under the hood
 :color: info

--- a/docs/source/user_guide/movement_dataset.md
+++ b/docs/source/user_guide/movement_dataset.md
@@ -59,7 +59,6 @@ Attributes:
     source_file:      /home/user/.movement/data/poses/SLEAP_three-mice_Aeon...
     ds_type:          poses
     frame_path:       /home/user/.movement/data/frames/three-mice_Aeon_fram...
-    video_path:       None
 ```
 
 :::
@@ -88,13 +87,10 @@ Data variables:
     shape        (time, space, individuals) float64 7kB 60.0 30.0 ... 72.0 36.0
     confidence   (time, individuals) float64 3kB nan nan nan nan ... nan nan nan
 Attributes:
-    fps:              None
     time_unit:        frames
     source_software:  VIA-tracks
     source_file:      /home/user/.movement/data/bboxes/VIA_multiple-crabs_5...
     ds_type:          bboxes
-    frame_path:       None
-    video_path:       None
 ```
 :::
 
@@ -177,10 +173,10 @@ share some common **dimensions**.
 Both poses and bounding boxes datasets in `movement` have associated metadata. These can be stored as dataset **attributes** (i.e. inside the specially designated `attrs` dictionary) in the form of key-value pairs.
 
 Right after loading a `movement` dataset, the following **attributes** are created:
-- `fps`: the number of frames per second in the video. If not provided, it is set to `None`.
+- `fps`: the number of frames per second in the video (absent if not provided by the user during loading).
 - `time_unit`: the unit of the `time` **coordinates** (either `frames` or `seconds`).
 - `source_software`: the software that produced the pose or bounding box tracks.
-- `source_file`: the path to the file from which the data were loaded.
+- `source_file`: the path to the file from which the data were loaded (absent if the dataset was not loaded from a file).
 - `ds_type`: the type of dataset loaded (either `poses` or `bboxes`).
 
 Some of the [sample datasets](target-sample-data) provided with

--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -672,6 +672,7 @@ def _ds_from_valid_data(data: ValidBboxesDataset) -> xr.Dataset:
     # if fps is provided:
     # time_coords is expressed in seconds, with the time origin
     # set as frame 0 == time 0 seconds
+    # Store fps as a dataset attribute
     if data.fps:
         # Compute elapsed time from frame 0.
         # Ignoring type error because `data.frame_array` is not None after

--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -664,6 +664,11 @@ def _ds_from_valid_data(data: ValidBboxesDataset) -> xr.Dataset:
     # Create the time coordinate
     time_coords = data.frame_array.squeeze()  # type: ignore
     time_unit = "frames"
+
+    dataset_attrs: dict[str, str | float | None] = {
+        "source_software": data.source_software,
+        "ds_type": "bboxes",
+    }
     # if fps is provided:
     # time_coords is expressed in seconds, with the time origin
     # set as frame 0 == time 0 seconds
@@ -675,7 +680,9 @@ def _ds_from_valid_data(data: ValidBboxesDataset) -> xr.Dataset:
             [frame / data.fps for frame in data.frame_array.squeeze()]  # type: ignore
         )
         time_unit = "seconds"
+        dataset_attrs["fps"] = data.fps
 
+    dataset_attrs["time_unit"] = time_unit
     # Convert data to an xarray.Dataset
     # with dimensions ('time', 'space', 'individuals')
     DIM_NAMES = ValidBboxesDataset.DIM_NAMES
@@ -693,11 +700,5 @@ def _ds_from_valid_data(data: ValidBboxesDataset) -> xr.Dataset:
             DIM_NAMES[1]: ["x", "y", "z"][:n_space],
             DIM_NAMES[2]: data.individual_names,
         },
-        attrs={
-            "fps": data.fps,
-            "time_unit": time_unit,
-            "source_software": data.source_software,
-            "source_file": None,
-            "ds_type": "bboxes",
-        },
+        attrs=dataset_attrs,
     )

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -684,7 +684,6 @@ def _ds_from_valid_data(data: ValidPosesDataset) -> xr.Dataset:
 
     dataset_attrs: dict[str, str | float | None] = {
         "source_software": data.source_software,
-        "source_file": None,
         "ds_type": "poses",
     }
     # Create the time coordinate, depending on the value of fps

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -681,13 +681,22 @@ def _ds_from_valid_data(data: ValidPosesDataset) -> xr.Dataset:
     """
     n_frames = data.position_array.shape[0]
     n_space = data.position_array.shape[1]
+
+    dataset_attrs: dict[str, str | float | None] = {
+        "source_software": data.source_software,
+        "source_file": None,
+        "ds_type": "poses",
+    }
     # Create the time coordinate, depending on the value of fps
     if data.fps is not None:
         time_coords = np.arange(n_frames, dtype=float) / data.fps
         time_unit = "seconds"
+        dataset_attrs["fps"] = data.fps
     else:
         time_coords = np.arange(n_frames, dtype=int)
         time_unit = "frames"
+
+    dataset_attrs["time_unit"] = time_unit
 
     DIM_NAMES = ValidPosesDataset.DIM_NAMES
     # Convert data to an xarray.Dataset
@@ -704,13 +713,7 @@ def _ds_from_valid_data(data: ValidPosesDataset) -> xr.Dataset:
             DIM_NAMES[2]: data.keypoint_names,
             DIM_NAMES[3]: data.individual_names,
         },
-        attrs={
-            "fps": data.fps,
-            "time_unit": time_unit,
-            "source_software": data.source_software,
-            "source_file": None,
-            "ds_type": "poses",
-        },
+        attrs=dataset_attrs,
     )
 
 

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -314,8 +314,10 @@ def to_sleap_analysis_file(ds: xr.Dataset, file_path: str | Path) -> None:
     n_individuals = len(individual_names)
     keypoint_names = ds.keypoints.values.tolist()
     # Compute frame indices from fps, if set
-    if ds.fps is not None:
-        frame_idxs = np.rint(ds.time.values * ds.fps).astype(int).tolist()
+
+    fps = getattr(ds, "fps", None)
+    if fps is not None:
+        frame_idxs = np.rint(ds.time.values * fps).astype(int).tolist()
     else:
         frame_idxs = ds.time.values.astype(int).tolist()
     n_frames = frame_idxs[-1] - frame_idxs[0] + 1

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -328,8 +328,12 @@ def to_sleap_analysis_file(ds: xr.Dataset, file_path: str | Path) -> None:
     point_scores = ds.confidence.data.T
     instance_scores = np.full((n_individuals, n_frames), np.nan, dtype=float)
     tracking_scores = np.full((n_individuals, n_frames), np.nan, dtype=float)
+
+    source_file = getattr(ds, "source_file", None)
     labels_path = (
-        ds.source_file if Path(ds.source_file).suffix == ".slp" else ""
+        source_file
+        if source_file is not None and Path(source_file).suffix == ".slp"
+        else ""
     )
     data_dict = dict(
         track_names=individual_names,

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -314,7 +314,6 @@ def to_sleap_analysis_file(ds: xr.Dataset, file_path: str | Path) -> None:
     n_individuals = len(individual_names)
     keypoint_names = ds.keypoints.values.tolist()
     # Compute frame indices from fps, if set
-
     fps = getattr(ds, "fps", None)
     if fps is not None:
         frame_idxs = np.rint(ds.time.values * fps).astype(int).tolist()

--- a/movement/sample_data.py
+++ b/movement/sample_data.py
@@ -300,9 +300,9 @@ def fetch_dataset(
             )
 
     if file_paths["frame"]:
-        ds.attrs["frame_path"] = file_paths["frame"]
+        ds.attrs["frame_path"] = file_paths["frame"].as_posix()
 
     if file_paths["video"]:
-        ds.attrs["video_path"] = file_paths["video"]
+        ds.attrs["video_path"] = file_paths["video"].as_posix()
 
     return ds

--- a/movement/sample_data.py
+++ b/movement/sample_data.py
@@ -299,7 +299,10 @@ def fetch_dataset(
                 fps=metadata[filename]["fps"],
             )
 
-    ds.attrs["frame_path"] = file_paths["frame"]
-    ds.attrs["video_path"] = file_paths["video"]
+    if file_paths["frame"]:
+        ds.attrs["frame_path"] = file_paths["frame"]
+
+    if file_paths["video"]:
+        ds.attrs["video_path"] = file_paths["video"]
 
     return ds

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -105,7 +105,6 @@ def valid_bboxes_dataset(valid_bboxes_arrays):
             dim_names[2]: [f"id_{id}" for id in range(n_individuals)],
         },
         attrs={
-            "fps": None,
             "time_unit": "frames",
             "source_software": "test",
             "source_file": "test_bboxes.csv",
@@ -263,7 +262,6 @@ def valid_poses_dataset(valid_poses_arrays, request):
             dim_names[3]: [f"id_{i}" for i in range(n_individuals)],
         },
         attrs={
-            "fps": None,
             "time_unit": "frames",
             "source_software": "test",
             "source_file": "test_poses.h5",

--- a/tests/fixtures/helpers.py
+++ b/tests/fixtures/helpers.py
@@ -78,7 +78,8 @@ class Helpers:
         assert dataset.source_software == expected_values.get(
             "source_software"
         )
-        assert dataset.fps == expected_values.get("fps")
+        fps = getattr(dataset, "fps", None)
+        assert fps == expected_values.get("fps")
 
     @staticmethod
     def count_nans(da):

--- a/tests/fixtures/helpers.py
+++ b/tests/fixtures/helpers.py
@@ -70,7 +70,8 @@ class Helpers:
 
         # Check the metadata attributes
         expected_file_path = expected_values.get("file_path")
-        assert dataset.source_file == (
+        source_file = getattr(dataset, "source_file", None)
+        assert source_file == (
             expected_file_path.as_posix()
             if expected_file_path is not None
             else None

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -607,9 +607,9 @@ def test_fps_and_time_coords(
     assert ds.time_unit == expected_time_unit
     # check fps is as expected
     if bool(expected_fps):
-        assert ds.fps == expected_fps
+        assert getattr(ds, "fps", None) == expected_fps
     else:
-        assert ds.fps is None
+        assert not hasattr(ds, "fps")
     # check loading frame numbers from file
     if use_frame_numbers_from_file:
         assert_time_coordinates(

--- a/tests/test_unit/test_load_poses.py
+++ b/tests/test_unit/test_load_poses.py
@@ -202,7 +202,7 @@ def test_fps_and_time_coords(fps, expected_fps, expected_time_unit):
     )
     assert ds.time_unit == expected_time_unit
     if expected_fps is None:
-        assert ds.fps is expected_fps
+        assert "fps" not in ds.attrs
     else:
         assert ds.fps == expected_fps
         np.testing.assert_allclose(

--- a/tests/test_unit/test_sample_data.py
+++ b/tests/test_unit/test_sample_data.py
@@ -136,15 +136,18 @@ def test_fetch_dataset(valid_sample_datasets, with_video):
 
         assert getattr(ds, "fps", None) == sample["fps"]
 
+        frame_path = getattr(ds, "frame_path", None)
+        video_path = getattr(ds, "video_path", None)
+
         if sample["frame_file"]:
-            assert ds.attrs["frame_path"].name == sample["frame_file"]
+            assert frame_path.name == sample["frame_file"]
         else:
-            assert ds.attrs["frame_path"] is None
+            assert frame_path is None
 
         if sample["video_file"] and with_video:
-            assert ds.attrs["video_path"].name == sample["video_file"]
+            assert video_path.name == sample["video_file"]
         else:
-            assert ds.attrs["video_path"] is None
+            assert video_path is None
 
     # Test with an invalid file
     with pytest.raises(ValueError):

--- a/tests/test_unit/test_sample_data.py
+++ b/tests/test_unit/test_sample_data.py
@@ -134,7 +134,7 @@ def test_fetch_dataset(valid_sample_datasets, with_video):
         ds = fetch_dataset(sample_name, with_video=with_video)
         assert isinstance(ds, Dataset)
 
-        assert ds.attrs["fps"] == sample["fps"]
+        assert getattr(ds, "fps", None) == sample["fps"]
 
         if sample["frame_file"]:
             assert ds.attrs["frame_path"].name == sample["frame_file"]

--- a/tests/test_unit/test_sample_data.py
+++ b/tests/test_unit/test_sample_data.py
@@ -140,12 +140,12 @@ def test_fetch_dataset(valid_sample_datasets, with_video):
         video_path = getattr(ds, "video_path", None)
 
         if sample["frame_file"]:
-            assert frame_path.name == sample["frame_file"]
+            assert frame_path.split("/")[-1] == sample["frame_file"]
         else:
             assert frame_path is None
 
         if sample["video_file"] and with_video:
-            assert video_path.name == sample["video_file"]
+            assert video_path.split("/")[-1] == sample["video_file"]
         else:
             assert video_path is None
 


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

This PR is needed to prevent errors when saving datasets to NetCDF by ensuring that optional attributes are not included if they are None.

**What does this PR do?**

This PR prevents serialization issues by ensuring attributes such as fps, source_file, video_path, and frame_path are only added to the dataset if specified.

## References

#420 

## How has this PR been tested?

Pytest: Updated tests for fps handling.
Manual Testing: Ensured NetCDF serialization works.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

Yes. The documentation has been updated.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
