### PR TITLE
Fix: update frame slider after deletion of layers

### DIFF
--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -56,7 +56,8 @@ class DataLoader(QWidget):
         self._create_load_button()
 
         # Connect methods to napari events
-        self.viewer.layers.events.removed.connect(self._on_layer_deleted)
+        if hasattr(self.viewer, "layers"):
+            self.viewer.layers.events.removed.connect(self._on_layer_deleted)
 
         # Enable layer tooltips from napari settings
         self._enable_layer_tooltips()

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -55,6 +55,9 @@ class DataLoader(QWidget):
         self._create_file_path_widget()
         self._create_load_button()
 
+        # Connect methods to napari events
+        self.viewer.layers.events.removed.connect(self._on_layer_deleted)
+
         # Enable layer tooltips from napari settings
         self._enable_layer_tooltips()
 

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -57,7 +57,9 @@ class DataLoader(QWidget):
 
         # Connect methods to napari events
         if hasattr(self.viewer, "layers"):
-            self.viewer.layers.events.removed.connect(self._on_layer_deleted)
+            self.viewer.layers.events.removed.connect(
+                self._on_layer_deleted, ref=True
+            )
 
         # Enable layer tooltips from napari settings
         self._enable_layer_tooltips()

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -55,21 +55,15 @@ class DataLoader(QWidget):
         self._create_file_path_widget()
         self._create_load_button()
 
-        # Connect methods to napari events
-        if hasattr(self.viewer, "layers"):
-            self.viewer.layers.events.removed.connect(
-                self._on_layer_deleted, ref=True
-            )
-
         # Enable layer tooltips from napari settings
         self._enable_layer_tooltips()
 
         # Connect to layer events
         self.viewer.layers.events.inserted.connect(
-            self._update_frame_slider_range
+            self._update_frame_slider_range, ref=True
         )
         self.viewer.layers.events.removed.connect(
-            self._update_frame_slider_range
+            self._update_frame_slider_range, ref=True
         )
 
     def _create_source_software_widget(self):

--- a/tests/fixtures/napari.py
+++ b/tests/fixtures/napari.py
@@ -69,6 +69,34 @@ def valid_poses_dataset_long(valid_poses_dataset, tmp_path):
 
 
 @pytest.fixture
+def valid_poses_dataset_long_nan_start(
+    valid_poses_dataset_with_localised_nans,
+):
+    """Return a (path, dataset) pair representing a poses dataset
+    with 2 individuals ("id_0" and "id_1") and 3 keypoints
+    ("centroid", "left", "right") moving in uniform linear
+    motion for 10 frames in 2D space.
+    """
+    out_path, ds = valid_poses_dataset_with_localised_nans(
+        {
+            "time": "start",
+            "individuals": ["id_0", "id_1"],
+            "keypoints": ["centroid", "left", "right"],
+        }
+    )
+    # # Export as a DLC-csv file
+    # out_path = tmp_path / "ds_long_with_nan_start.csv"
+    # save_poses.to_dlc_file(
+    #     valid_poses_dataset_with_nan, out_path, split_individuals=False
+    # # )
+    # out_path = (
+    #     out_path.parent / "ds_long_with_nan_start.csv"
+    # )
+
+    return (out_path, ds)
+
+
+@pytest.fixture
 def valid_poses_dataset_short(valid_poses_dataset, tmp_path):
     """Return a (path, dataset) pair representing a poses dataset
     with data for 5 frames.

--- a/tests/fixtures/napari.py
+++ b/tests/fixtures/napari.py
@@ -4,22 +4,8 @@ import pytest
 from movement.io import save_poses
 
 
-def get_half_valid_poses_dataset(ds, out_file_path):
-    """Return a (path, dataset) pair containing the data of the first half
-    of the frames from the input dataset.
-    """
-    # Modify the dataset to have only half of the frames
-    ds = ds.sel(time=slice(0, ds.coords["time"].shape[0] // 2))
-
-    # Export as a DLC-csv file
-    # out_file_path = out_path / "ds_short.csv"
-    save_poses.to_dlc_file(ds, out_file_path, split_individuals=False)
-
-    return (out_file_path, ds)
-
-
 @pytest.fixture
-def valid_poses_dataset_with_localised_nans(valid_poses_dataset, tmp_path):
+def valid_poses_path_and_ds_with_localised_nans(valid_poses_dataset, tmp_path):
     """Return a factory of (path, dataset) pairs representing
     valid pose datasets with NaN values at specific locations.
     """
@@ -27,7 +13,9 @@ def valid_poses_dataset_with_localised_nans(valid_poses_dataset, tmp_path):
     # original fixture
     ds = valid_poses_dataset.copy(deep=True)
 
-    def _valid_poses_dataset_with_localised_nans(nan_location):
+    def _valid_poses_path_and_ds_with_localised_nans(
+        nan_location, filename="ds_with_nans.csv"
+    ):
         """Return a valid poses dataset and corresponding file with NaN values
         at specific locations.
 
@@ -57,33 +45,29 @@ def valid_poses_dataset_with_localised_nans(valid_poses_dataset, tmp_path):
         ] = np.nan
 
         # Export as a DLC-csv file
-        out_path = tmp_path / "ds_with_nans.csv"
+        out_path = tmp_path / filename
         save_poses.to_dlc_file(ds, out_path, split_individuals=False)
 
         return (out_path, ds)
 
-    return _valid_poses_dataset_with_localised_nans
+    return _valid_poses_path_and_ds_with_localised_nans
 
 
 @pytest.fixture
-def valid_poses_dataset_long(valid_poses_dataset, tmp_path):
+def valid_poses_path_and_ds(valid_poses_dataset, tmp_path):
     """Return a (path, dataset) pair representing a poses dataset
     with data for 10 frames.
 
     The fixture is derived from the `valid_poses_dataset` fixture.
     """
-    # Export as a DLC-csv file
-    out_path = tmp_path / "ds_long.csv"
-    save_poses.to_dlc_file(
-        valid_poses_dataset, out_path, split_individuals=False
-    )
-
+    out_path = tmp_path / "ds.csv"
+    save_poses.to_dlc_file(valid_poses_dataset, out_path)
     return (out_path, valid_poses_dataset)
 
 
 @pytest.fixture
-def valid_poses_dataset_long_nan_start(
-    valid_poses_dataset_with_localised_nans,
+def valid_poses_path_and_ds_nan_start(
+    valid_poses_path_and_ds_with_localised_nans,
 ):
     """Return a (path, dataset) pair representing a poses dataset
     with 2 individuals ("id_0" and "id_1") and 3 keypoints
@@ -91,12 +75,34 @@ def valid_poses_dataset_long_nan_start(
     motion for 10 frames in 2D space, with all NaN values for the
     first frame.
     """
-    out_path, ds = valid_poses_dataset_with_localised_nans(
+    out_path, ds = valid_poses_path_and_ds_with_localised_nans(
         {
             "time": "start",
             "individuals": ["id_0", "id_1"],
             "keypoints": ["centroid", "left", "right"],
-        }
+        },
+        filename="ds_with_nan_start.csv",
+    )
+    return (out_path, ds)
+
+
+@pytest.fixture
+def valid_poses_path_and_ds_nan_end(
+    valid_poses_path_and_ds_with_localised_nans,
+):
+    """Return a (path, dataset) pair representing a poses dataset
+    with 2 individuals ("id_0" and "id_1") and 3 keypoints
+    ("centroid", "left", "right") moving in uniform linear
+    motion for 10 frames in 2D space, with all NaN values for the
+    last frame.
+    """
+    out_path, ds = valid_poses_path_and_ds_with_localised_nans(
+        {
+            "time": "end",
+            "individuals": ["id_0", "id_1"],
+            "keypoints": ["centroid", "left", "right"],
+        },
+        filename="ds_with_nan_end.csv",
     )
     return (out_path, ds)
 
@@ -109,28 +115,12 @@ def valid_poses_dataset_short(valid_poses_dataset, tmp_path):
     The fixture is derived from the `valid_poses_dataset` fixture.
     """
     # Modify the dataset to have only 5 frames
-    out_path, ds = get_half_valid_poses_dataset(
-        valid_poses_dataset, tmp_path / "ds_short.csv"
+    valid_poses_dataset = valid_poses_dataset.sel(time=slice(0, 5))
+
+    # Export as a DLC-csv file
+    out_path = tmp_path / "ds_short.csv"
+    save_poses.to_dlc_file(
+        valid_poses_dataset, out_path, split_individuals=False
     )
 
-    return out_path, ds
-
-
-@pytest.fixture
-def valid_poses_dataset_short_nan_start(
-    valid_poses_dataset_long_nan_start,
-    tmp_path,
-):
-    """Return a (path, dataset) pair representing a poses dataset
-    with 2 individuals ("id_0" and "id_1") and 3 keypoints
-    ("centroid", "left", "right") moving in uniform linear
-    motion for 10 frames in 2D space, with all NaN values for the
-    first frame.
-    """
-    # Get the dataset with all NaN values at the start
-    _, ds = valid_poses_dataset_long_nan_start
-
-    # Modify the dataset to have only 5 frames
-    return get_half_valid_poses_dataset(
-        ds, tmp_path / "ds_short_nan_start.csv"
-    )
+    return (out_path, valid_poses_dataset)

--- a/tests/fixtures/napari.py
+++ b/tests/fixtures/napari.py
@@ -36,18 +36,20 @@ def valid_poses_dataset_with_localised_nans(valid_poses_dataset, tmp_path):
         "left", "right") moving in uniform linear motion for 10 frames in 2D
         space.
         """
+        # Make a deep-copy of the valid dataset to avoid modifying the
+        # original fixture
+        ds = valid_poses_dataset.copy(deep=True)
+
         # Express NaN location in time in "time" coordinates
         if nan_location["time"] == "start":
             time_point = 0
         elif nan_location["time"] == "middle":
-            time_point = valid_poses_dataset.coords["time"][
-                valid_poses_dataset.coords["time"].shape[0] // 2
-            ]
+            time_point = ds.coords["time"][ds.coords["time"].shape[0] // 2]
         elif nan_location["time"] == "end":
-            time_point = valid_poses_dataset.coords["time"][-1]
+            time_point = ds.coords["time"][-1]
 
         # Set the selected values to NaN
-        valid_poses_dataset.position.loc[
+        ds.position.loc[
             {
                 "individuals": nan_location["individuals"],
                 "keypoints": nan_location["keypoints"],
@@ -57,11 +59,9 @@ def valid_poses_dataset_with_localised_nans(valid_poses_dataset, tmp_path):
 
         # Export as a DLC-csv file
         out_path = tmp_path / "ds_with_nans.csv"
-        save_poses.to_dlc_file(
-            valid_poses_dataset, out_path, split_individuals=False
-        )
+        save_poses.to_dlc_file(ds, out_path, split_individuals=False)
 
-        return (out_path, valid_poses_dataset)
+        return (out_path, ds)
 
     return _valid_poses_dataset_with_localised_nans
 

--- a/tests/fixtures/napari.py
+++ b/tests/fixtures/napari.py
@@ -5,6 +5,37 @@ from movement.io import save_poses
 
 
 @pytest.fixture
+def valid_poses_path_and_ds(valid_poses_dataset, tmp_path):
+    """Return a (path, dataset) pair representing a poses dataset
+    with data for 10 frames.
+
+    The fixture is derived from the `valid_poses_dataset` fixture.
+    """
+    out_path = tmp_path / "ds.csv"
+    save_poses.to_dlc_file(valid_poses_dataset, out_path)
+    return (out_path, valid_poses_dataset)
+
+
+@pytest.fixture
+def valid_poses_path_and_ds_short(valid_poses_dataset, tmp_path):
+    """Return a (path, dataset) pair representing a poses dataset
+    with data for 5 frames.
+
+    The fixture is derived from the `valid_poses_dataset` fixture.
+    """
+    # Modify the dataset to have only 5 frames
+    valid_poses_dataset = valid_poses_dataset.sel(time=slice(0, 5))
+
+    # Export as a DLC-csv file
+    out_path = tmp_path / "ds_short.csv"
+    save_poses.to_dlc_file(
+        valid_poses_dataset, out_path, split_individuals=False
+    )
+
+    return (out_path, valid_poses_dataset)
+
+
+@pytest.fixture
 def valid_poses_path_and_ds_with_localised_nans(valid_poses_dataset, tmp_path):
     """Return a factory of (path, dataset) pairs representing
     valid pose datasets with NaN values at specific locations.
@@ -54,18 +85,6 @@ def valid_poses_path_and_ds_with_localised_nans(valid_poses_dataset, tmp_path):
 
 
 @pytest.fixture
-def valid_poses_path_and_ds(valid_poses_dataset, tmp_path):
-    """Return a (path, dataset) pair representing a poses dataset
-    with data for 10 frames.
-
-    The fixture is derived from the `valid_poses_dataset` fixture.
-    """
-    out_path = tmp_path / "ds.csv"
-    save_poses.to_dlc_file(valid_poses_dataset, out_path)
-    return (out_path, valid_poses_dataset)
-
-
-@pytest.fixture
 def valid_poses_path_and_ds_nan_start(
     valid_poses_path_and_ds_with_localised_nans,
 ):
@@ -105,22 +124,3 @@ def valid_poses_path_and_ds_nan_end(
         filename="ds_with_nan_end.csv",
     )
     return (out_path, ds)
-
-
-@pytest.fixture
-def valid_poses_dataset_short(valid_poses_dataset, tmp_path):
-    """Return a (path, dataset) pair representing a poses dataset
-    with data for 5 frames.
-
-    The fixture is derived from the `valid_poses_dataset` fixture.
-    """
-    # Modify the dataset to have only 5 frames
-    valid_poses_dataset = valid_poses_dataset.sel(time=slice(0, 5))
-
-    # Export as a DLC-csv file
-    out_path = tmp_path / "ds_short.csv"
-    save_poses.to_dlc_file(
-        valid_poses_dataset, out_path, split_individuals=False
-    )
-
-    return (out_path, valid_poses_dataset)

--- a/tests/fixtures/napari.py
+++ b/tests/fixtures/napari.py
@@ -124,3 +124,37 @@ def valid_poses_path_and_ds_nan_end(
         filename="ds_with_nan_end.csv",
     )
     return (out_path, ds)
+
+
+@pytest.fixture
+def sample_layer_data():
+    """Return a dictionary of sample data for each napari layer type."""
+    n_frames = 2000
+
+    sample_points_data = np.random.rand(n_frames, 3)
+    sample_image_data = np.random.rand(n_frames, 200, 200)
+    sample_tracks_data = np.hstack(
+        (
+            np.tile([1, 2, 3, 4], (1, n_frames // 4)).T,
+            np.random.rand(n_frames, 3),
+        )
+    )
+    sample_labels_data = np.random.randint(0, 2, (200, 200))
+    sample_shapes_data = np.random.rand(4, 2)
+    sample_surface_data = (
+        np.random.rand(4, 2),  # vertices
+        np.array([[0, 1, 2], [1, 2, 3]]),  # faces
+        np.linspace(0, 1, 4),  # values
+    )
+    sample_vector_data = np.random.rand(100, 2, 2)
+
+    return {
+        "Points": sample_points_data,
+        "Image": sample_image_data,
+        "Tracks": sample_tracks_data,
+        "Labels": sample_labels_data,
+        "Shapes": sample_shapes_data,
+        "Surface": sample_surface_data,
+        "Vectors": sample_vector_data,
+        "n_frames": n_frames,
+    }

--- a/tests/fixtures/napari.py
+++ b/tests/fixtures/napari.py
@@ -23,6 +23,9 @@ def valid_poses_dataset_with_localised_nans(valid_poses_dataset, tmp_path):
     """Return a factory of (path, dataset) pairs representing
     valid pose datasets with NaN values at specific locations.
     """
+    # Make a deep-copy of the valid dataset to avoid modifying the
+    # original fixture
+    ds = valid_poses_dataset.copy(deep=True)
 
     def _valid_poses_dataset_with_localised_nans(nan_location):
         """Return a valid poses dataset and corresponding file with NaN values
@@ -36,10 +39,6 @@ def valid_poses_dataset_with_localised_nans(valid_poses_dataset, tmp_path):
         "left", "right") moving in uniform linear motion for 10 frames in 2D
         space.
         """
-        # Make a deep-copy of the valid dataset to avoid modifying the
-        # original fixture
-        ds = valid_poses_dataset.copy(deep=True)
-
         # Express NaN location in time in "time" coordinates
         if nan_location["time"] == "start":
             time_point = 0

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -319,11 +319,11 @@ def test_dimension_slider_multiple_files(
         ],
         [
             "valid_poses_dataset_short",
-            "valid_poses_dataset_long_nan_start",  # --- has nan
+            "valid_poses_dataset_long_nan_start",
         ],
         [
             "valid_poses_dataset_long",
-            "valid_poses_dataset_short_nan_start",  # --- has nan
+            "valid_poses_dataset_short_nan_start",
         ],
         [
             "valid_poses_dataset_short_nan_start",
@@ -349,23 +349,17 @@ def test_dimension_slider_multiple_files_with_deletion(
         for j in range(len(list_input_data_files))
     ]
 
-    # Check exactly one of the datasets has all NaN values at the start
-    assert (
-        sum(
-            [
-                ds.position.sel(
-                    individuals=ds.coords["individuals"],
-                    keypoints=ds.coords["keypoints"],
-                    time=ds.coords["time"][0],
-                )
-                .isnull()
-                .all()
-                .values
-                for ds in list_datasets
-            ]
-        )
-        == 1
+    # Check the expected number of datasets have all NaN values at the start
+    expected_datasets_with_nans = sum(
+        ["nan" in file_name for file_name in list_input_data_files]
     )
+    actual_datasets_with_nans = sum(
+        [
+            ds.position.sel(time=ds.coords["time"][0]).isnull().all().values
+            for ds in list_datasets
+        ]
+    )
+    assert actual_datasets_with_nans == expected_datasets_with_nans
 
     # Get the maximum number of frames from all datasets
     max_frames = max(ds.sizes["time"] for ds in list_datasets)

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -5,6 +5,8 @@ This is because mocking widget methods would not work after the widget is
 instantiated (the methods would have already been connected to signals).
 """
 
+from contextlib import nullcontext as does_not_raise
+
 import pytest
 from napari.components.dims import RangeTuple
 from napari.layers.points.points import Points
@@ -427,10 +429,8 @@ def test_deletion_all_layers(make_napari_viewer_proxy):
     data_loader_widget._on_load_clicked()
 
     # Delete all layers
-    viewer.layers.clear()
-
-    # Check no errors are raised
-    assert len(viewer.layers) == 0
+    with does_not_raise():
+        viewer.layers.clear()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -56,6 +56,21 @@ def test_button_connected_to_on_clicked(
     mock_method.assert_called_once()
 
 
+# --------test connection to napari events ------------------#
+def test_layer_removed_connected_to_method(make_napari_viewer_proxy):
+    """Test that the widget is connected to napari events."""
+    # Create a mock napari viewer
+    viewer = make_napari_viewer_proxy()
+    data_loader_widget = DataLoader(viewer)
+
+    # Check that the _on_layer_deleted is a callback linked to the
+    # napari layer removal event
+    assert (
+        data_loader_widget._on_layer_deleted.__name__
+        in data_loader_widget.viewer.layers.events.removed.callback_refs
+    )
+
+
 # ------------------- tests for widget methods--------------------------------#
 # In these tests we check if calling a widget method has the expected effects
 

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -18,8 +18,6 @@ from napari.layers import (
     Tracks,
     Vectors,
 )
-
-# from napari.layers.points.points import Points
 from napari.settings import get_settings
 from pytest import DATA_PATHS
 from qtpy.QtWidgets import QComboBox, QDoubleSpinBox, QLineEdit, QPushButton
@@ -455,7 +453,7 @@ def test_dimension_slider_with_deletion(
         data_loader_widget.source_software_combo.setCurrentText("DeepLabCut")
         data_loader_widget._on_load_clicked()
 
-    # Check the frame slider
+    # Check the frame slider after loading all data
     assert viewer.dims.range[0] == RangeTuple(
         start=0.0, stop=max_frames - 1, step=1.0
     )
@@ -466,7 +464,7 @@ def test_dimension_slider_with_deletion(
     # Update maximum number of frames from the remaining layers
     max_frames = max(ds.sizes["time"] for ds in list_datasets[1:])
 
-    # Check the frame slider is as expected
+    # Check the frame slider after deletion
     assert viewer.dims.range[0] == RangeTuple(
         start=0.0, stop=max_frames - 1, step=1.0
     )

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -137,6 +137,27 @@ def test_file_filters_per_source_software(
     )
 
 
+def test_on_layer_deleted(make_napari_viewer_proxy, mocker):
+    """Test that the frame slider check is called when a layer is removed."""
+    # Create a mock napari viewer
+    data_loader_widget = DataLoader(make_napari_viewer_proxy())
+
+    # Mock the frame slider check method
+    mock_frame_slider_check = mocker.patch(
+        "movement.napari.loader_widgets.DataLoader._check_frame_slider_range"
+    )
+
+    # Add a sample layer to the viewer
+    mock_layer = Points(name="mock_layer")
+    data_loader_widget.viewer.add_layer(mock_layer)
+
+    # Delete the layer
+    data_loader_widget.viewer.layers.remove(mock_layer)
+
+    # Check that the slider check method was called
+    mock_frame_slider_check.assert_called_once()
+
+
 def test_on_load_clicked_without_file_path(make_napari_viewer_proxy, capsys):
     """Test that clicking 'Load' without a file path shows a warning."""
     # Instantiate the napari viewer and the data loader widget

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -431,10 +431,15 @@ def test_dimension_slider_with_deletion(
         data_loader_widget.source_software_combo.setCurrentText("DeepLabCut")
         data_loader_widget._on_load_clicked()
 
+    # Check the frame slider
+    assert viewer.dims.range[0] == RangeTuple(
+        start=0.0, stop=max_frames - 1, step=1.0
+    )
+
     # Remove the first loaded layer
     viewer.layers.remove(viewer.layers[0])
 
-    # Get maximum number of frames from the remaining layer / dataset
+    # Update maximum number of frames from the remaining layers
     max_frames = max(ds.sizes["time"] for ds in list_datasets[1:])
 
     # Check the frame slider is as expected

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -59,17 +59,19 @@ def test_button_connected_to_on_clicked(
 
 
 # --------test connection to napari events ------------------#
-def test_layer_removed_connected_to_method(make_napari_viewer_proxy):
-    """Test that the widget is connected to napari events."""
-    # Create a mock napari viewer
+def test_layer_events_connected_to_methods(make_napari_viewer_proxy):
+    """Test the layer added/removed event is connected to the right method."""
     viewer = make_napari_viewer_proxy()
     data_loader_widget = DataLoader(viewer)
 
-    # Check that the _on_layer_deleted is a callback linked to the
-    # napari layer removal event
     assert (
-        data_loader_widget._on_layer_deleted.__name__
+        data_loader_widget._update_frame_slider_range.__name__
         in data_loader_widget.viewer.layers.events.removed.callback_refs
+    )
+
+    assert (
+        data_loader_widget._update_frame_slider_range.__name__
+        in data_loader_widget.viewer.layers.events.inserted.callback_refs
     )
 
 
@@ -137,24 +139,28 @@ def test_file_filters_per_source_software(
     )
 
 
-def test_on_layer_deleted(make_napari_viewer_proxy, mocker):
-    """Test that the frame slider check is called when a layer is removed."""
+def test_on_layer_added_and_deleted(make_napari_viewer_proxy, mocker):
+    """Test the frame slider update is called when a layer is added/removed."""
     # Create a mock napari viewer
     data_loader_widget = DataLoader(make_napari_viewer_proxy())
 
     # Mock the frame slider check method
     mock_frame_slider_check = mocker.patch(
-        "movement.napari.loader_widgets.DataLoader._check_frame_slider_range"
+        "movement.napari.loader_widgets.DataLoader._update_frame_slider_range"
     )
 
     # Add a sample layer to the viewer
     mock_layer = Points(name="mock_layer")
     data_loader_widget.viewer.add_layer(mock_layer)
 
+    # Check that the slider check method was called once
+    mock_frame_slider_check.assert_called_once()
+    mock_frame_slider_check.reset_mock()
+
     # Delete the layer
     data_loader_widget.viewer.layers.remove(mock_layer)
 
-    # Check that the slider check method was called
+    # Check that the slider check method was called once
     mock_frame_slider_check.assert_called_once()
 
 

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -312,16 +312,26 @@ def test_dimension_slider_multiple_files(
         [
             "valid_poses_path_and_ds",
             "valid_poses_path_and_ds_nan_start",
-        ],
+        ],  # one with NaNs at the start remains after deletion
         [
             "valid_poses_path_and_ds",
             "valid_poses_path_and_ds_nan_end",
-        ],
+        ],  # one with NaNs at the end remains after deletion
         [
             "valid_poses_path_and_ds",
             "valid_poses_path_and_ds_nan_start",
             "valid_poses_path_and_ds_nan_end",
-        ],
+        ],  # two remain after deletion, with NaNs at the start and end
+        [
+            "valid_poses_path_and_ds",
+            "valid_poses_path_and_ds_short",
+            "valid_poses_path_and_ds_nan_start",
+        ],  # two remain after deletion, the longest one with NaNs at the start
+        [
+            "valid_poses_path_and_ds",
+            "valid_poses_path_and_ds_short",
+            "valid_poses_path_and_ds_nan_end",
+        ],  # two remain after deletion, the longest one with NaNs at the end
     ],
 )
 def test_dimension_slider_with_deletion(

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -316,10 +316,11 @@ def test_dimension_slider_multiple_files(
         # ["valid_poses_dataset_long", "valid_poses_dataset_short"],
         #   # after deletion of the first, frame slider should match the
         #   "short" dataset
-        # ["valid_poses_dataset_short", "valid_poses_dataset_long"],
+        ["valid_poses_dataset_short", "valid_poses_dataset_long"],
         #   # after deletion of the first, frame slider should match the
         #   "long" dataset
         ["valid_poses_dataset_short", "valid_poses_dataset_long_nan_start"],
+        ["valid_poses_dataset_long_nan_start", "valid_poses_dataset_short"],
     ],
 )
 def test_dimension_slider_multiple_files_with_deletion(
@@ -328,7 +329,7 @@ def test_dimension_slider_multiple_files_with_deletion(
     request,
 ):
     """Test that the dimension slider is set to the correct range of frames
-    after deleting a layer.
+    after loading two point layers, and deleting the first loaded layer.
     """
     # Get the datasets to load (paths and ds)
     list_paths, list_datasets = [
@@ -355,7 +356,7 @@ def test_dimension_slider_multiple_files_with_deletion(
     # Remove the first loaded layer
     viewer.layers.remove(viewer.layers[0])
 
-    # Get maximum number of frames from the remaining dataset
+    # Get maximum number of frames from the 2nd data file
     max_frames = list_datasets[1].sizes["time"]
 
     # Check the frame slider is as expected

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -340,7 +340,7 @@ def test_dimension_slider_multiple_files_with_deletion(
     when loading two point layers, deleting one, and the remaining layer has
     all NaN values at the start.
     """
-    # Get the datasets to load (paths and ds)
+    # Get the input data to load (paths and ds)
     list_paths, list_datasets = [
         [
             request.getfixturevalue(file_name)[j]
@@ -364,7 +364,7 @@ def test_dimension_slider_multiple_files_with_deletion(
     # Get the maximum number of frames from all datasets
     max_frames = max(ds.sizes["time"] for ds in list_datasets)
 
-    # Load each dataset in order
+    # Load each dataset as a points layer in napari
     viewer = make_napari_viewer_proxy()
     data_loader_widget = DataLoader(viewer)
     for file_path in list_paths:
@@ -372,10 +372,10 @@ def test_dimension_slider_multiple_files_with_deletion(
         data_loader_widget.source_software_combo.setCurrentText("DeepLabCut")
         data_loader_widget._on_load_clicked()
 
-    # Remove the first layer
+    # Remove the first loaded layer
     viewer.layers.remove(viewer.layers[0])
 
-    # Get maximum number of frames from the remaining data file
+    # Get maximum number of frames from the remaining layer / dataset
     max_frames = list_datasets[1].sizes["time"]
 
     # Check the frame slider is as expected

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -267,8 +267,16 @@ def test_dimension_slider_with_nans(
     ],
     ids=["long_first", "short_first"],
 )
+@pytest.mark.parametrize(
+    "delete_first_layer",
+    [False, True],
+    ids=["no_layer_deletion", "layer_deletion"],
+)
 def test_dimension_slider_multiple_files(
-    list_input_data_files, make_napari_viewer_proxy, request
+    list_input_data_files,
+    delete_first_layer,
+    make_napari_viewer_proxy,
+    request,
 ):
     """Test that the dimension slider is set to the maximum number of frames
     when multiple files are loaded.
@@ -304,6 +312,20 @@ def test_dimension_slider_multiple_files(
     # in the longest dataset
     _, ds_long = request.getfixturevalue("valid_poses_dataset_long")
     assert max_frames == ds_long.sizes["time"]
+
+    # Simulate deleting the first layer and check the frame slider
+    # is set to the maximum number of frames
+    if delete_first_layer:
+        # Remove the first loaded layer
+        viewer.layers.remove(viewer.layers[0])
+
+        # Get maximum number of frames from the remaining dataset
+        max_frames = list_datasets[1].sizes["time"]
+
+        # Check the frame slider is as expected
+        assert viewer.dims.range[0] == RangeTuple(
+            start=0.0, stop=max_frames - 1, step=1.0
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -268,9 +268,7 @@ def test_dimension_slider_with_nans(
     ids=["long_first", "short_first"],
 )
 def test_dimension_slider_multiple_files(
-    list_input_data_files,
-    make_napari_viewer_proxy,
-    request,
+    list_input_data_files, make_napari_viewer_proxy, request
 ):
     """Test that the dimension slider is set to the maximum number of frames
     when multiple files are loaded.


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
If you load multiple files as points layers and delete one of them, the frame slider is automatically updated to reflect the dimensions of the remaining data. 

However, we currently only force the slider to match the full range of frames when a new point layer is loaded, not when one is removed. So after a delete event, if any file in the remaining data has all NaN values in the first frame (index `0`) or last frame (index `n`), napari will set the frame slider to start with `1` or end at `n-1` respectively. 

I use "frame slider" to refer to what napari documentation calls "dimension slider" for clarity, since in our widget it will represent number of frames most of the time.

**What does this PR do?**
This PR links the frame slider check to a "layer deletion" event. Specifically:
- It links layer deletion events to a `_on_layer_deleted` method, that runs `_check_frame_slider_range`
	- The check is skipped if there are no points layers in the viewer.
-  It adds a test that checks the frame slider is as expected when multiple files are loaded, one is deleted, and the remaining ones start or end with NaNs
- It adds a test to check there are no errors when all layers are deleted  

## References

Relates to #503  

## How has this PR been tested?

Tests pass locally and in CI.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ n/a ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
