### PR TITLE
Added U-turn detection function (issue #362)

### DIFF
--- a/movement/kinematics.py
+++ b/movement/kinematics.py
@@ -948,3 +948,58 @@ def _compute_scaled_path_length(
     valid_proportion = valid_segments / (data.sizes["time"] - 1)
     # return scaled path length
     return compute_norm(displacement).sum(dim="time") / valid_proportion
+
+
+def detect_u_turns(
+    data: xr.DataArray,
+    use_direction: Literal["forward_vector", "displacement"] = "displacement",
+    u_turn_threshold: float = np.pi * 5 / 6,  # 150 degrees in radians
+    camera_view: Literal["top_down", "bottom_up"] = "bottom_up",
+) -> xr.DataArray:
+    """Detect U-turn behavior in a trajectory.
+
+    This function computes the directional change between consecutive time
+    frames and accumulates the rotation angles. If the accumulated angle
+    exceeds a specified threshold, a U-turn is detected.
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        The trajectory data, which must contain the 'time' and 'space' (x, y).
+    use_direction : Literal["forward_vector", "displacement"], optional
+        Method to compute direction vectors, default is `"displacement"`:
+        - `"forward_vector"`: Computes the forward direction vector.
+        - `"displacement"`: Computes displacement vectors.
+    u_turn_threshold : float, optional
+        The angle threshold (in radians) to detect U-turn. Default is (`5π/6`).
+
+    camera_view : Literal["top_down", "bottom_up"], optional
+        Specifies the camera perspective used for computing direction vectors.
+
+    Returns
+    -------
+    xarray.DataArray
+        Indicating whether a U-turn has occurred (`True` for a U-turn).
+
+    """
+    # Compute direction vectors based on the chosen method
+    if use_direction == "forward_vector":
+        direction_vectors = compute_forward_vector(
+            data, "left_ear", "right_ear", camera_view=camera_view
+        )
+    elif use_direction == "displacement":
+        direction_vectors = compute_displacement(data)
+    else:
+        raise ValueError(
+            "use_direction must be 'forward_vector' or 'displacement'"
+        )
+
+    angles = compute_signed_angle_2d(
+        direction_vectors.shift(time=1), direction_vectors
+    )
+    cumulative_rotation = angles.cumsum(dim="time")
+    rotation_range = cumulative_rotation.max(
+        dim="time"
+    ) - cumulative_rotation.min(dim="time")
+    u_turn_detected = rotation_range >= u_turn_threshold
+    return u_turn_detected


### PR DESCRIPTION
Added an U-turn detection function. 

## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

This PR implements U-turn detection, as requested in [issue #362](https://github.com/neuroinformatics-unit/movement/issues/362).

**What does this PR do?**

Using the extreme value difference of the accumulated rotation angle to judge. (support setting extreme value threshold)

## References

[#362](https://github.com/neuroinformatics-unit/movement/issues/362)  

## How has this PR been tested?

The new code has been tested using a fixture that provides a mock dataset for U-turn detection, ensuring that the function detect_u_turns works correctly for both "forward_vector" and "displacement" directions. Tests also verify that the U-turn detection results match the expected values, with results under different thresholds all meeting the expectations.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

The docstring has been updated to explain the new detection method and parameters.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
