### PR TITLE
Added support for exporting bboxes in VIA-tracks (issue #495) 

### DIFF
--- a/movement/io/save_boxes.py
+++ b/movement/io/save_boxes.py
@@ -1,0 +1,121 @@
+"""Save pose tracking data from ``movement`` to various file formats."""
+
+import logging
+import json
+import uuid
+from pathlib import Path
+from typing import Union, Dict, List, Optional
+
+# Configure logger
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def _validate_file_path(
+    file_path: Union[str, Path], 
+    expected_suffix: List[str]
+) -> Path:
+    """Validate and normalize file paths."""
+    path = Path(file_path).resolve()
+    if path.suffix.lower() not in [s.lower() for s in expected_suffix]:
+        raise ValueError(f"Invalid file extension. Expected: {expected_suffix}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+def to_via_tracks_file(
+    bboxes: Union["Bboxes", Dict[int, "Bboxes"]],
+    file_path: Union[str, Path],
+    video_metadata: Optional[Dict] = None,
+) -> None:
+    """Save bounding boxes to a VIA-tracks format file.
+
+    Parameters
+    ----------
+    bboxes : Bboxes or dict[int, Bboxes]
+        Bounding boxes to export. If dict, keys are frame indices.
+    file_path : str or Path
+        Path to save the VIA-tracks JSON file.
+    video_metadata : dict, optional
+        Video metadata including filename, size, width, height.
+        Defaults to minimal metadata if None.
+
+    Examples
+    --------
+    >>> from movement.io import save_poses
+    >>> bboxes = Bboxes([[10,20,50,60]], format="xyxy")
+    >>> save_poses.to_via_tracks_file(bboxes, "output.json", 
+    ...     {"filename": "video.mp4", "width": 1280, "height": 720})
+    """
+    file = _validate_file_path(file_path, expected_suffix=[".json"])
+    
+    # Create minimal metadata if not provided
+    video_metadata = video_metadata or {
+        "filename": "unknown_video.mp4",
+        "size": -1,
+        "width": 0,
+        "height": 0
+    }
+    
+    # Initialize VIA-tracks structure
+    via_data = {
+        "_via_settings": {
+            "ui": {"file_content_align": "center"},
+            "core": {"buffer_size": 18, "filepath": {}}
+        },
+        "_via_data_format_version": "2.0.10",
+        "_via_image_id_list": [],
+        "_via_attributes": {"region": {}, "file": {}},
+        "_via_data": {"metadata": {}, "vid_list": {}, "cache": {}}
+    }
+    
+    # Create video ID
+    vid = str(uuid.uuid4())
+    via_data["_via_data"]["vid_list"][vid] = {
+        "fid_list": [],
+        "filepath": video_metadata["filename"],
+        "filetype": "video",
+        "filesize": video_metadata["size"],
+        "width": video_metadata["width"],
+        "height": video_metadata["height"]
+    }
+    
+    # Process bboxes
+    frame_dict = bboxes if isinstance(bboxes, dict) else {0: bboxes}
+    
+    for frame_idx, frame_bboxes in frame_dict.items():
+        # Convert to xyxy format if needed
+        current_bboxes = frame_bboxes
+        if frame_bboxes.format != "xyxy":
+            current_bboxes = frame_bboxes.convert("xyxy", inplace=False)
+        
+        # Add frame metadata
+        fid = str(frame_idx)
+        via_data["_via_data"]["vid_list"][vid]["fid_list"].append(fid)
+        mid = f"{vid}_{fid}"
+        via_data["_via_data"]["metadata"][mid] = {
+            "vid": vid,
+            "flg": 0,
+            "z": [],
+            "xy": [],
+            "av": {}
+        }
+        
+        # Add regions
+        for i, bbox in enumerate(current_bboxes.bboxes):
+            x1, y1, x2, y2 = bbox
+            region = {
+                "shape_attributes": {
+                    "name": "rect",
+                    "x": float(x1),
+                    "y": float(y1),
+                    "width": float(x2 - x1),
+                    "height": float(y2 - y1)
+                },
+                "region_attributes": {"id": i}
+            }
+            via_data["_via_data"]["metadata"][mid]["xy"].append(region)
+    
+    # Save to file
+    with open(file, 'w') as f:
+        json.dump(via_data, f, indent=2)
+    
+    logger.info(f"Saved bounding boxes to VIA-tracks file: {file}")

--- a/movement/io/save_boxes.py
+++ b/movement/io/save_boxes.py
@@ -1,126 +1,216 @@
-"""Save pose tracking data to various file formats."""
+"""Save bounding boxes data from ``movement`` to VIA-tracks CSV format."""
 
+import csv
 import json
 import logging
-import uuid
 from pathlib import Path
 
 import numpy as np
+import xarray as xr
 
-# Configure logger
-logging.basicConfig(level=logging.INFO)
+from movement.utils.logging import log_error
+from movement.validators.datasets import ValidBboxesDataset
+from movement.validators.files import ValidFile
+
 logger = logging.getLogger(__name__)
 
 
-class Bboxes:
-    """Container for bounding box coordinates in various formats."""
+def _validate_dataset(ds: xr.Dataset) -> None:
+    """Validate the input as a proper ``movement`` bounding boxes dataset.
 
-    def __init__(self, coordinates, format: str):
-        """Initialize with box coordinates and format."""
-        self.coordinates = np.array(coordinates)
-        self.format = format
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        Dataset to validate.
 
-    def convert(self, target_format: str, inplace: bool = False):
-        """Convert coordinates to target format."""
-        if self.format == target_format:
-            return self
+    Raises
+    ------
+    TypeError
+        If the input is not an xarray Dataset.
+    ValueError
+        If the dataset is missing required data variables or dimensions.
 
-        if self.format == "xywh" and target_format == "xyxy":
-            converted = []
-            for box in self.coordinates:
-                x, y, w, h = box
-                converted.append([x, y, x + w, y + h])
-            new_coords = np.array(converted)
+    """
+    if not isinstance(ds, xr.Dataset):
+        raise log_error(
+            TypeError, f"Expected an xarray Dataset, but got {type(ds)}."
+        )
 
-            if inplace:
-                self.coordinates = new_coords
-                self.format = target_format
-                return self
-            return Bboxes(new_coords, target_format)
-
+    missing_vars = set(ValidBboxesDataset.VAR_NAMES) - set(ds.data_vars)
+    if missing_vars:
         raise ValueError(
-            f"Unsupported conversion: {self.format} -> {target_format}"
+            f"Missing required data variables: {sorted(missing_vars)}"
+        )
+
+    missing_dims = set(ValidBboxesDataset.DIM_NAMES) - set(ds.dims)
+    if missing_dims:
+        raise ValueError(
+            f"Missing required dimensions: {sorted(missing_dims)}"
         )
 
 
-def validate_json_extension(file_path):  # type: ignore
-    """Validate file has .json extension."""
-    path = Path(file_path).resolve()
+def _validate_file_path(
+    file_path: str | Path, expected_suffix: list[str]
+) -> ValidFile:
+    """Validate the input file path.
 
-    if path.suffix.lower() != ".json":
-        raise ValueError("Invalid file extension. Expected: .json")
+    Parameters
+    ----------
+    file_path : pathlib.Path or str
+        Path to the file to validate.
+    expected_suffix : list of str
+        Expected suffix(es) for the file.
 
-    path.parent.mkdir(parents=True, exist_ok=True)
-    return path
+    Returns
+    -------
+    ValidFile
+        The validated file.
+
+    Raises
+    ------
+    OSError
+        If the file cannot be written.
+    ValueError
+        If the file does not have the expected suffix.
+
+    """
+    try:
+        file = ValidFile(
+            file_path,
+            expected_permission="w",
+            expected_suffix=expected_suffix,
+        )
+    except (OSError, ValueError) as error:
+        logger.error(error)
+        raise error
+    return file
 
 
-def to_via_tracks_file(boxes, file_path, video_metadata=None):  # type: ignore
-    """Save bounding boxes to VIA-tracks format."""
-    file = validate_json_extension(file_path)
+def _prepare_via_row(
+    frame: int,
+    individual: str,
+    pos: np.ndarray,
+    shape: np.ndarray,
+    video_id: str,
+) -> list:
+    """Prepare a single row for the VIA-tracks CSV file.
 
-    # Set default metadata
-    video_metadata = video_metadata or {
-        "filename": "unknown_video.mp4",
-        "size": -1,
-        "width": 0,
-        "height": 0,
-    }
+    Parameters
+    ----------
+    frame : int
+        Frame number.
+    individual : str
+        Individual identifier.
+    pos : np.ndarray
+        Position data (x, y).
+    shape : np.ndarray
+        Shape data (width, height).
+    video_id : str
+        Video identifier.
 
-    via_data = {
-        "_via_settings": {
-            "ui": {"file_content_align": "center"},
-            "core": {"buffer_size": 18, "filepath": {}},
-        },
-        "_via_data_format_version": "2.0.10",
-        "_via_image_id_list": [],
-        "_via_attributes": {"region": {}, "file": {}},
-        "_via_data": {"metadata": {}, "vid_list": {}, "cache": {}},
-    }
+    Returns
+    -------
+    list
+        Row data in VIA-tracks format.
 
-    vid = str(uuid.uuid4())
-    via_data["_via_data"]["vid_list"][vid] = {
-        "fid_list": [],
-        "filepath": video_metadata.get("filename"),
-        "filetype": "video",
-        "filesize": video_metadata["size"],
-        "width": video_metadata["width"],
-        "height": video_metadata["height"],
-    }
+    """
+    # Calculate top-left coordinates
+    x_center, y_center = pos
+    width, height = shape
+    x = x_center - width / 2
+    y = y_center - height / 2
 
-    frame_dict = boxes if isinstance(boxes, dict) else {0: boxes}
-
-    for frame_idx, frame_boxes in frame_dict.items():
-        current_boxes = frame_boxes
-        if frame_boxes.format != "xyxy":
-            current_boxes = frame_boxes.convert("xyxy", inplace=False)
-
-        fid = str(frame_idx)
-        via_data["_via_data"]["vid_list"][vid]["fid_list"].append(fid)
-        mid = f"{vid}_{fid}"
-
-        via_data["_via_data"]["metadata"][mid] = {
-            "vid": vid,
-            "flg": 0,
-            "z": [],
-            "xy": [],
-            "av": {},
+    # Prepare region shape attributes
+    region_shape_attributes = json.dumps(
+        {
+            "name": "rect",
+            "x": int(x),
+            "y": int(y),
+            "width": int(width),
+            "height": int(height),
         }
+    )
 
-        for i, box in enumerate(current_boxes.coordinates):
-            x1, y1, x2, y2 = box
-            region = {
-                "shape_attributes": {
-                    "name": "rect",
-                    "x": float(x1),
-                    "y": float(y1),
-                    "width": float(x2 - x1),
-                    "height": float(y2 - y1),
-                },
-                "region_attributes": {"id": i},
-            }
-            via_data["_via_data"]["metadata"][mid]["xy"].append(region)
+    # Prepare region attributes
+    region_attributes = json.dumps({"track": individual})
 
-    with open(file, "w") as f:
-        json.dump(via_data, f, indent=2)
+    return [
+        f"{video_id}_{frame:06d}.jpg",  # filename
+        0,  # file_size (placeholder)
+        "{}",  # file_attributes (empty JSON object)
+        1,  # region_count
+        0,  # region_id
+        region_shape_attributes,
+        region_attributes,
+    ]
 
-    logger.info(f"Saved bounding boxes to VIA-tracks file: {file}")
+
+def to_via_tracks_file(
+    ds: xr.Dataset,
+    file_path: str | Path,
+    video_id: str | None = None,
+) -> Path:
+    """Save a movement bounding boxes dataset to a VIA-tracks CSV file.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        The movement bounding boxes dataset to export.
+    file_path : str or pathlib.Path
+        Path where the VIA-tracks CSV file will be saved.
+    video_id : str, optional
+        Video identifier to use in the export. If None, will use the filename.
+
+    Returns
+    -------
+    pathlib.Path
+        Path to the saved file.
+
+    Examples
+    --------
+    >>> from movement.io import save_boxes, load_boxes
+    >>> ds = load_boxes.from_via_tracks_file("/path/to/file.csv")
+    >>> save_boxes.to_via_tracks_file(ds, "/path/to/output.csv")
+
+    """
+    file = _validate_file_path(file_path, expected_suffix=[".csv"])
+    _validate_dataset(ds)
+
+    # Use filename as video_id if not provided
+    if video_id is None:
+        video_id = file.path.stem
+
+    with open(file.path, "w", newline="") as f:
+        writer = csv.writer(f)
+
+        # Write header
+        writer.writerow(
+            [
+                "filename",
+                "file_size",
+                "file_attributes",
+                "region_count",
+                "region_id",
+                "region_shape_attributes",
+                "region_attributes",
+            ]
+        )
+
+        # For each individual and time point
+        for frame, time in enumerate(ds.time.values):
+            for individual in ds.individuals.values:
+                # Get position and shape data
+                pos = ds.position.sel(time=time, individuals=individual).values
+                shape = ds.shape.sel(time=time, individuals=individual).values
+
+                # Skip if NaN values
+                if np.isnan(pos).any() or np.isnan(shape).any():
+                    continue
+
+                # Write row
+                writer.writerow(
+                    _prepare_via_row(frame, individual, pos, shape, video_id)
+                )
+
+    logger.info(f"Saved bounding boxes dataset to {file.path}.")
+    return file.path

--- a/movement/io/save_boxes.py
+++ b/movement/io/save_boxes.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 class Bboxes:
     """Container for bounding box coordinates in various formats.
-    
+
     Parameters
     ----------
     coordinates : list or np.ndarray
@@ -32,14 +32,14 @@ class Bboxes:
 
     def convert(self, target_format: str, inplace: bool = False) -> "Bboxes":
         """Convert coordinates to target format.
-        
+
         Parameters
         ----------
         target_format : str
             Desired output format ('xyxy' or 'xywh')
         inplace : bool, optional
             Whether to modify the current instance
-            
+
         Returns
         -------
         Bboxes
@@ -48,32 +48,34 @@ class Bboxes:
         """
         if self.format == target_format:
             return self
-            
+
         if self.format == "xywh" and target_format == "xyxy":
             converted = []
             for box in self.coordinates:
                 x, y, w, h = box
                 converted.append([x, y, x + w, y + h])
             new_coords = np.array(converted)
-            
+
             if inplace:
                 self.coordinates = new_coords
                 self.format = target_format
                 return self
             return Bboxes(new_coords, target_format)
-            
+
         raise ValueError(
             f"Unsupported conversion: {self.format} -> {target_format}"
         )
 
 
 def _validate_file_path(
-    file_path: str | Path, 
-    expected_suffix: Sequence[str]  # Changed to Sequence for indexable type
+    file_path: str | Path,
+    expected_suffix: Sequence[str],  # Changed to Sequence for indexable type
 ) -> Path:
     """Validate and normalize file paths."""
     path = Path(file_path).resolve()
-    valid_suffixes = [s.lower() for s in expected_suffix]  # This is now indexable
+    valid_suffixes = [
+        s.lower() for s in expected_suffix
+    ]  # This is now indexable
     if path.suffix.lower() not in valid_suffixes:
         raise ValueError(
             f"Invalid file extension. Expected: {expected_suffix}"
@@ -88,7 +90,7 @@ def to_via_tracks_file(
     video_metadata: dict | None = None,
 ) -> None:
     """Save bounding boxes to VIA-tracks format.
-    
+
     Parameters
     ----------
     boxes : Bboxes or dict[int, Bboxes]
@@ -100,7 +102,7 @@ def to_via_tracks_file(
 
     """
     file = _validate_file_path(file_path, [".json"])
-    
+
     # Set default metadata
     video_metadata = video_metadata or {
         "filename": "unknown_video.mp4",
@@ -112,12 +114,12 @@ def to_via_tracks_file(
     via_data = {
         "_via_settings": {
             "ui": {"file_content_align": "center"},
-            "core": {"buffer_size": 18, "filepath": {}}
+            "core": {"buffer_size": 18, "filepath": {}},
         },
         "_via_data_format_version": "2.0.10",
         "_via_image_id_list": [],
         "_via_attributes": {"region": {}, "file": {}},
-        "_via_data": {"metadata": {}, "vid_list": {}, "cache": {}}
+        "_via_data": {"metadata": {}, "vid_list": {}, "cache": {}},
     }
 
     vid = str(uuid.uuid4())
@@ -140,7 +142,7 @@ def to_via_tracks_file(
         fid = str(frame_idx)
         via_data["_via_data"]["vid_list"][vid]["fid_list"].append(fid)
         mid = f"{vid}_{fid}"
-        
+
         via_data["_via_data"]["metadata"][mid] = {
             "vid": vid,
             "flg": 0,
@@ -157,9 +159,9 @@ def to_via_tracks_file(
                     "x": float(x1),
                     "y": float(y1),
                     "width": float(x2 - x1),
-                    "height": float(y2 - y1)
+                    "height": float(y2 - y1),
                 },
-                "region_attributes": {"id": i}
+                "region_attributes": {"id": i},
             }
             via_data["_via_data"]["metadata"][mid]["xy"].append(region)
 

--- a/movement/io/save_boxes.py
+++ b/movement/io/save_boxes.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 class Bboxes:
     """Container for bounding box coordinates in various formats.
-
+    
     Parameters
     ----------
     coordinates : list or np.ndarray
@@ -32,14 +32,14 @@ class Bboxes:
 
     def convert(self, target_format: str, inplace: bool = False) -> "Bboxes":
         """Convert coordinates to target format.
-
+        
         Parameters
         ----------
         target_format : str
             Desired output format ('xyxy' or 'xywh')
         inplace : bool, optional
             Whether to modify the current instance
-
+            
         Returns
         -------
         Bboxes
@@ -48,31 +48,32 @@ class Bboxes:
         """
         if self.format == target_format:
             return self
-
+            
         if self.format == "xywh" and target_format == "xyxy":
             converted = []
             for box in self.coordinates:
                 x, y, w, h = box
                 converted.append([x, y, x + w, y + h])
             new_coords = np.array(converted)
-
+            
             if inplace:
                 self.coordinates = new_coords
                 self.format = target_format
                 return self
             return Bboxes(new_coords, target_format)
-
+            
         raise ValueError(
             f"Unsupported conversion: {self.format} -> {target_format}"
         )
 
 
 def _validate_file_path(
-    file_path: str | Path, expected_suffix: Sequence[str]
+    file_path: str | Path, 
+    expected_suffix: Sequence[str]  # Changed to Sequence for indexable type
 ) -> Path:
     """Validate and normalize file paths."""
     path = Path(file_path).resolve()
-    valid_suffixes = [s.lower() for s in expected_suffix]
+    valid_suffixes = [s.lower() for s in expected_suffix]  # This is now indexable
     if path.suffix.lower() not in valid_suffixes:
         raise ValueError(
             f"Invalid file extension. Expected: {expected_suffix}"
@@ -87,7 +88,7 @@ def to_via_tracks_file(
     video_metadata: dict | None = None,
 ) -> None:
     """Save bounding boxes to VIA-tracks format.
-
+    
     Parameters
     ----------
     boxes : Bboxes or dict[int, Bboxes]
@@ -99,7 +100,7 @@ def to_via_tracks_file(
 
     """
     file = _validate_file_path(file_path, [".json"])
-
+    
     # Set default metadata
     video_metadata = video_metadata or {
         "filename": "unknown_video.mp4",
@@ -111,12 +112,12 @@ def to_via_tracks_file(
     via_data = {
         "_via_settings": {
             "ui": {"file_content_align": "center"},
-            "core": {"buffer_size": 18, "filepath": {}},
+            "core": {"buffer_size": 18, "filepath": {}}
         },
         "_via_data_format_version": "2.0.10",
         "_via_image_id_list": [],
         "_via_attributes": {"region": {}, "file": {}},
-        "_via_data": {"metadata": {}, "vid_list": {}, "cache": {}},
+        "_via_data": {"metadata": {}, "vid_list": {}, "cache": {}}
     }
 
     vid = str(uuid.uuid4())
@@ -139,7 +140,7 @@ def to_via_tracks_file(
         fid = str(frame_idx)
         via_data["_via_data"]["vid_list"][vid]["fid_list"].append(fid)
         mid = f"{vid}_{fid}"
-
+        
         via_data["_via_data"]["metadata"][mid] = {
             "vid": vid,
             "flg": 0,
@@ -156,9 +157,9 @@ def to_via_tracks_file(
                     "x": float(x1),
                     "y": float(y1),
                     "width": float(x2 - x1),
-                    "height": float(y2 - y1),
+                    "height": float(y2 - y1)
                 },
-                "region_attributes": {"id": i},
+                "region_attributes": {"id": i}
             }
             via_data["_via_data"]["metadata"][mid]["xy"].append(region)
 

--- a/movement/io/save_boxes.py
+++ b/movement/io/save_boxes.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 class Bboxes:
     """Container for bounding box coordinates in various formats.
-
+    
     Parameters
     ----------
     coordinates : list or np.ndarray
@@ -32,14 +32,14 @@ class Bboxes:
 
     def convert(self, target_format: str, inplace: bool = False) -> "Bboxes":
         """Convert coordinates to target format.
-
+        
         Parameters
         ----------
         target_format : str
             Desired output format ('xyxy' or 'xywh')
         inplace : bool, optional
             Whether to modify the current instance
-
+            
         Returns
         -------
         Bboxes
@@ -48,34 +48,32 @@ class Bboxes:
         """
         if self.format == target_format:
             return self
-
+            
         if self.format == "xywh" and target_format == "xyxy":
             converted = []
             for box in self.coordinates:
                 x, y, w, h = box
                 converted.append([x, y, x + w, y + h])
             new_coords = np.array(converted)
-
+            
             if inplace:
                 self.coordinates = new_coords
                 self.format = target_format
                 return self
             return Bboxes(new_coords, target_format)
-
+            
         raise ValueError(
             f"Unsupported conversion: {self.format} -> {target_format}"
         )
 
 
 def _validate_file_path(
-    file_path: str | Path,
-    expected_suffix: Sequence[str],  # Changed to Sequence for indexable type
+    file_path: str | Path, 
+    expected_suffix: Sequence[str]  # Changed to Sequence for indexable type
 ) -> Path:
     """Validate and normalize file paths."""
     path = Path(file_path).resolve()
-    valid_suffixes = [
-        s.lower() for s in expected_suffix
-    ]  # This is now indexable
+    valid_suffixes = [s.lower() for s in expected_suffix]  # This is now indexable
     if path.suffix.lower() not in valid_suffixes:
         raise ValueError(
             f"Invalid file extension. Expected: {expected_suffix}"
@@ -90,7 +88,7 @@ def to_via_tracks_file(
     video_metadata: dict | None = None,
 ) -> None:
     """Save bounding boxes to VIA-tracks format.
-
+    
     Parameters
     ----------
     boxes : Bboxes or dict[int, Bboxes]
@@ -102,7 +100,7 @@ def to_via_tracks_file(
 
     """
     file = _validate_file_path(file_path, [".json"])
-
+    
     # Set default metadata
     video_metadata = video_metadata or {
         "filename": "unknown_video.mp4",
@@ -114,18 +112,18 @@ def to_via_tracks_file(
     via_data = {
         "_via_settings": {
             "ui": {"file_content_align": "center"},
-            "core": {"buffer_size": 18, "filepath": {}},
+            "core": {"buffer_size": 18, "filepath": {}}
         },
         "_via_data_format_version": "2.0.10",
         "_via_image_id_list": [],
         "_via_attributes": {"region": {}, "file": {}},
-        "_via_data": {"metadata": {}, "vid_list": {}, "cache": {}},
+        "_via_data": {"metadata": {}, "vid_list": {}, "cache": {}}
     }
 
     vid = str(uuid.uuid4())
     via_data["_via_data"]["vid_list"][vid] = {
         "fid_list": [],
-        "filepath": video_metadata["filename"],
+        "filepath": video_metadata.get("filename"),
         "filetype": "video",
         "filesize": video_metadata["size"],
         "width": video_metadata["width"],
@@ -142,7 +140,7 @@ def to_via_tracks_file(
         fid = str(frame_idx)
         via_data["_via_data"]["vid_list"][vid]["fid_list"].append(fid)
         mid = f"{vid}_{fid}"
-
+        
         via_data["_via_data"]["metadata"][mid] = {
             "vid": vid,
             "flg": 0,
@@ -159,9 +157,9 @@ def to_via_tracks_file(
                     "x": float(x1),
                     "y": float(y1),
                     "width": float(x2 - x1),
-                    "height": float(y2 - y1),
+                    "height": float(y2 - y1)
                 },
-                "region_attributes": {"id": i},
+                "region_attributes": {"id": i}
             }
             via_data["_via_data"]["metadata"][mid]["xy"].append(region)
 

--- a/movement/io/save_boxes.py
+++ b/movement/io/save_boxes.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 class Bboxes:
     """Container for bounding box coordinates in various formats.
-
+    
     Parameters
     ----------
     coordinates : list or np.ndarray
@@ -32,14 +32,14 @@ class Bboxes:
 
     def convert(self, target_format: str, inplace: bool = False) -> "Bboxes":
         """Convert coordinates to target format.
-
+        
         Parameters
         ----------
         target_format : str
             Desired output format ('xyxy' or 'xywh')
         inplace : bool, optional
             Whether to modify the current instance
-
+            
         Returns
         -------
         Bboxes
@@ -48,27 +48,28 @@ class Bboxes:
         """
         if self.format == target_format:
             return self
-
+            
         if self.format == "xywh" and target_format == "xyxy":
             converted = []
             for box in self.coordinates:
                 x, y, w, h = box
                 converted.append([x, y, x + w, y + h])
             new_coords = np.array(converted)
-
+            
             if inplace:
                 self.coordinates = new_coords
                 self.format = target_format
                 return self
             return Bboxes(new_coords, target_format)
-
+            
         raise ValueError(
             f"Unsupported conversion: {self.format} -> {target_format}"
         )
 
 
 def _validate_file_path(
-    file_path: str | Path, expected_suffix: Sequence[str]
+    file_path: str | Path, 
+    expected_suffix: Sequence[str]
 ) -> Path:
     """Validate and normalize file paths."""
     path = Path(file_path).resolve()
@@ -87,7 +88,7 @@ def to_via_tracks_file(
     video_metadata: dict | None = None,
 ) -> None:
     """Save bounding boxes to VIA-tracks format.
-
+    
     Parameters
     ----------
     boxes : Bboxes or dict[int, Bboxes]
@@ -99,7 +100,7 @@ def to_via_tracks_file(
 
     """
     file = _validate_file_path(file_path, [".json"])
-
+    
     # Set default metadata
     video_metadata = video_metadata or {
         "filename": "unknown_video.mp4",
@@ -111,12 +112,12 @@ def to_via_tracks_file(
     via_data = {
         "_via_settings": {
             "ui": {"file_content_align": "center"},
-            "core": {"buffer_size": 18, "filepath": {}},
+            "core": {"buffer_size": 18, "filepath": {}}
         },
         "_via_data_format_version": "2.0.10",
         "_via_image_id_list": [],
         "_via_attributes": {"region": {}, "file": {}},
-        "_via_data": {"metadata": {}, "vid_list": {}, "cache": {}},
+        "_via_data": {"metadata": {}, "vid_list": {}, "cache": {}}
     }
 
     vid = str(uuid.uuid4())
@@ -139,7 +140,7 @@ def to_via_tracks_file(
         fid = str(frame_idx)
         via_data["_via_data"]["vid_list"][vid]["fid_list"].append(fid)
         mid = f"{vid}_{fid}"
-
+        
         via_data["_via_data"]["metadata"][mid] = {
             "vid": vid,
             "flg": 0,
@@ -156,9 +157,9 @@ def to_via_tracks_file(
                     "x": float(x1),
                     "y": float(y1),
                     "width": float(x2 - x1),
-                    "height": float(y2 - y1),
+                    "height": float(y2 - y1)
                 },
-                "region_attributes": {"id": i},
+                "region_attributes": {"id": i}
             }
             via_data["_via_data"]["metadata"][mid]["xy"].append(region)
 

--- a/movement/io/save_boxes.py
+++ b/movement/io/save_boxes.py
@@ -2,17 +2,14 @@
 
 import csv
 import json
-import logging
 from pathlib import Path
 
 import numpy as np
 import xarray as xr
+from loguru import logger
 
-from movement.utils.logging import log_error
 from movement.validators.datasets import ValidBboxesDataset
 from movement.validators.files import ValidFile
-
-logger = logging.getLogger(__name__)
 
 
 def _validate_dataset(ds: xr.Dataset) -> None:
@@ -32,21 +29,21 @@ def _validate_dataset(ds: xr.Dataset) -> None:
 
     """
     if not isinstance(ds, xr.Dataset):
-        raise log_error(
-            TypeError, f"Expected an xarray Dataset, but got {type(ds)}."
-        )
+        error_msg = f"Expected an xarray Dataset, but got {type(ds)}."
+        logger.error(error_msg)
+        raise TypeError(error_msg)
 
     missing_vars = set(ValidBboxesDataset.VAR_NAMES) - set(ds.data_vars)
     if missing_vars:
-        raise ValueError(
-            f"Missing required data variables: {sorted(missing_vars)}"
-        )
+        error_msg = f"Missing required data variables: {sorted(missing_vars)}"
+        logger.error(error_msg)
+        raise ValueError(error_msg)
 
     missing_dims = set(ValidBboxesDataset.DIM_NAMES) - set(ds.dims)
     if missing_dims:
-        raise ValueError(
-            f"Missing required dimensions: {sorted(missing_dims)}"
-        )
+        error_msg = f"Missing required dimensions: {sorted(missing_dims)}"
+        logger.error(error_msg)
+        raise ValueError(error_msg)
 
 
 def _validate_file_path(

--- a/movement/io/save_boxes.py
+++ b/movement/io/save_boxes.py
@@ -1,30 +1,33 @@
 """Save pose tracking data from ``movement`` to various file formats."""
 
-import logging
 import json
+import logging
 import uuid
 from pathlib import Path
-from typing import Union, Dict, List, Optional
+from typing import Union
 
 # Configure logger
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
 def _validate_file_path(
-    file_path: Union[str, Path], 
-    expected_suffix: List[str]
+    file_path: str | Path, expected_suffix: list[str]
 ) -> Path:
     """Validate and normalize file paths."""
     path = Path(file_path).resolve()
     if path.suffix.lower() not in [s.lower() for s in expected_suffix]:
-        raise ValueError(f"Invalid file extension. Expected: {expected_suffix}")
+        raise ValueError(
+            f"Invalid file extension. Expected: {expected_suffix}"
+        )
     path.parent.mkdir(parents=True, exist_ok=True)
     return path
 
+
 def to_via_tracks_file(
-    bboxes: Union["Bboxes", Dict[int, "Bboxes"]],
-    file_path: Union[str, Path],
-    video_metadata: Optional[Dict] = None,
+    bboxes: Union["Bboxes", dict[int, "Bboxes"]],
+    file_path: str | Path,
+    video_metadata: dict | None = None,
 ) -> None:
     """Save bounding boxes to a VIA-tracks format file.
 
@@ -41,32 +44,36 @@ def to_via_tracks_file(
     Examples
     --------
     >>> from movement.io import save_poses
-    >>> bboxes = Bboxes([[10,20,50,60]], format="xyxy")
-    >>> save_poses.to_via_tracks_file(bboxes, "output.json", 
-    ...     {"filename": "video.mp4", "width": 1280, "height": 720})
+    >>> bboxes = Bboxes([[10, 20, 50, 60]], format="xyxy")
+    >>> save_poses.to_via_tracks_file(
+    ...     bboxes,
+    ...     "output.json",
+    ...     {"filename": "video.mp4", "width": 1280, "height": 720},
+    ... )
+
     """
     file = _validate_file_path(file_path, expected_suffix=[".json"])
-    
+
     # Create minimal metadata if not provided
     video_metadata = video_metadata or {
         "filename": "unknown_video.mp4",
         "size": -1,
         "width": 0,
-        "height": 0
+        "height": 0,
     }
-    
+
     # Initialize VIA-tracks structure
     via_data = {
         "_via_settings": {
             "ui": {"file_content_align": "center"},
-            "core": {"buffer_size": 18, "filepath": {}}
+            "core": {"buffer_size": 18, "filepath": {}},
         },
         "_via_data_format_version": "2.0.10",
         "_via_image_id_list": [],
         "_via_attributes": {"region": {}, "file": {}},
-        "_via_data": {"metadata": {}, "vid_list": {}, "cache": {}}
+        "_via_data": {"metadata": {}, "vid_list": {}, "cache": {}},
     }
-    
+
     # Create video ID
     vid = str(uuid.uuid4())
     via_data["_via_data"]["vid_list"][vid] = {
@@ -75,18 +82,18 @@ def to_via_tracks_file(
         "filetype": "video",
         "filesize": video_metadata["size"],
         "width": video_metadata["width"],
-        "height": video_metadata["height"]
+        "height": video_metadata["height"],
     }
-    
+
     # Process bboxes
     frame_dict = bboxes if isinstance(bboxes, dict) else {0: bboxes}
-    
+
     for frame_idx, frame_bboxes in frame_dict.items():
         # Convert to xyxy format if needed
         current_bboxes = frame_bboxes
         if frame_bboxes.format != "xyxy":
             current_bboxes = frame_bboxes.convert("xyxy", inplace=False)
-        
+
         # Add frame metadata
         fid = str(frame_idx)
         via_data["_via_data"]["vid_list"][vid]["fid_list"].append(fid)
@@ -96,9 +103,9 @@ def to_via_tracks_file(
             "flg": 0,
             "z": [],
             "xy": [],
-            "av": {}
+            "av": {},
         }
-        
+
         # Add regions
         for i, bbox in enumerate(current_bboxes.bboxes):
             x1, y1, x2, y2 = bbox
@@ -108,14 +115,14 @@ def to_via_tracks_file(
                     "x": float(x1),
                     "y": float(y1),
                     "width": float(x2 - x1),
-                    "height": float(y2 - y1)
+                    "height": float(y2 - y1),
                 },
-                "region_attributes": {"id": i}
+                "region_attributes": {"id": i},
             }
             via_data["_via_data"]["metadata"][mid]["xy"].append(region)
-    
+
     # Save to file
-    with open(file, 'w') as f:
+    with open(file, "w") as f:
         json.dump(via_data, f, indent=2)
-    
+
     logger.info(f"Saved bounding boxes to VIA-tracks file: {file}")

--- a/movement/io/save_boxes.py
+++ b/movement/io/save_boxes.py
@@ -1,9 +1,8 @@
-"""Save pose tracking data from ``movement`` to various file formats."""
+"""Save pose tracking data to various file formats."""
 
 import json
 import logging
 import uuid
-from collections.abc import Sequence
 from pathlib import Path
 
 import numpy as np
@@ -14,38 +13,15 @@ logger = logging.getLogger(__name__)
 
 
 class Bboxes:
-    """Container for bounding box coordinates in various formats.
+    """Container for bounding box coordinates in various formats."""
 
-    Parameters
-    ----------
-    coordinates : list or np.ndarray
-        Array of bounding box coordinates
-    format : str
-        Coordinate format specification (e.g., 'xyxy', 'xywh')
-
-    """
-
-    def __init__(self, coordinates: list | np.ndarray, format: str):
+    def __init__(self, coordinates, format: str):
         """Initialize with box coordinates and format."""
         self.coordinates = np.array(coordinates)
         self.format = format
 
-    def convert(self, target_format: str, inplace: bool = False) -> "Bboxes":
-        """Convert coordinates to target format.
-
-        Parameters
-        ----------
-        target_format : str
-            Desired output format ('xyxy' or 'xywh')
-        inplace : bool, optional
-            Whether to modify the current instance
-
-        Returns
-        -------
-        Bboxes
-            Converted bounding boxes
-
-        """
+    def convert(self, target_format: str, inplace: bool = False):
+        """Convert coordinates to target format."""
         if self.format == target_format:
             return self
 
@@ -67,41 +43,20 @@ class Bboxes:
         )
 
 
-def _validate_file_path(
-    file_path: str | Path,
-    expected_suffix: Sequence[str],  # Changed to Sequence for indexable type
-) -> Path:
-    """Validate and normalize file paths."""
+def validate_json_extension(file_path):  # type: ignore
+    """Validate file has .json extension."""
     path = Path(file_path).resolve()
-    valid_suffixes = [
-        s.lower() for s in expected_suffix
-    ]  # This is now indexable
-    if path.suffix.lower() not in valid_suffixes:
-        raise ValueError(
-            f"Invalid file extension. Expected: {expected_suffix}"
-        )
+
+    if path.suffix.lower() != ".json":
+        raise ValueError("Invalid file extension. Expected: .json")
+
     path.parent.mkdir(parents=True, exist_ok=True)
     return path
 
 
-def to_via_tracks_file(
-    boxes: Bboxes | dict[int, Bboxes],
-    file_path: str | Path,
-    video_metadata: dict | None = None,
-) -> None:
-    """Save bounding boxes to VIA-tracks format.
-
-    Parameters
-    ----------
-    boxes : Bboxes or dict[int, Bboxes]
-        Bounding boxes to export
-    file_path : str or Path
-        Output JSON file path
-    video_metadata : dict, optional
-        Video metadata including filename, size, etc.
-
-    """
-    file = _validate_file_path(file_path, [".json"])
+def to_via_tracks_file(boxes, file_path, video_metadata=None):  # type: ignore
+    """Save bounding boxes to VIA-tracks format."""
+    file = validate_json_extension(file_path)
 
     # Set default metadata
     video_metadata = video_metadata or {

--- a/movement/io/save_boxes.py
+++ b/movement/io/save_boxes.py
@@ -6,8 +6,8 @@ from pathlib import Path
 
 import numpy as np
 import xarray as xr
-from loguru import logger
 
+from movement.utils.logging import logger
 from movement.validators.datasets import ValidBboxesDataset
 from movement.validators.files import ValidFile
 
@@ -30,20 +30,17 @@ def _validate_dataset(ds: xr.Dataset) -> None:
     """
     if not isinstance(ds, xr.Dataset):
         error_msg = f"Expected an xarray Dataset, but got {type(ds)}."
-        logger.error(error_msg)
-        raise TypeError(error_msg)
+        raise logger.error(TypeError(error_msg))
 
     missing_vars = set(ValidBboxesDataset.VAR_NAMES) - set(ds.data_vars)
     if missing_vars:
         error_msg = f"Missing required data variables: {sorted(missing_vars)}"
-        logger.error(error_msg)
-        raise ValueError(error_msg)
+        raise logger.error(ValueError(error_msg))
 
     missing_dims = set(ValidBboxesDataset.DIM_NAMES) - set(ds.dims)
     if missing_dims:
         error_msg = f"Missing required dimensions: {sorted(missing_dims)}"
-        logger.error(error_msg)
-        raise ValueError(error_msg)
+        raise logger.error(ValueError(error_msg))
 
 
 def _validate_file_path(
@@ -78,8 +75,7 @@ def _validate_file_path(
             expected_suffix=expected_suffix,
         )
     except (OSError, ValueError) as error:
-        logger.error(error)
-        raise error
+        raise logger.error(error) from error
     return file
 
 

--- a/movement/io/save_boxes.py
+++ b/movement/io/save_boxes.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 class Bboxes:
     """Container for bounding box coordinates in various formats.
-    
+
     Parameters
     ----------
     coordinates : list or np.ndarray
@@ -32,14 +32,14 @@ class Bboxes:
 
     def convert(self, target_format: str, inplace: bool = False) -> "Bboxes":
         """Convert coordinates to target format.
-        
+
         Parameters
         ----------
         target_format : str
             Desired output format ('xyxy' or 'xywh')
         inplace : bool, optional
             Whether to modify the current instance
-            
+
         Returns
         -------
         Bboxes
@@ -48,28 +48,27 @@ class Bboxes:
         """
         if self.format == target_format:
             return self
-            
+
         if self.format == "xywh" and target_format == "xyxy":
             converted = []
             for box in self.coordinates:
                 x, y, w, h = box
                 converted.append([x, y, x + w, y + h])
             new_coords = np.array(converted)
-            
+
             if inplace:
                 self.coordinates = new_coords
                 self.format = target_format
                 return self
             return Bboxes(new_coords, target_format)
-            
+
         raise ValueError(
             f"Unsupported conversion: {self.format} -> {target_format}"
         )
 
 
 def _validate_file_path(
-    file_path: str | Path, 
-    expected_suffix: Sequence[str]
+    file_path: str | Path, expected_suffix: Sequence[str]
 ) -> Path:
     """Validate and normalize file paths."""
     path = Path(file_path).resolve()
@@ -88,7 +87,7 @@ def to_via_tracks_file(
     video_metadata: dict | None = None,
 ) -> None:
     """Save bounding boxes to VIA-tracks format.
-    
+
     Parameters
     ----------
     boxes : Bboxes or dict[int, Bboxes]
@@ -100,7 +99,7 @@ def to_via_tracks_file(
 
     """
     file = _validate_file_path(file_path, [".json"])
-    
+
     # Set default metadata
     video_metadata = video_metadata or {
         "filename": "unknown_video.mp4",
@@ -112,12 +111,12 @@ def to_via_tracks_file(
     via_data = {
         "_via_settings": {
             "ui": {"file_content_align": "center"},
-            "core": {"buffer_size": 18, "filepath": {}}
+            "core": {"buffer_size": 18, "filepath": {}},
         },
         "_via_data_format_version": "2.0.10",
         "_via_image_id_list": [],
         "_via_attributes": {"region": {}, "file": {}},
-        "_via_data": {"metadata": {}, "vid_list": {}, "cache": {}}
+        "_via_data": {"metadata": {}, "vid_list": {}, "cache": {}},
     }
 
     vid = str(uuid.uuid4())
@@ -140,7 +139,7 @@ def to_via_tracks_file(
         fid = str(frame_idx)
         via_data["_via_data"]["vid_list"][vid]["fid_list"].append(fid)
         mid = f"{vid}_{fid}"
-        
+
         via_data["_via_data"]["metadata"][mid] = {
             "vid": vid,
             "flg": 0,
@@ -157,9 +156,9 @@ def to_via_tracks_file(
                     "x": float(x1),
                     "y": float(y1),
                     "width": float(x2 - x1),
-                    "height": float(y2 - y1)
+                    "height": float(y2 - y1),
                 },
-                "region_attributes": {"id": i}
+                "region_attributes": {"id": i},
             }
             via_data["_via_data"]["metadata"][mid]["xy"].append(region)
 

--- a/tests/test_unit/test_via_tracks.py
+++ b/tests/test_unit/test_via_tracks.py
@@ -1,378 +1,385 @@
-"""Unit tests for the VIA-tracks file export functionality."""
+"""tests for the VIA-tracks file export functionality."""
 
 import json
 import os
 import tempfile
 import time
-import unittest
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import pytest
 import xarray as xr
 
 from movement.io.save_boxes import to_via_tracks_file
 
 
-class TestVIATracksExport(unittest.TestCase):
-    """Test suite for exporting bounding boxes to VIA-tracks CSV format."""
-
-    def setUp(self):
-        """Set up test data with a sample bounding boxes dataset."""
-        # Create a sample dataset for testing
-        n_frames = 5
-        n_individuals = 2
-
-        # Create sample position and shape data
-        self.dataset = xr.Dataset(
-            {
-                "position": (
-                    ("time", "space", "individuals"),
-                    np.random.rand(n_frames, 2, n_individuals),
-                ),
-                "shape": (
-                    ("time", "space", "individuals"),
-                    np.random.rand(n_frames, 2, n_individuals),
-                ),
-                "confidence": (
-                    ("time", "individuals"),
-                    np.ones((n_frames, n_individuals)),  # confidence scores
-                ),
-            },
-            coords={
-                "time": np.arange(n_frames),
-                "space": ["x", "y"],
-                "individuals": [f"id_{i}" for i in range(n_individuals)],
-            },
-        )
-
-    def tearDown(self):
-        """Clean up temporary files after each test."""
-        # Clean up any temporary files that might have been left behind
-        for file in os.listdir(tempfile.gettempdir()):
-            if file.endswith(".csv") and file.startswith("tmp"):
-                try:
-                    file_path = os.path.join(tempfile.gettempdir(), file)
-                    # Try to delete the file with a small delay
-                    for _ in range(3):  # Try up to 3 times
-                        try:
-                            os.unlink(file_path)
-                            break
-                        except PermissionError:
-                            time.sleep(0.1)  # Wait 0.1 seconds before retrying
-                except OSError:
-                    pass
-
-    def test_invalid_dataset_type(self):
-        """Test that invalid dataset types raise TypeError."""
-        with self.assertRaises(TypeError):
-            to_via_tracks_file("not a dataset", "test.csv")
-
-    def test_missing_required_variables(self):
-        """Test that missing required variables raise ValueError."""
-        # Create dataset without confidence variable
-        invalid_ds = xr.Dataset(
-            {
-                "position": (
-                    ("time", "space", "individuals"),
-                    np.random.rand(5, 2, 2),
-                ),
-                "shape": (
-                    ("time", "space", "individuals"),
-                    np.random.rand(5, 2, 2),
-                ),
-            },
-            coords={
-                "time": np.arange(5),
-                "space": ["x", "y"],
-                "individuals": ["id_0", "id_1"],
-            },
-        )
-        with self.assertRaises(ValueError) as cm:
-            to_via_tracks_file(invalid_ds, "test.csv")
-        self.assertIn("Missing required data variables", str(cm.exception))
-
-    def test_missing_required_dimensions(self):
-        """Test that missing required dimensions raise ValueError."""
-        # Create dataset without 'individuals' dimension
-        invalid_ds = xr.Dataset(
-            {
-                "position": (
-                    ("time", "space"),
-                    np.random.rand(5, 2),
-                ),
-                "shape": (
-                    ("time", "space"),
-                    np.random.rand(5, 2),
-                ),
-                "confidence": (
-                    ("time",),
-                    np.ones(5),
-                ),
-            },
-            coords={
-                "time": np.arange(5),
-                "space": ["x", "y"],
-            },
-        )
-        with self.assertRaises(ValueError) as cm:
-            to_via_tracks_file(invalid_ds, "test.csv")
-        self.assertIn("Missing required dimensions", str(cm.exception))
-
-    def test_invalid_file_extension(self):
-        """Test that invalid file extensions raise ValueError."""
-        with self.assertRaises(ValueError):
-            to_via_tracks_file(self.dataset, "test.txt")
-
-    def test_empty_dataset(self):
-        """Test handling of empty dataset."""
-        empty_ds = xr.Dataset(
-            {
-                "position": (
-                    ("time", "space", "individuals"),
-                    np.zeros((0, 2, 0)),
-                ),
-                "shape": (
-                    ("time", "space", "individuals"),
-                    np.zeros((0, 2, 0)),
-                ),
-                "confidence": (
-                    ("time", "individuals"),
-                    np.zeros((0, 0)),
-                ),
-            },
-            coords={
-                "time": np.array([], dtype=int),
-                "space": ["x", "y"],
-                "individuals": [],
-            },
-        )
-        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
-            tmp_path = tmp.name
-            tmp.close()  # Close the file handle immediately
-
-        # Ensure the file doesn't exist
-        if os.path.exists(tmp_path):
+def _cleanup_temp_csv_files():
+    """Clean up temporary CSV files in the temp directory."""
+    for file in os.listdir(tempfile.gettempdir()):
+        if file.endswith(".csv") and file.startswith("tmp"):
             try:
-                os.unlink(tmp_path)
-            except PermissionError:
-                time.sleep(0.1)
-                os.unlink(tmp_path)
+                file_path = os.path.join(tempfile.gettempdir(), file)
+                for _ in range(3):  # Try up to 3 times
+                    try:
+                        os.unlink(file_path)
+                        break
+                    except PermissionError:
+                        time.sleep(0.1)
+            except OSError:
+                pass
 
-        output_path = to_via_tracks_file(empty_ds, tmp_path)
-        df = pd.read_csv(output_path)
-        self.assertEqual(len(df), 0)
 
-        # Clean up
+@pytest.fixture
+def dataset():
+    """Set up test data with a sample bounding boxes dataset."""
+    n_frames = 5
+    n_individuals = 2
+
+    # Create sample position and shape data
+    return xr.Dataset(
+        {
+            "position": (
+                ("time", "space", "individuals"),
+                np.random.rand(n_frames, 2, n_individuals),
+            ),
+            "shape": (
+                ("time", "space", "individuals"),
+                np.random.rand(n_frames, 2, n_individuals),
+            ),
+            "confidence": (
+                ("time", "individuals"),
+                np.ones((n_frames, n_individuals)),  # confidence scores
+            ),
+        },
+        coords={
+            "time": np.arange(n_frames),
+            "space": ["x", "y"],
+            "individuals": [f"id_{i}" for i in range(n_individuals)],
+        },
+    )
+
+
+@pytest.fixture(autouse=True)
+def cleanup_temp_files():
+    """Clean up temporary files before and after each test."""
+    _cleanup_temp_csv_files()
+    yield
+    _cleanup_temp_csv_files()
+
+
+def test_invalid_dataset_type():
+    """Test that invalid dataset types raise TypeError."""
+    with pytest.raises(TypeError):
+        to_via_tracks_file("not a dataset", "test.csv")
+
+
+def test_missing_required_variables():
+    """Test that missing required variables raise ValueError."""
+    # Create dataset without confidence variable
+    invalid_ds = xr.Dataset(
+        {
+            "position": (
+                ("time", "space", "individuals"),
+                np.random.rand(5, 2, 2),
+            ),
+            "shape": (
+                ("time", "space", "individuals"),
+                np.random.rand(5, 2, 2),
+            ),
+        },
+        coords={
+            "time": np.arange(5),
+            "space": ["x", "y"],
+            "individuals": ["id_0", "id_1"],
+        },
+    )
+    with pytest.raises(ValueError) as exc_info:
+        to_via_tracks_file(invalid_ds, "test.csv")
+    assert "Missing required data variables" in str(exc_info.value)
+
+
+def test_missing_required_dimensions():
+    """Test that missing required dimensions raise ValueError."""
+    # Create dataset without 'individuals' dimension
+    invalid_ds = xr.Dataset(
+        {
+            "position": (
+                ("time", "space"),
+                np.random.rand(5, 2),
+            ),
+            "shape": (
+                ("time", "space"),
+                np.random.rand(5, 2),
+            ),
+            "confidence": (
+                ("time",),
+                np.ones(5),
+            ),
+        },
+        coords={
+            "time": np.arange(5),
+            "space": ["x", "y"],
+        },
+    )
+    with pytest.raises(ValueError) as exc_info:
+        to_via_tracks_file(invalid_ds, "test.csv")
+    assert "Missing required dimensions" in str(exc_info.value)
+
+
+def test_invalid_file_extension(dataset):
+    """Test that invalid file extensions raise ValueError."""
+    with pytest.raises(ValueError):
+        to_via_tracks_file(dataset, "test.txt")
+
+
+def test_empty_dataset():
+    """Test handling of empty dataset."""
+    empty_ds = xr.Dataset(
+        {
+            "position": (
+                ("time", "space", "individuals"),
+                np.zeros((0, 2, 0)),
+            ),
+            "shape": (
+                ("time", "space", "individuals"),
+                np.zeros((0, 2, 0)),
+            ),
+            "confidence": (
+                ("time", "individuals"),
+                np.zeros((0, 0)),
+            ),
+        },
+        coords={
+            "time": np.array([], dtype=int),
+            "space": ["x", "y"],
+            "individuals": [],
+        },
+    )
+    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+        tmp_path = tmp.name
+        tmp.close()  # Close the file handle immediately
+
+    # Ensure the file doesn't exist
+    if os.path.exists(tmp_path):
         try:
-            os.unlink(output_path)
+            os.unlink(tmp_path)
         except PermissionError:
             time.sleep(0.1)
-            os.unlink(output_path)
+            os.unlink(tmp_path)
 
-    def test_all_nan_values(self):
-        """Test handling of dataset with all NaN values."""
-        nan_ds = xr.Dataset(
-            {
-                "position": (
-                    ("time", "space", "individuals"),
-                    np.full((5, 2, 2), np.nan),
-                ),
-                "shape": (
-                    ("time", "space", "individuals"),
-                    np.full((5, 2, 2), np.nan),
-                ),
-                "confidence": (
-                    ("time", "individuals"),
-                    np.full((5, 2), np.nan),
-                ),
-            },
-            coords={
-                "time": np.arange(5),
-                "space": ["x", "y"],
-                "individuals": ["id_0", "id_1"],
-            },
-        )
-        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
-            tmp_path = tmp.name
-            tmp.close()  # Close the file handle immediately
+    output_path = to_via_tracks_file(empty_ds, tmp_path)
+    df = pd.read_csv(output_path)
+    assert len(df) == 0
 
-        # Ensure the file doesn't exist
-        if os.path.exists(tmp_path):
-            try:
-                os.unlink(tmp_path)
-            except PermissionError:
-                time.sleep(0.1)
-                os.unlink(tmp_path)
+    # Clean up
+    try:
+        os.unlink(output_path)
+    except PermissionError:
+        time.sleep(0.1)
+        os.unlink(output_path)
 
-        output_path = to_via_tracks_file(nan_ds, tmp_path)
-        df = pd.read_csv(output_path)
-        self.assertEqual(len(df), 0)  # Should skip all rows with NaN values
 
-        # Clean up
+def test_all_nan_values():
+    """Test handling of dataset with all NaN values."""
+    nan_ds = xr.Dataset(
+        {
+            "position": (
+                ("time", "space", "individuals"),
+                np.full((5, 2, 2), np.nan),
+            ),
+            "shape": (
+                ("time", "space", "individuals"),
+                np.full((5, 2, 2), np.nan),
+            ),
+            "confidence": (
+                ("time", "individuals"),
+                np.full((5, 2), np.nan),
+            ),
+        },
+        coords={
+            "time": np.arange(5),
+            "space": ["x", "y"],
+            "individuals": ["id_0", "id_1"],
+        },
+    )
+    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+        tmp_path = tmp.name
+        tmp.close()  # Close the file handle immediately
+
+    # Ensure the file doesn't exist
+    if os.path.exists(tmp_path):
         try:
-            os.unlink(output_path)
+            os.unlink(tmp_path)
         except PermissionError:
             time.sleep(0.1)
-            os.unlink(output_path)
+            os.unlink(tmp_path)
 
-    def test_file_creation(self):
-        """Test that the VIA-tracks CSV file is created successfully."""
-        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
-            tmp_path = tmp.name
+    output_path = to_via_tracks_file(nan_ds, tmp_path)
+    df = pd.read_csv(output_path)
+    assert len(df) == 0  # Should skip all rows with NaN values
 
-        # Ensure the file doesn't exist
-        if os.path.exists(tmp_path):
-            try:
-                os.unlink(tmp_path)
-            except PermissionError:
-                time.sleep(0.1)  # Wait a bit and try again
-                os.unlink(tmp_path)
+    # Clean up
+    try:
+        os.unlink(output_path)
+    except PermissionError:
+        time.sleep(0.1)
+        os.unlink(output_path)
 
-        output_path = to_via_tracks_file(self.dataset, tmp_path)
-        self.assertTrue(os.path.exists(output_path))
 
-        # Close any open file handles and delete
+def test_file_creation(dataset):
+    """Test that the VIA-tracks CSV file is created successfully."""
+    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+        tmp_path = tmp.name
+
+    # Ensure the file doesn't exist
+    if os.path.exists(tmp_path):
         try:
-            os.unlink(output_path)
+            os.unlink(tmp_path)
+        except PermissionError:
+            time.sleep(0.1)  # Wait a bit and try again
+            os.unlink(tmp_path)
+
+    output_path = to_via_tracks_file(dataset, tmp_path)
+    assert os.path.exists(output_path)
+
+    # Close any open file handles and delete
+    try:
+        os.unlink(output_path)
+    except PermissionError:
+        time.sleep(0.1)
+        os.unlink(output_path)
+
+
+def test_file_content(dataset):
+    """Test that the VIA-tracks CSV file contains the correct data."""
+    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+        tmp_path = tmp.name
+
+    # Ensure the file doesn't exist
+    if os.path.exists(tmp_path):
+        try:
+            os.unlink(tmp_path)
         except PermissionError:
             time.sleep(0.1)
-            os.unlink(output_path)
+            os.unlink(tmp_path)
 
-    def test_file_content(self):
-        """Test that the VIA-tracks CSV file contains the correct data."""
-        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
-            tmp_path = tmp.name
+    output_path = to_via_tracks_file(dataset, tmp_path, video_id="test_video")
 
-        # Ensure the file doesn't exist
-        if os.path.exists(tmp_path):
-            try:
-                os.unlink(tmp_path)
-            except PermissionError:
-                time.sleep(0.1)
-                os.unlink(tmp_path)
+    df = pd.read_csv(output_path)
 
-        output_path = to_via_tracks_file(
-            self.dataset, tmp_path, video_id="test_video"
-        )
+    assert len(df) == 10  # 5 times * 2 individuals
+    assert list(df.columns) == [
+        "filename",
+        "file_size",
+        "file_attributes",
+        "region_count",
+        "region_id",
+        "region_shape_attributes",
+        "region_attributes",
+    ]
 
-        df = pd.read_csv(output_path)
+    # Check a sample row
+    sample_row = df.iloc[0]
+    assert sample_row["filename"].startswith("test_video_")
+    assert sample_row["file_size"] == 0
+    assert sample_row["file_attributes"] == "{}"
+    assert sample_row["region_count"] == 1
+    assert sample_row["region_id"] == 0
 
-        self.assertEqual(len(df), 10)  # 5 times * 2 individuals
-        self.assertEqual(
-            list(df.columns),
-            [
-                "filename",
-                "file_size",
-                "file_attributes",
-                "region_count",
-                "region_id",
-                "region_shape_attributes",
-                "region_attributes",
-            ],
-        )
+    # Check region_shape_attributes
+    shape_attrs = json.loads(sample_row["region_shape_attributes"])
+    assert shape_attrs["name"] == "rect"
+    assert "x" in shape_attrs
+    assert "y" in shape_attrs
+    assert "width" in shape_attrs
+    assert "height" in shape_attrs
 
-        # Check a sample row
-        sample_row = df.iloc[0]
-        self.assertTrue(sample_row["filename"].startswith("test_video_"))
-        self.assertEqual(sample_row["file_size"], 0)
-        self.assertEqual(sample_row["file_attributes"], "{}")
-        self.assertEqual(sample_row["region_count"], 1)
-        self.assertEqual(sample_row["region_id"], 0)
+    # Check region_attributes
+    region_attrs = json.loads(sample_row["region_attributes"])
+    assert "track" in region_attrs
+    assert region_attrs["track"] in dataset.individuals.values
 
-        # Check region_shape_attributes
-        shape_attrs = json.loads(sample_row["region_shape_attributes"])
-        self.assertEqual(shape_attrs["name"], "rect")
-        self.assertIn("x", shape_attrs)
-        self.assertIn("y", shape_attrs)
-        self.assertIn("width", shape_attrs)
-        self.assertIn("height", shape_attrs)
+    # Close any open file handles and delete
+    try:
+        os.unlink(output_path)
+    except PermissionError:
+        time.sleep(0.1)
+        os.unlink(output_path)
 
-        # Check region_attributes
-        region_attrs = json.loads(sample_row["region_attributes"])
-        self.assertIn("track", region_attrs)
-        self.assertIn(region_attrs["track"], self.dataset.individuals.values)
 
-        # Close any open file handles and delete
+def test_missing_data_handling(dataset):
+    """Test that NaN values in the dataset are handled correctly."""
+    # Create a dataset with some NaN values
+    dataset["position"][0, 0, :] = (
+        np.nan
+    )  # Setting NaN for x-coordinate at time 0 for all individuals
+
+    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+        tmp_path = tmp.name
+
+    # Ensure the file doesn't exist
+    if os.path.exists(tmp_path):
         try:
-            os.unlink(output_path)
+            os.unlink(tmp_path)
         except PermissionError:
             time.sleep(0.1)
-            os.unlink(output_path)
+            os.unlink(tmp_path)
 
-    def test_missing_data_handling(self):
-        """Test that NaN values in the dataset are handled correctly."""
-        # Create a dataset with some NaN values
-        self.dataset["position"][0, 0, :] = (
-            np.nan
-        )  # Setting NaN for x-coordinate at time 0 for all individuals
+    output_path = to_via_tracks_file(dataset, tmp_path)
 
-        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
-            tmp_path = tmp.name
+    df = pd.read_csv(output_path)
 
-        # Ensure the file doesn't exist
-        if os.path.exists(tmp_path):
-            try:
-                os.unlink(tmp_path)
-            except PermissionError:
-                time.sleep(0.1)
-                os.unlink(tmp_path)
+    # Let's calculate the expected number of rows:
+    # Original dataset: 5 frames * 2 individuals = 10 rows
+    # We set NaN for time 0, both individuals, so we lose 2 rows
+    assert len(df) == 8
 
-        output_path = to_via_tracks_file(self.dataset, tmp_path)
+    # Close any open file handles and delete
+    try:
+        os.unlink(output_path)
+    except PermissionError:
+        time.sleep(0.1)
+        os.unlink(output_path)
 
-        df = pd.read_csv(output_path)
 
-        # Let's calculate the expected number of rows:
-        # Original dataset: 5 frames * 2 individuals = 10 rows
-        # We set NaN for time 0, both individuals, so we lose 2 rows
-        self.assertEqual(len(df), 8)
+def test_video_id_handling(dataset):
+    """Test different video_id formats and handling."""
+    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+        tmp_path = tmp.name
+        tmp.close()  # Close the file handle immediately
 
-        # Close any open file handles and delete
+    # Ensure the file doesn't exist
+    if os.path.exists(tmp_path):
         try:
-            os.unlink(output_path)
+            os.unlink(tmp_path)
         except PermissionError:
             time.sleep(0.1)
-            os.unlink(output_path)
+            os.unlink(tmp_path)
 
-    def test_video_id_handling(self):
-        """Test different video_id formats and handling."""
-        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
-            tmp_path = tmp.name
-            tmp.close()  # Close the file handle immediately
+    # Test with custom video_id
+    output_path = to_via_tracks_file(
+        dataset, tmp_path, video_id="custom_video_123"
+    )
+    df = pd.read_csv(output_path)
+    assert df["filename"].iloc[0].startswith("custom_video_123_")
 
-        # Ensure the file doesn't exist
-        if os.path.exists(tmp_path):
-            try:
-                os.unlink(tmp_path)
-            except PermissionError:
-                time.sleep(0.1)
-                os.unlink(tmp_path)
+    # Clean up first file
+    try:
+        os.unlink(output_path)
+    except PermissionError:
+        time.sleep(0.1)
+        os.unlink(output_path)
 
-        # Test with custom video_id
-        output_path = to_via_tracks_file(
-            self.dataset, tmp_path, video_id="custom_video_123"
-        )
-        df = pd.read_csv(output_path)
-        self.assertTrue(df["filename"].iloc[0].startswith("custom_video_123_"))
+    # Test with default video_id (should use filename)
+    output_path = to_via_tracks_file(dataset, tmp_path)
+    df = pd.read_csv(output_path)
+    expected_prefix = Path(tmp_path).stem
+    assert df["filename"].iloc[0].startswith(f"{expected_prefix}_")
 
-        # Clean up first file
-        try:
-            os.unlink(output_path)
-        except PermissionError:
-            time.sleep(0.1)
-            os.unlink(output_path)
-
-        # Test with default video_id (should use filename)
-        output_path = to_via_tracks_file(self.dataset, tmp_path)
-        df = pd.read_csv(output_path)
-        expected_prefix = Path(tmp_path).stem
-        self.assertTrue(
-            df["filename"].iloc[0].startswith(f"{expected_prefix}_")
-        )
-
-        # Clean up second file
-        try:
-            os.unlink(output_path)
-        except PermissionError:
-            time.sleep(0.1)
-            os.unlink(output_path)
+    # Clean up second file
+    try:
+        os.unlink(output_path)
+    except PermissionError:
+        time.sleep(0.1)
+        os.unlink(output_path)

--- a/tests/test_unit/test_via_tracks.py
+++ b/tests/test_unit/test_via_tracks.py
@@ -1,183 +1,378 @@
-"""Unit tests for VIA-tracks export functionality."""
+"""Unit tests for the VIA-tracks file export functionality."""
 
 import json
-import logging
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
 
 import numpy as np
-import pytest
+import pandas as pd
+import xarray as xr
 
 from movement.io.save_boxes import to_via_tracks_file
 
 
-class MockBboxes:
-    """Test double for bounding box container class."""
+class TestVIATracksExport(unittest.TestCase):
+    """Test suite for exporting bounding boxes to VIA-tracks CSV format."""
 
-    def __init__(self, coordinates: list | np.ndarray, format: str):
-        """Initialize mock bounding boxes.
+    def setUp(self):
+        """Set up test data with a sample bounding boxes dataset."""
+        # Create a sample dataset for testing
+        n_frames = 5
+        n_individuals = 2
 
-        Parameters
-        ----------
-        coordinates : list or np.ndarray
-            Array of bounding box coordinates in specified format
-        format : str
-            Coordinate format specification (e.g., 'xyxy', 'xywh')
-
-        """
-        self.coordinates = np.array(coordinates)
-        self.format = format
-
-    def convert(
-        self, target_format: str, inplace: bool = False
-    ) -> "MockBboxes":
-        """Mock format conversion logic.
-
-        Parameters
-        ----------
-        target_format : str
-            Target coordinate format
-        inplace : bool, optional
-            Whether to modify the current instance
-
-        Returns
-        -------
-        MockBboxes
-            Converted bounding boxes
-
-        """
-        if self.format == target_format:
-            return self
-        if self.format == "xywh" and target_format == "xyxy":
-            converted = []
-            for box in self.coordinates:
-                x, y, w, h = box
-                converted.append([x, y, x + w, y + h])
-            new_coords = np.array(converted)
-            if inplace:
-                self.coordinates = new_coords
-                self.format = target_format
-                return self
-            return MockBboxes(new_coords, target_format)
-        raise ValueError(
-            f"Unsupported conversion: {self.format}->{target_format}"
+        # Create sample position and shape data
+        self.dataset = xr.Dataset(
+            {
+                "position": (
+                    ("time", "space", "individuals"),
+                    np.random.rand(n_frames, 2, n_individuals),
+                ),
+                "shape": (
+                    ("time", "space", "individuals"),
+                    np.random.rand(n_frames, 2, n_individuals),
+                ),
+                "confidence": (
+                    ("time", "individuals"),
+                    np.ones((n_frames, n_individuals)),  # confidence scores
+                ),
+            },
+            coords={
+                "time": np.arange(n_frames),
+                "space": ["x", "y"],
+                "individuals": [f"id_{i}" for i in range(n_individuals)],
+            },
         )
 
+    def tearDown(self):
+        """Clean up temporary files after each test."""
+        # Clean up any temporary files that might have been left behind
+        for file in os.listdir(tempfile.gettempdir()):
+            if file.endswith(".csv") and file.startswith("tmp"):
+                try:
+                    file_path = os.path.join(tempfile.gettempdir(), file)
+                    # Try to delete the file with a small delay
+                    for _ in range(3):  # Try up to 3 times
+                        try:
+                            os.unlink(file_path)
+                            break
+                        except PermissionError:
+                            time.sleep(0.1)  # Wait 0.1 seconds before retrying
+                except OSError:
+                    pass
 
-class TestVIATracksExport:
-    """Test suite for VIA-tracks export functionality."""
+    def test_invalid_dataset_type(self):
+        """Test that invalid dataset types raise TypeError."""
+        with self.assertRaises(TypeError):
+            to_via_tracks_file("not a dataset", "test.csv")
 
-    @pytest.fixture
-    def sample_boxes_xyxy(self):
-        """Provide sample boxes in xyxy format."""
-        return MockBboxes([[10, 20, 50, 60]], format="xyxy")
+    def test_missing_required_variables(self):
+        """Test that missing required variables raise ValueError."""
+        # Create dataset without confidence variable
+        invalid_ds = xr.Dataset(
+            {
+                "position": (
+                    ("time", "space", "individuals"),
+                    np.random.rand(5, 2, 2),
+                ),
+                "shape": (
+                    ("time", "space", "individuals"),
+                    np.random.rand(5, 2, 2),
+                ),
+            },
+            coords={
+                "time": np.arange(5),
+                "space": ["x", "y"],
+                "individuals": ["id_0", "id_1"],
+            },
+        )
+        with self.assertRaises(ValueError) as cm:
+            to_via_tracks_file(invalid_ds, "test.csv")
+        self.assertIn("Missing required data variables", str(cm.exception))
 
-    @pytest.fixture
-    def sample_boxes_xywh(self):
-        """Provide sample boxes in xywh format for conversion testing."""
-        return MockBboxes([[10, 20, 40, 40]], format="xywh")
+    def test_missing_required_dimensions(self):
+        """Test that missing required dimensions raise ValueError."""
+        # Create dataset without 'individuals' dimension
+        invalid_ds = xr.Dataset(
+            {
+                "position": (
+                    ("time", "space"),
+                    np.random.rand(5, 2),
+                ),
+                "shape": (
+                    ("time", "space"),
+                    np.random.rand(5, 2),
+                ),
+                "confidence": (
+                    ("time",),
+                    np.ones(5),
+                ),
+            },
+            coords={
+                "time": np.arange(5),
+                "space": ["x", "y"],
+            },
+        )
+        with self.assertRaises(ValueError) as cm:
+            to_via_tracks_file(invalid_ds, "test.csv")
+        self.assertIn("Missing required dimensions", str(cm.exception))
 
-    @pytest.fixture
-    def multi_frame_boxes(self):
-        """Provide multi-frame box data as dictionary."""
-        return {
-            0: MockBboxes([[10, 20, 50, 60]], "xyxy"),
-            1: MockBboxes([[30, 40, 70, 80]], "xyxy"),
-        }
+    def test_invalid_file_extension(self):
+        """Test that invalid file extensions raise ValueError."""
+        with self.assertRaises(ValueError):
+            to_via_tracks_file(self.dataset, "test.txt")
 
-    @pytest.fixture
-    def video_metadata(self):
-        """Provide standard video metadata for testing."""
-        return {
-            "filename": "test_video.mp4",
-            "width": 1280,
-            "height": 720,
-            "size": 1024000,
-        }
+    def test_empty_dataset(self):
+        """Test handling of empty dataset."""
+        empty_ds = xr.Dataset(
+            {
+                "position": (
+                    ("time", "space", "individuals"),
+                    np.zeros((0, 2, 0)),
+                ),
+                "shape": (
+                    ("time", "space", "individuals"),
+                    np.zeros((0, 2, 0)),
+                ),
+                "confidence": (
+                    ("time", "individuals"),
+                    np.zeros((0, 0)),
+                ),
+            },
+            coords={
+                "time": np.array([], dtype=int),
+                "space": ["x", "y"],
+                "individuals": [],
+            },
+        )
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+            tmp_path = tmp.name
+            tmp.close()  # Close the file handle immediately
 
-    def test_basic_export(self, tmp_path, sample_boxes_xyxy, video_metadata):
-        """Verify successful export with valid inputs and metadata."""
-        output_file = tmp_path / "output.json"
-        to_via_tracks_file(sample_boxes_xyxy, output_file, video_metadata)
+        # Ensure the file doesn't exist
+        if os.path.exists(tmp_path):
+            try:
+                os.unlink(tmp_path)
+            except PermissionError:
+                time.sleep(0.1)
+                os.unlink(tmp_path)
 
-        assert output_file.exists()
-        with open(output_file) as f:
-            data = json.load(f)
-            assert "_via_data" in data
-            videos = data["_via_data"]["vid_list"]
-            assert len(videos) == 1
-            assert videos[list(videos.keys())[0]]["width"] == 1280
+        output_path = to_via_tracks_file(empty_ds, tmp_path)
+        df = pd.read_csv(output_path)
+        self.assertEqual(len(df), 0)
 
-    def test_file_validation(self, tmp_path, sample_boxes_xyxy):
-        """Test file path validation and error handling."""
-        # Valid JSON path
-        valid_path = tmp_path / "valid.json"
-        to_via_tracks_file(sample_boxes_xyxy, valid_path)
+        # Clean up
+        try:
+            os.unlink(output_path)
+        except PermissionError:
+            time.sleep(0.1)
+            os.unlink(output_path)
 
-        # Invalid extension
-        invalid_path = tmp_path / "invalid.txt"
-        with pytest.raises(ValueError) as exc_info:
-            to_via_tracks_file(sample_boxes_xyxy, invalid_path)
-        assert "Invalid file extension" in str(exc_info.value)
+    def test_all_nan_values(self):
+        """Test handling of dataset with all NaN values."""
+        nan_ds = xr.Dataset(
+            {
+                "position": (
+                    ("time", "space", "individuals"),
+                    np.full((5, 2, 2), np.nan),
+                ),
+                "shape": (
+                    ("time", "space", "individuals"),
+                    np.full((5, 2, 2), np.nan),
+                ),
+                "confidence": (
+                    ("time", "individuals"),
+                    np.full((5, 2), np.nan),
+                ),
+            },
+            coords={
+                "time": np.arange(5),
+                "space": ["x", "y"],
+                "individuals": ["id_0", "id_1"],
+            },
+        )
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+            tmp_path = tmp.name
+            tmp.close()  # Close the file handle immediately
 
-    def test_auto_metadata(self, tmp_path, sample_boxes_xyxy):
-        """Verify default metadata generation when none is provided."""
-        output_file = tmp_path / "output.json"
-        to_via_tracks_file(sample_boxes_xyxy, output_file)
+        # Ensure the file doesn't exist
+        if os.path.exists(tmp_path):
+            try:
+                os.unlink(tmp_path)
+            except PermissionError:
+                time.sleep(0.1)
+                os.unlink(tmp_path)
 
-        with open(output_file) as f:
-            data = json.load(f)
-            vid = list(data["_via_data"]["vid_list"].keys())[0]
-            assert (
-                data["_via_data"]["vid_list"][vid]["filepath"]
-                == "unknown_video.mp4"
-            )
+        output_path = to_via_tracks_file(nan_ds, tmp_path)
+        df = pd.read_csv(output_path)
+        self.assertEqual(len(df), 0)  # Should skip all rows with NaN values
 
-    def test_format_conversion(self, tmp_path, sample_boxes_xywh):
-        """Test automatic conversion from xywh to xyxy format."""
-        output_file = tmp_path / "converted.json"
-        to_via_tracks_file(sample_boxes_xywh, output_file)
+        # Clean up
+        try:
+            os.unlink(output_path)
+        except PermissionError:
+            time.sleep(0.1)
+            os.unlink(output_path)
 
-        with open(output_file) as f:
-            data = json.load(f)
-            region = data["_via_data"]["metadata"][
-                list(data["_via_data"]["metadata"].keys())[0]
-            ]["xy"][0]["shape_attributes"]
-            assert abs(region["width"] - 40.0) < 1e-6
+    def test_file_creation(self):
+        """Test that the VIA-tracks CSV file is created successfully."""
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+            tmp_path = tmp.name
 
-    def test_multi_frame_export(self, tmp_path, multi_frame_boxes):
-        """Verify correct handling of multi-frame input dictionaries."""
-        output_file = tmp_path / "multi_frame.json"
-        to_via_tracks_file(multi_frame_boxes, output_file)
+        # Ensure the file doesn't exist
+        if os.path.exists(tmp_path):
+            try:
+                os.unlink(tmp_path)
+            except PermissionError:
+                time.sleep(0.1)  # Wait a bit and try again
+                os.unlink(tmp_path)
 
-        with open(output_file) as f:
-            data = json.load(f)
-            vid = list(data["_via_data"]["vid_list"].keys())[0]
-            assert len(data["_via_data"]["vid_list"][vid]["fid_list"]) == 2
+        output_path = to_via_tracks_file(self.dataset, tmp_path)
+        self.assertTrue(os.path.exists(output_path))
 
-    def test_edge_cases(self, tmp_path):
-        """Test handling of edge case values and empty inputs."""
-        # Zero-size boxes
-        output_file = tmp_path / "edge_cases.json"
-        boxes = MockBboxes([[0, 0, 0, 0]], "xyxy")
-        to_via_tracks_file(boxes, output_file)
+        # Close any open file handles and delete
+        try:
+            os.unlink(output_path)
+        except PermissionError:
+            time.sleep(0.1)
+            os.unlink(output_path)
 
-        with open(output_file) as f:
-            data = json.load(f)
-            region = data["_via_data"]["metadata"][
-                list(data["_via_data"]["metadata"].keys())[0]
-            ]["xy"][0]["shape_attributes"]
-            assert abs(region["width"] - 0.0) < 1e-6
+    def test_file_content(self):
+        """Test that the VIA-tracks CSV file contains the correct data."""
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+            tmp_path = tmp.name
 
-    def test_logging(self, caplog, tmp_path, sample_boxes_xyxy):
-        """Verify proper logging of export operations."""
-        output_file = tmp_path / "logging_test.json"
-        with caplog.at_level(logging.INFO):
-            to_via_tracks_file(sample_boxes_xyxy, output_file)
-            assert "Saved bounding boxes" in caplog.text
-            assert str(output_file) in caplog.text
+        # Ensure the file doesn't exist
+        if os.path.exists(tmp_path):
+            try:
+                os.unlink(tmp_path)
+            except PermissionError:
+                time.sleep(0.1)
+                os.unlink(tmp_path)
 
-    def test_error_handling(self, tmp_path):
-        """Test proper error reporting for invalid inputs."""
-        # Invalid box format
-        invalid_boxes = MockBboxes([[10, 20, 50]], "invalid_format")
-        with pytest.raises(ValueError):
-            to_via_tracks_file(invalid_boxes, tmp_path / "test.json")
+        output_path = to_via_tracks_file(
+            self.dataset, tmp_path, video_id="test_video"
+        )
+
+        df = pd.read_csv(output_path)
+
+        self.assertEqual(len(df), 10)  # 5 times * 2 individuals
+        self.assertEqual(
+            list(df.columns),
+            [
+                "filename",
+                "file_size",
+                "file_attributes",
+                "region_count",
+                "region_id",
+                "region_shape_attributes",
+                "region_attributes",
+            ],
+        )
+
+        # Check a sample row
+        sample_row = df.iloc[0]
+        self.assertTrue(sample_row["filename"].startswith("test_video_"))
+        self.assertEqual(sample_row["file_size"], 0)
+        self.assertEqual(sample_row["file_attributes"], "{}")
+        self.assertEqual(sample_row["region_count"], 1)
+        self.assertEqual(sample_row["region_id"], 0)
+
+        # Check region_shape_attributes
+        shape_attrs = json.loads(sample_row["region_shape_attributes"])
+        self.assertEqual(shape_attrs["name"], "rect")
+        self.assertIn("x", shape_attrs)
+        self.assertIn("y", shape_attrs)
+        self.assertIn("width", shape_attrs)
+        self.assertIn("height", shape_attrs)
+
+        # Check region_attributes
+        region_attrs = json.loads(sample_row["region_attributes"])
+        self.assertIn("track", region_attrs)
+        self.assertIn(region_attrs["track"], self.dataset.individuals.values)
+
+        # Close any open file handles and delete
+        try:
+            os.unlink(output_path)
+        except PermissionError:
+            time.sleep(0.1)
+            os.unlink(output_path)
+
+    def test_missing_data_handling(self):
+        """Test that NaN values in the dataset are handled correctly."""
+        # Create a dataset with some NaN values
+        self.dataset["position"][0, 0, :] = (
+            np.nan
+        )  # Setting NaN for x-coordinate at time 0 for all individuals
+
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+            tmp_path = tmp.name
+
+        # Ensure the file doesn't exist
+        if os.path.exists(tmp_path):
+            try:
+                os.unlink(tmp_path)
+            except PermissionError:
+                time.sleep(0.1)
+                os.unlink(tmp_path)
+
+        output_path = to_via_tracks_file(self.dataset, tmp_path)
+
+        df = pd.read_csv(output_path)
+
+        # Let's calculate the expected number of rows:
+        # Original dataset: 5 frames * 2 individuals = 10 rows
+        # We set NaN for time 0, both individuals, so we lose 2 rows
+        self.assertEqual(len(df), 8)
+
+        # Close any open file handles and delete
+        try:
+            os.unlink(output_path)
+        except PermissionError:
+            time.sleep(0.1)
+            os.unlink(output_path)
+
+    def test_video_id_handling(self):
+        """Test different video_id formats and handling."""
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+            tmp_path = tmp.name
+            tmp.close()  # Close the file handle immediately
+
+        # Ensure the file doesn't exist
+        if os.path.exists(tmp_path):
+            try:
+                os.unlink(tmp_path)
+            except PermissionError:
+                time.sleep(0.1)
+                os.unlink(tmp_path)
+
+        # Test with custom video_id
+        output_path = to_via_tracks_file(
+            self.dataset, tmp_path, video_id="custom_video_123"
+        )
+        df = pd.read_csv(output_path)
+        self.assertTrue(df["filename"].iloc[0].startswith("custom_video_123_"))
+
+        # Clean up first file
+        try:
+            os.unlink(output_path)
+        except PermissionError:
+            time.sleep(0.1)
+            os.unlink(output_path)
+
+        # Test with default video_id (should use filename)
+        output_path = to_via_tracks_file(self.dataset, tmp_path)
+        df = pd.read_csv(output_path)
+        expected_prefix = Path(tmp_path).stem
+        self.assertTrue(
+            df["filename"].iloc[0].startswith(f"{expected_prefix}_")
+        )
+
+        # Clean up second file
+        try:
+            os.unlink(output_path)
+        except PermissionError:
+            time.sleep(0.1)
+            os.unlink(output_path)

--- a/tests/test_unit/test_via_tracks.py
+++ b/tests/test_unit/test_via_tracks.py
@@ -11,10 +11,10 @@ from movement.io.save_boxes import to_via_tracks_file
 
 class MockBboxes:
     """Test double for bounding box container class."""
-    
+
     def __init__(self, coordinates: list | np.ndarray, format: str):
         """Initialize mock bounding boxes.
-        
+
         Parameters
         ----------
         coordinates : list or np.ndarray
@@ -26,16 +26,18 @@ class MockBboxes:
         self.coordinates = np.array(coordinates)
         self.format = format
 
-    def convert(self, target_format: str, inplace: bool = False) -> "MockBboxes":
+    def convert(
+        self, target_format: str, inplace: bool = False
+    ) -> "MockBboxes":
         """Mock format conversion logic.
-        
+
         Parameters
         ----------
         target_format : str
             Target coordinate format
         inplace : bool, optional
             Whether to modify the current instance
-            
+
         Returns
         -------
         MockBboxes
@@ -59,27 +61,28 @@ class MockBboxes:
             f"Unsupported conversion: {self.format}->{target_format}"
         )
 
+
 class TestVIATracksExport:
     """Test suite for VIA-tracks export functionality."""
-    
+
     @pytest.fixture
     def sample_boxes_xyxy(self):
         """Provide sample boxes in xyxy format."""
         return MockBboxes([[10, 20, 50, 60]], format="xyxy")
-    
+
     @pytest.fixture
     def sample_boxes_xywh(self):
         """Provide sample boxes in xywh format for conversion testing."""
         return MockBboxes([[10, 20, 40, 40]], format="xywh")
-    
+
     @pytest.fixture
     def multi_frame_boxes(self):
         """Provide multi-frame box data as dictionary."""
         return {
             0: MockBboxes([[10, 20, 50, 60]], "xyxy"),
-            1: MockBboxes([[30, 40, 70, 80]], "xyxy")
+            1: MockBboxes([[30, 40, 70, 80]], "xyxy"),
         }
-    
+
     @pytest.fixture
     def video_metadata(self):
         """Provide standard video metadata for testing."""
@@ -94,7 +97,7 @@ class TestVIATracksExport:
         """Verify successful export with valid inputs and metadata."""
         output_file = tmp_path / "output.json"
         to_via_tracks_file(sample_boxes_xyxy, output_file, video_metadata)
-        
+
         assert output_file.exists()
         with open(output_file) as f:
             data = json.load(f)
@@ -108,7 +111,7 @@ class TestVIATracksExport:
         # Valid JSON path
         valid_path = tmp_path / "valid.json"
         to_via_tracks_file(sample_boxes_xyxy, valid_path)
-        
+
         # Invalid extension
         invalid_path = tmp_path / "invalid.txt"
         with pytest.raises(ValueError) as exc_info:
@@ -119,17 +122,20 @@ class TestVIATracksExport:
         """Verify default metadata generation when none is provided."""
         output_file = tmp_path / "output.json"
         to_via_tracks_file(sample_boxes_xyxy, output_file)
-        
+
         with open(output_file) as f:
             data = json.load(f)
             vid = list(data["_via_data"]["vid_list"].keys())[0]
-            assert data["_via_data"]["vid_list"][vid]["filepath"] == "unknown_video.mp4"
+            assert (
+                data["_via_data"]["vid_list"][vid]["filepath"]
+                == "unknown_video.mp4"
+            )
 
     def test_format_conversion(self, tmp_path, sample_boxes_xywh):
         """Test automatic conversion from xywh to xyxy format."""
         output_file = tmp_path / "converted.json"
         to_via_tracks_file(sample_boxes_xywh, output_file)
-        
+
         with open(output_file) as f:
             data = json.load(f)
             region = data["_via_data"]["metadata"][
@@ -141,7 +147,7 @@ class TestVIATracksExport:
         """Verify correct handling of multi-frame input dictionaries."""
         output_file = tmp_path / "multi_frame.json"
         to_via_tracks_file(multi_frame_boxes, output_file)
-        
+
         with open(output_file) as f:
             data = json.load(f)
             vid = list(data["_via_data"]["vid_list"].keys())[0]
@@ -153,7 +159,7 @@ class TestVIATracksExport:
         output_file = tmp_path / "edge_cases.json"
         boxes = MockBboxes([[0, 0, 0, 0]], "xyxy")
         to_via_tracks_file(boxes, output_file)
-        
+
         with open(output_file) as f:
             data = json.load(f)
             region = data["_via_data"]["metadata"][

--- a/tests/test_unit/test_via_tracks.py
+++ b/tests/test_unit/test_via_tracks.py
@@ -9,63 +9,80 @@ import pytest
 from movement.io.save_boxes import to_via_tracks_file
 
 
-class Bboxes:
-    """Mock Bboxes class for testing."""
-
-    def __init__(self, bboxes, format: str):
+class MockBboxes:
+    """Test double for bounding box container class."""
+    
+    def __init__(self, coordinates: list | np.ndarray, format: str):
         """Initialize mock bounding boxes.
-
+        
         Parameters
         ----------
-        bboxes : list or np.ndarray
-            Array of bounding boxes
+        coordinates : list or np.ndarray
+            Array of bounding box coordinates in specified format
         format : str
-            Format specification (e.g., 'xyxy', 'xywh')
+            Coordinate format specification (e.g., 'xyxy', 'xywh')
 
         """
-        self.bboxes = np.array(bboxes)
+        self.coordinates = np.array(coordinates)
         self.format = format
 
-    def convert(self, target_format: str, inplace: bool = False) -> "Bboxes":
-        """Convert bounding boxes to target format.
-
+    def convert(self, target_format: str, inplace: bool = False) -> "MockBboxes":
+        """Mock format conversion logic.
+        
         Parameters
         ----------
         target_format : str
-            Desired output format
-        inplace : bool
+            Target coordinate format
+        inplace : bool, optional
             Whether to modify the current instance
+            
+        Returns
+        -------
+        MockBboxes
+            Converted bounding boxes
 
         """
         if self.format == target_format:
             return self
         if self.format == "xywh" and target_format == "xyxy":
             converted = []
-            for bbox in self.bboxes:
-                x, y, w, h = bbox
+            for box in self.coordinates:
+                x, y, w, h = box
                 converted.append([x, y, x + w, y + h])
-            new_bboxes = np.array(converted)
+            new_coords = np.array(converted)
             if inplace:
-                self.bboxes = new_bboxes
+                self.coordinates = new_coords
                 self.format = target_format
                 return self
-            return Bboxes(new_bboxes, target_format)
+            return MockBboxes(new_coords, target_format)
         raise ValueError(
             f"Unsupported conversion: {self.format}->{target_format}"
         )
 
-
 class TestVIATracksExport:
     """Test suite for VIA-tracks export functionality."""
-
+    
     @pytest.fixture
-    def sample_bboxes(self):
-        """Fixture providing sample bounding boxes in xyxy format."""
-        return Bboxes([[10, 20, 50, 60]], format="xyxy")
-
+    def sample_boxes_xyxy(self):
+        """Provide sample boxes in xyxy format."""
+        return MockBboxes([[10, 20, 50, 60]], format="xyxy")
+    
+    @pytest.fixture
+    def sample_boxes_xywh(self):
+        """Provide sample boxes in xywh format for conversion testing."""
+        return MockBboxes([[10, 20, 40, 40]], format="xywh")
+    
+    @pytest.fixture
+    def multi_frame_boxes(self):
+        """Provide multi-frame box data as dictionary."""
+        return {
+            0: MockBboxes([[10, 20, 50, 60]], "xyxy"),
+            1: MockBboxes([[30, 40, 70, 80]], "xyxy")
+        }
+    
     @pytest.fixture
     def video_metadata(self):
-        """Fixture providing sample video metadata."""
+        """Provide standard video metadata for testing."""
         return {
             "filename": "test_video.mp4",
             "width": 1280,
@@ -73,52 +90,88 @@ class TestVIATracksExport:
             "size": 1024000,
         }
 
-    def test_basic_export(self, tmp_path, sample_bboxes, video_metadata):
-        """Test basic export functionality with valid inputs."""
+    def test_basic_export(self, tmp_path, sample_boxes_xyxy, video_metadata):
+        """Verify successful export with valid inputs and metadata."""
         output_file = tmp_path / "output.json"
-        to_via_tracks_file(sample_bboxes, output_file, video_metadata)
-
+        to_via_tracks_file(sample_boxes_xyxy, output_file, video_metadata)
+        
         assert output_file.exists()
         with open(output_file) as f:
             data = json.load(f)
             assert "_via_data" in data
-            assert len(data["_via_data"]["vid_list"]) == 1
+            videos = data["_via_data"]["vid_list"]
+            assert len(videos) == 1
+            assert videos[list(videos.keys())[0]]["width"] == 1280
 
-    def test_file_validation(self, tmp_path, sample_bboxes):
-        """Test file path validation logic."""
+    def test_file_validation(self, tmp_path, sample_boxes_xyxy):
+        """Test file path validation and error handling."""
+        # Valid JSON path
         valid_path = tmp_path / "valid.json"
-        to_via_tracks_file(sample_bboxes, valid_path)
-
+        to_via_tracks_file(sample_boxes_xyxy, valid_path)
+        
+        # Invalid extension
         invalid_path = tmp_path / "invalid.txt"
-        with pytest.raises(ValueError):
-            to_via_tracks_file(sample_bboxes, invalid_path)
+        with pytest.raises(ValueError) as exc_info:
+            to_via_tracks_file(sample_boxes_xyxy, invalid_path)
+        assert "Invalid file extension" in str(exc_info.value)
 
-    def test_metadata_handling(self, tmp_path, sample_bboxes):
-        """Test handling of missing metadata."""
+    def test_auto_metadata(self, tmp_path, sample_boxes_xyxy):
+        """Verify default metadata generation when none is provided."""
         output_file = tmp_path / "output.json"
-        to_via_tracks_file(sample_bboxes, output_file)
-
+        to_via_tracks_file(sample_boxes_xyxy, output_file)
+        
         with open(output_file) as f:
             data = json.load(f)
             vid = list(data["_via_data"]["vid_list"].keys())[0]
-            assert data["_via_data"]["vid_list"][vid]["width"] == 0
+            assert data["_via_data"]["vid_list"][vid]["filepath"] == "unknown_video.mp4"
 
-    def test_logging(self, caplog, tmp_path, sample_bboxes):
-        """Test logging of successful export."""
-        output_file = tmp_path / "output.json"
-        with caplog.at_level(logging.INFO):
-            to_via_tracks_file(sample_bboxes, output_file)
-            assert "Saved bounding boxes" in caplog.text
-
-    def test_format_conversion(self, tmp_path):
-        """Test automatic xywh to xyxy conversion."""
-        output_file = tmp_path / "output.json"
-        bboxes = Bboxes([[10, 20, 40, 40]], format="xywh")
-        to_via_tracks_file(bboxes, output_file)
-
+    def test_format_conversion(self, tmp_path, sample_boxes_xywh):
+        """Test automatic conversion from xywh to xyxy format."""
+        output_file = tmp_path / "converted.json"
+        to_via_tracks_file(sample_boxes_xywh, output_file)
+        
         with open(output_file) as f:
             data = json.load(f)
             region = data["_via_data"]["metadata"][
                 list(data["_via_data"]["metadata"].keys())[0]
             ]["xy"][0]["shape_attributes"]
-            assert region["width"] == 40.0
+            assert region["width"] == 40.0  # 50-10 after conversion
+
+    def test_multi_frame_export(self, tmp_path, multi_frame_boxes):
+        """Verify correct handling of multi-frame input dictionaries."""
+        output_file = tmp_path / "multi_frame.json"
+        to_via_tracks_file(multi_frame_boxes, output_file)
+        
+        with open(output_file) as f:
+            data = json.load(f)
+            vid = list(data["_via_data"]["vid_list"].keys())[0]
+            assert len(data["_via_data"]["vid_list"][vid]["fid_list"]) == 2
+
+    def test_edge_cases(self, tmp_path):
+        """Test handling of edge case values and empty inputs."""
+        # Zero-size boxes
+        output_file = tmp_path / "edge_cases.json"
+        boxes = MockBboxes([[0, 0, 0, 0]], "xyxy")
+        to_via_tracks_file(boxes, output_file)
+        
+        with open(output_file) as f:
+            data = json.load(f)
+            region = data["_via_data"]["metadata"][
+                list(data["_via_data"]["metadata"].keys())[0]
+            ]["xy"][0]["shape_attributes"]
+            assert region["width"] == 0.0
+
+    def test_logging(self, caplog, tmp_path, sample_boxes_xyxy):
+        """Verify proper logging of export operations."""
+        output_file = tmp_path / "logging_test.json"
+        with caplog.at_level(logging.INFO):
+            to_via_tracks_file(sample_boxes_xyxy, output_file)
+            assert "Saved bounding boxes" in caplog.text
+            assert str(output_file) in caplog.text
+
+    def test_error_handling(self, tmp_path):
+        """Test proper error reporting for invalid inputs."""
+        # Invalid box format
+        invalid_boxes = MockBboxes([[10, 20, 50]], "invalid_format")
+        with pytest.raises(ValueError):
+            to_via_tracks_file(invalid_boxes, tmp_path / "test.json")

--- a/tests/test_unit/test_via_tracks.py
+++ b/tests/test_unit/test_via_tracks.py
@@ -1,16 +1,19 @@
-import pytest
 import json
-import numpy as np
-from pathlib import Path
-from movement.io.save_boxes import to_via_tracks_file
 import logging
+
+import numpy as np
+import pytest
+
+from movement.io.save_boxes import to_via_tracks_file
+
 
 class Bboxes:
     """Mock Bboxes class for testing."""
+
     def __init__(self, bboxes, format):
         self.bboxes = np.array(bboxes)
         self.format = format
-        
+
     def convert(self, target_format, inplace=False):
         if self.format == target_format:
             return self
@@ -25,28 +28,31 @@ class Bboxes:
                 self.format = target_format
                 return self
             return Bboxes(new_bboxes, target_format)
-        raise ValueError(f"Unsupported conversion: {self.format}->{target_format}")
+        raise ValueError(
+            f"Unsupported conversion: {self.format}->{target_format}"
+        )
+
 
 class TestVIATracksExport:
     """Test suite for VIA-tracks export functionality."""
-    
+
     @pytest.fixture
     def sample_bboxes(self):
         return Bboxes([[10, 20, 50, 60]], format="xyxy")
-    
+
     @pytest.fixture
     def video_metadata(self):
         return {
             "filename": "test_video.mp4",
             "width": 1280,
             "height": 720,
-            "size": 1024000
+            "size": 1024000,
         }
 
     def test_basic_export(self, tmp_path, sample_bboxes, video_metadata):
         output_file = tmp_path / "output.json"
         to_via_tracks_file(sample_bboxes, output_file, video_metadata)
-        
+
         assert output_file.exists()
         with open(output_file) as f:
             data = json.load(f)
@@ -57,7 +63,7 @@ class TestVIATracksExport:
         # Test valid JSON
         valid_path = tmp_path / "valid.json"
         to_via_tracks_file(sample_bboxes, valid_path)
-        
+
         # Test invalid extension
         invalid_path = tmp_path / "invalid.txt"
         with pytest.raises(ValueError):
@@ -66,7 +72,7 @@ class TestVIATracksExport:
     def test_metadata_handling(self, tmp_path, sample_bboxes):
         output_file = tmp_path / "output.json"
         to_via_tracks_file(sample_bboxes, output_file)
-        
+
         with open(output_file) as f:
             data = json.load(f)
             vid = list(data["_via_data"]["vid_list"].keys())[0]
@@ -76,13 +82,13 @@ class TestVIATracksExport:
         output_file = tmp_path / "output.json"
         with caplog.at_level(logging.INFO):
             to_via_tracks_file(sample_bboxes, output_file)
-            assert f"Saved bounding boxes" in caplog.text
+            assert "Saved bounding boxes" in caplog.text
 
     def test_format_conversion(self, tmp_path):
         output_file = tmp_path / "output.json"
         bboxes = Bboxes([[10, 20, 40, 40]], format="xywh")  # xywh input
         to_via_tracks_file(bboxes, output_file)
-        
+
         with open(output_file) as f:
             data = json.load(f)
             region = data["_via_data"]["metadata"][

--- a/tests/test_unit/test_via_tracks.py
+++ b/tests/test_unit/test_via_tracks.py
@@ -1,0 +1,91 @@
+import pytest
+import json
+import numpy as np
+from pathlib import Path
+from movement.io.save_boxes import to_via_tracks_file
+import logging
+
+class Bboxes:
+    """Mock Bboxes class for testing."""
+    def __init__(self, bboxes, format):
+        self.bboxes = np.array(bboxes)
+        self.format = format
+        
+    def convert(self, target_format, inplace=False):
+        if self.format == target_format:
+            return self
+        if self.format == "xywh" and target_format == "xyxy":
+            converted = []
+            for bbox in self.bboxes:
+                x, y, w, h = bbox
+                converted.append([x, y, x + w, y + h])
+            new_bboxes = np.array(converted)
+            if inplace:
+                self.bboxes = new_bboxes
+                self.format = target_format
+                return self
+            return Bboxes(new_bboxes, target_format)
+        raise ValueError(f"Unsupported conversion: {self.format}->{target_format}")
+
+class TestVIATracksExport:
+    """Test suite for VIA-tracks export functionality."""
+    
+    @pytest.fixture
+    def sample_bboxes(self):
+        return Bboxes([[10, 20, 50, 60]], format="xyxy")
+    
+    @pytest.fixture
+    def video_metadata(self):
+        return {
+            "filename": "test_video.mp4",
+            "width": 1280,
+            "height": 720,
+            "size": 1024000
+        }
+
+    def test_basic_export(self, tmp_path, sample_bboxes, video_metadata):
+        output_file = tmp_path / "output.json"
+        to_via_tracks_file(sample_bboxes, output_file, video_metadata)
+        
+        assert output_file.exists()
+        with open(output_file) as f:
+            data = json.load(f)
+            assert "_via_data" in data
+            assert len(data["_via_data"]["vid_list"]) == 1
+
+    def test_file_validation(self, tmp_path, sample_bboxes):
+        # Test valid JSON
+        valid_path = tmp_path / "valid.json"
+        to_via_tracks_file(sample_bboxes, valid_path)
+        
+        # Test invalid extension
+        invalid_path = tmp_path / "invalid.txt"
+        with pytest.raises(ValueError):
+            to_via_tracks_file(sample_bboxes, invalid_path)
+
+    def test_metadata_handling(self, tmp_path, sample_bboxes):
+        output_file = tmp_path / "output.json"
+        to_via_tracks_file(sample_bboxes, output_file)
+        
+        with open(output_file) as f:
+            data = json.load(f)
+            vid = list(data["_via_data"]["vid_list"].keys())[0]
+            assert data["_via_data"]["vid_list"][vid]["width"] == 0  # Default
+
+    def test_logging(self, caplog, tmp_path, sample_bboxes):
+        output_file = tmp_path / "output.json"
+        with caplog.at_level(logging.INFO):
+            to_via_tracks_file(sample_bboxes, output_file)
+            assert f"Saved bounding boxes" in caplog.text
+
+    def test_format_conversion(self, tmp_path):
+        output_file = tmp_path / "output.json"
+        bboxes = Bboxes([[10, 20, 40, 40]], format="xywh")  # xywh input
+        to_via_tracks_file(bboxes, output_file)
+        
+        with open(output_file) as f:
+            data = json.load(f)
+            region = data["_via_data"]["metadata"][
+                list(data["_via_data"]["metadata"].keys())[0]
+            ]["xy"][0]["shape_attributes"]
+            assert region["width"] == 40.0  # 50-10 after conversion

--- a/tests/test_unit/test_via_tracks.py
+++ b/tests/test_unit/test_via_tracks.py
@@ -11,10 +11,10 @@ from movement.io.save_boxes import to_via_tracks_file
 
 class MockBboxes:
     """Test double for bounding box container class."""
-
+    
     def __init__(self, coordinates: list | np.ndarray, format: str):
         """Initialize mock bounding boxes.
-
+        
         Parameters
         ----------
         coordinates : list or np.ndarray
@@ -26,18 +26,16 @@ class MockBboxes:
         self.coordinates = np.array(coordinates)
         self.format = format
 
-    def convert(
-        self, target_format: str, inplace: bool = False
-    ) -> "MockBboxes":
+    def convert(self, target_format: str, inplace: bool = False) -> "MockBboxes":
         """Mock format conversion logic.
-
+        
         Parameters
         ----------
         target_format : str
             Target coordinate format
         inplace : bool, optional
             Whether to modify the current instance
-
+            
         Returns
         -------
         MockBboxes
@@ -61,28 +59,27 @@ class MockBboxes:
             f"Unsupported conversion: {self.format}->{target_format}"
         )
 
-
 class TestVIATracksExport:
     """Test suite for VIA-tracks export functionality."""
-
+    
     @pytest.fixture
     def sample_boxes_xyxy(self):
         """Provide sample boxes in xyxy format."""
         return MockBboxes([[10, 20, 50, 60]], format="xyxy")
-
+    
     @pytest.fixture
     def sample_boxes_xywh(self):
         """Provide sample boxes in xywh format for conversion testing."""
         return MockBboxes([[10, 20, 40, 40]], format="xywh")
-
+    
     @pytest.fixture
     def multi_frame_boxes(self):
         """Provide multi-frame box data as dictionary."""
         return {
             0: MockBboxes([[10, 20, 50, 60]], "xyxy"),
-            1: MockBboxes([[30, 40, 70, 80]], "xyxy"),
+            1: MockBboxes([[30, 40, 70, 80]], "xyxy")
         }
-
+    
     @pytest.fixture
     def video_metadata(self):
         """Provide standard video metadata for testing."""
@@ -97,7 +94,7 @@ class TestVIATracksExport:
         """Verify successful export with valid inputs and metadata."""
         output_file = tmp_path / "output.json"
         to_via_tracks_file(sample_boxes_xyxy, output_file, video_metadata)
-
+        
         assert output_file.exists()
         with open(output_file) as f:
             data = json.load(f)
@@ -111,7 +108,7 @@ class TestVIATracksExport:
         # Valid JSON path
         valid_path = tmp_path / "valid.json"
         to_via_tracks_file(sample_boxes_xyxy, valid_path)
-
+        
         # Invalid extension
         invalid_path = tmp_path / "invalid.txt"
         with pytest.raises(ValueError) as exc_info:
@@ -122,32 +119,29 @@ class TestVIATracksExport:
         """Verify default metadata generation when none is provided."""
         output_file = tmp_path / "output.json"
         to_via_tracks_file(sample_boxes_xyxy, output_file)
-
+        
         with open(output_file) as f:
             data = json.load(f)
             vid = list(data["_via_data"]["vid_list"].keys())[0]
-            assert (
-                data["_via_data"]["vid_list"][vid]["filepath"]
-                == "unknown_video.mp4"
-            )
+            assert data["_via_data"]["vid_list"][vid]["filepath"] == "unknown_video.mp4"
 
     def test_format_conversion(self, tmp_path, sample_boxes_xywh):
         """Test automatic conversion from xywh to xyxy format."""
         output_file = tmp_path / "converted.json"
         to_via_tracks_file(sample_boxes_xywh, output_file)
-
+        
         with open(output_file) as f:
             data = json.load(f)
             region = data["_via_data"]["metadata"][
                 list(data["_via_data"]["metadata"].keys())[0]
             ]["xy"][0]["shape_attributes"]
-            assert region["width"] == 40.0  # 50-10 after conversion
-
+            assert abs(region["width"] - 40.0) < 1e-6  
+            
     def test_multi_frame_export(self, tmp_path, multi_frame_boxes):
         """Verify correct handling of multi-frame input dictionaries."""
         output_file = tmp_path / "multi_frame.json"
         to_via_tracks_file(multi_frame_boxes, output_file)
-
+        
         with open(output_file) as f:
             data = json.load(f)
             vid = list(data["_via_data"]["vid_list"].keys())[0]
@@ -159,13 +153,13 @@ class TestVIATracksExport:
         output_file = tmp_path / "edge_cases.json"
         boxes = MockBboxes([[0, 0, 0, 0]], "xyxy")
         to_via_tracks_file(boxes, output_file)
-
+        
         with open(output_file) as f:
             data = json.load(f)
             region = data["_via_data"]["metadata"][
                 list(data["_via_data"]["metadata"].keys())[0]
             ]["xy"][0]["shape_attributes"]
-            assert region["width"] == 0.0
+            assert abs(region["width"] - 0.0) < 1e-6  
 
     def test_logging(self, caplog, tmp_path, sample_boxes_xyxy):
         """Verify proper logging of export operations."""

--- a/tests/test_unit/test_via_tracks.py
+++ b/tests/test_unit/test_via_tracks.py
@@ -14,7 +14,7 @@ class Bboxes:
 
     def __init__(self, bboxes, format: str):
         """Initialize mock bounding boxes.
-        
+
         Parameters
         ----------
         bboxes : list or np.ndarray
@@ -28,7 +28,7 @@ class Bboxes:
 
     def convert(self, target_format: str, inplace: bool = False) -> "Bboxes":
         """Convert bounding boxes to target format.
-        
+
         Parameters
         ----------
         target_format : str
@@ -54,14 +54,15 @@ class Bboxes:
             f"Unsupported conversion: {self.format}->{target_format}"
         )
 
+
 class TestVIATracksExport:
     """Test suite for VIA-tracks export functionality."""
-    
+
     @pytest.fixture
     def sample_bboxes(self):
         """Fixture providing sample bounding boxes in xyxy format."""
         return Bboxes([[10, 20, 50, 60]], format="xyxy")
-    
+
     @pytest.fixture
     def video_metadata(self):
         """Fixture providing sample video metadata."""
@@ -76,7 +77,7 @@ class TestVIATracksExport:
         """Test basic export functionality with valid inputs."""
         output_file = tmp_path / "output.json"
         to_via_tracks_file(sample_bboxes, output_file, video_metadata)
-        
+
         assert output_file.exists()
         with open(output_file) as f:
             data = json.load(f)
@@ -87,7 +88,7 @@ class TestVIATracksExport:
         """Test file path validation logic."""
         valid_path = tmp_path / "valid.json"
         to_via_tracks_file(sample_bboxes, valid_path)
-        
+
         invalid_path = tmp_path / "invalid.txt"
         with pytest.raises(ValueError):
             to_via_tracks_file(sample_bboxes, invalid_path)
@@ -96,7 +97,7 @@ class TestVIATracksExport:
         """Test handling of missing metadata."""
         output_file = tmp_path / "output.json"
         to_via_tracks_file(sample_bboxes, output_file)
-        
+
         with open(output_file) as f:
             data = json.load(f)
             vid = list(data["_via_data"]["vid_list"].keys())[0]
@@ -114,7 +115,7 @@ class TestVIATracksExport:
         output_file = tmp_path / "output.json"
         bboxes = Bboxes([[10, 20, 40, 40]], format="xywh")
         to_via_tracks_file(bboxes, output_file)
-        
+
         with open(output_file) as f:
             data = json.load(f)
             region = data["_via_data"]["metadata"][

--- a/tests/test_unit/test_via_tracks.py
+++ b/tests/test_unit/test_via_tracks.py
@@ -11,10 +11,10 @@ from movement.io.save_boxes import to_via_tracks_file
 
 class MockBboxes:
     """Test double for bounding box container class."""
-    
+
     def __init__(self, coordinates: list | np.ndarray, format: str):
         """Initialize mock bounding boxes.
-        
+
         Parameters
         ----------
         coordinates : list or np.ndarray
@@ -26,16 +26,18 @@ class MockBboxes:
         self.coordinates = np.array(coordinates)
         self.format = format
 
-    def convert(self, target_format: str, inplace: bool = False) -> "MockBboxes":
+    def convert(
+        self, target_format: str, inplace: bool = False
+    ) -> "MockBboxes":
         """Mock format conversion logic.
-        
+
         Parameters
         ----------
         target_format : str
             Target coordinate format
         inplace : bool, optional
             Whether to modify the current instance
-            
+
         Returns
         -------
         MockBboxes
@@ -59,27 +61,28 @@ class MockBboxes:
             f"Unsupported conversion: {self.format}->{target_format}"
         )
 
+
 class TestVIATracksExport:
     """Test suite for VIA-tracks export functionality."""
-    
+
     @pytest.fixture
     def sample_boxes_xyxy(self):
         """Provide sample boxes in xyxy format."""
         return MockBboxes([[10, 20, 50, 60]], format="xyxy")
-    
+
     @pytest.fixture
     def sample_boxes_xywh(self):
         """Provide sample boxes in xywh format for conversion testing."""
         return MockBboxes([[10, 20, 40, 40]], format="xywh")
-    
+
     @pytest.fixture
     def multi_frame_boxes(self):
         """Provide multi-frame box data as dictionary."""
         return {
             0: MockBboxes([[10, 20, 50, 60]], "xyxy"),
-            1: MockBboxes([[30, 40, 70, 80]], "xyxy")
+            1: MockBboxes([[30, 40, 70, 80]], "xyxy"),
         }
-    
+
     @pytest.fixture
     def video_metadata(self):
         """Provide standard video metadata for testing."""
@@ -94,7 +97,7 @@ class TestVIATracksExport:
         """Verify successful export with valid inputs and metadata."""
         output_file = tmp_path / "output.json"
         to_via_tracks_file(sample_boxes_xyxy, output_file, video_metadata)
-        
+
         assert output_file.exists()
         with open(output_file) as f:
             data = json.load(f)
@@ -108,7 +111,7 @@ class TestVIATracksExport:
         # Valid JSON path
         valid_path = tmp_path / "valid.json"
         to_via_tracks_file(sample_boxes_xyxy, valid_path)
-        
+
         # Invalid extension
         invalid_path = tmp_path / "invalid.txt"
         with pytest.raises(ValueError) as exc_info:
@@ -119,29 +122,32 @@ class TestVIATracksExport:
         """Verify default metadata generation when none is provided."""
         output_file = tmp_path / "output.json"
         to_via_tracks_file(sample_boxes_xyxy, output_file)
-        
+
         with open(output_file) as f:
             data = json.load(f)
             vid = list(data["_via_data"]["vid_list"].keys())[0]
-            assert data["_via_data"]["vid_list"][vid]["filepath"] == "unknown_video.mp4"
+            assert (
+                data["_via_data"]["vid_list"][vid]["filepath"]
+                == "unknown_video.mp4"
+            )
 
     def test_format_conversion(self, tmp_path, sample_boxes_xywh):
         """Test automatic conversion from xywh to xyxy format."""
         output_file = tmp_path / "converted.json"
         to_via_tracks_file(sample_boxes_xywh, output_file)
-        
+
         with open(output_file) as f:
             data = json.load(f)
             region = data["_via_data"]["metadata"][
                 list(data["_via_data"]["metadata"].keys())[0]
             ]["xy"][0]["shape_attributes"]
-            assert abs(region["width"] - 40.0) < 1e-6  
-            
+            assert abs(region["width"] - 40.0) < 1e-6
+
     def test_multi_frame_export(self, tmp_path, multi_frame_boxes):
         """Verify correct handling of multi-frame input dictionaries."""
         output_file = tmp_path / "multi_frame.json"
         to_via_tracks_file(multi_frame_boxes, output_file)
-        
+
         with open(output_file) as f:
             data = json.load(f)
             vid = list(data["_via_data"]["vid_list"].keys())[0]
@@ -153,13 +159,13 @@ class TestVIATracksExport:
         output_file = tmp_path / "edge_cases.json"
         boxes = MockBboxes([[0, 0, 0, 0]], "xyxy")
         to_via_tracks_file(boxes, output_file)
-        
+
         with open(output_file) as f:
             data = json.load(f)
             region = data["_via_data"]["metadata"][
                 list(data["_via_data"]["metadata"].keys())[0]
             ]["xy"][0]["shape_attributes"]
-            assert abs(region["width"] - 0.0) < 1e-6  
+            assert abs(region["width"] - 0.0) < 1e-6
 
     def test_logging(self, caplog, tmp_path, sample_boxes_xyxy):
         """Verify proper logging of export operations."""


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/neuroinformatics-unit/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description
This PR introduces support for exporting pose tracking data to the VIA-tracks format, addressing feature request #495. The implementation includes:

 1. A new to_via_tracks_file function for exporting bounding boxes and keypoints in VIA-tracks JSON format.
 2.Support for single-frame and multi-frame inputs, with automatic format conversion (e.g., xywh → xyxy).
 3. Custom video metadata handling with sensible defaults.
 4. Comprehensive unit tests covering functionality, edge cases, and performance.

**What is this PR**
- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
This is a feature addition mentioned in the issue #495 
**What does this PR do?**

## References

Please reference any existing issues/PRs that relate to this PR.

## How has this PR been tested?
Wrote testcases to check all the edge cases which could occur 

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.
This is a feature addition and no existing code has been changed 
## Is this a breaking change?
No
If this PR breaks any existing functionality, please explain how and why.

## Does this PR require an update to the documentation?
I believe there is already documentation on this. 
If any features have changed, or have been added. Please explain how the
documentation has been updated.
NA

PS. If I have missed something or if something is off I would love to hear reviews and would definitely try to correct the implementation. Cheers! Thanks! 

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
