### PR TITLE
Extended the interpolate_over_time to bfill, ffill, nearest and constant functionality

### DIFF
--- a/movement/filtering.py
+++ b/movement/filtering.py
@@ -82,7 +82,7 @@ def interpolate_over_time(
     method : str
         String indicating which method to use for interpolation.
         Methods are: `linear`, `nearest`, `zero`, `quadratic`, `cubic`, `krogh`
-        `polynomial`, `spline`, `barycentric`, `slinear`, `pchip`, `akima`, 
+        `polynomial`, `spline`, `barycentric`, `slinear`, `pchip`, `akima`,
         `bfill`, `ffill`, `constant`
         Default is ``linear``.
     max_gap : int, optional
@@ -119,8 +119,10 @@ def interpolate_over_time(
         data_interpolated = getattr(data, method)(dim="time", **kwargs)
     elif method == "constant":
         if fill_value is None:
-            raise ValueError("fill_value must be provided \
-            for method='constant'")
+            raise ValueError(
+                "fill_value must be provided \
+            for method='constant'"
+            )
         data_interpolated = data.fillna(fill_value, **kwargs)
     else:
         data_interpolated = data.interpolate_na(


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
This PR closes the issue #326. This PR adds support for common data imputation methods (`bfill`, `ffill`, `nearest`, and `constant`) to the interpolate_over_time function. 

**What does this PR do?**
- Extends the interpolate_over_time function to support `bfill`, `ffill`, `nearest`, and `constant` imputation methods.
- Includes a `fill_value` parameter for the constant method.
- Update the docstring of interpolate_over_time function for the relevant changes.

## References
Issue #326 

## How has this PR been tested?
This PR has been tested locally by runnig the pytest and it pass all test cases.

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
Yes. I have update the docstring of the interpolate_over_time function accordingly.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
