### PR TITLE
Add trajectory complexity measures - implement straightness index

### DIFF
--- a/examples/trajectory_straightness.py
+++ b/examples/trajectory_straightness.py
@@ -1,0 +1,209 @@
+"""Trajectory straightness analysis
+==============================
+
+This example demonstrates how to compute and visualize the straightness index
+of animal movement trajectories.
+"""
+
+# %%
+# Imports
+# -------
+
+# For interactive plots: install ipympl with `pip install ipympl` and uncomment
+# the following line in your notebook
+# %matplotlib widget
+import numpy as np
+from matplotlib import pyplot as plt
+
+from movement import sample_data
+from movement.trajectory_complexity import compute_straightness_index
+from movement.plots import plot_centroid_trajectory
+
+# %%
+# Load sample dataset
+# ------------------
+# First, we load an example dataset. In this case, we select the
+# ``SLEAP_three-mice_Aeon_proofread`` sample data.
+ds = sample_data.fetch_dataset(
+    "SLEAP_three-mice_Aeon_proofread.analysis.h5",
+)
+
+print(ds)
+
+# %%
+# We'll use the position data for our trajectory analysis
+position = ds.position
+
+# %% 
+# Plot trajectories
+# ----------------
+# First, let's visualize the trajectories of the mice in the XY plane,
+# to get a sense of their movement patterns.
+
+fig, ax = plt.subplots(1, 1, figsize=(10, 8))
+# Plot trajectories for each mouse
+for mouse_name, col in zip(
+    position.individuals.values,
+    ["r", "g", "b"],  # colors
+    strict=False,
+):
+    plot_centroid_trajectory(
+        position,
+        individual=mouse_name,
+        ax=ax,  # Use the same axes for all plots
+        c=col,
+        marker="o",
+        s=10,
+        alpha=0.2,
+        label=mouse_name,
+    )
+    ax.legend().set_alpha(1)
+
+ax.set_title("Mouse Trajectories")
+ax.invert_yaxis()  # Make y-axis match image coordinates (0 at top)
+plt.tight_layout()
+
+# %% 
+# Compute Straightness Index
+# -------------------------
+# Now let's compute the straightness index for each mouse trajectory. 
+# The straightness index is a measure of how direct a path is, calculated as 
+# the ratio of the straight-line distance between start and end points to 
+# the total path length traveled.
+#
+# Values close to 1 indicate nearly straight paths, while values closer to 0 
+# indicate more tortuous or winding paths.
+
+straightness = compute_straightness_index(position)
+print("Straightness index by individual:")
+for ind in straightness.individual.values:
+    print(f"  {ind}: {straightness.sel(individuals=ind).item():.3f}")
+
+# %%
+# Visualize Trajectories with Straightness Index
+# ---------------------------------------------
+# Let's create a more informative plot that shows both the trajectories
+# and their straightness index values.
+
+fig, ax = plt.subplots(1, 1, figsize=(12, 8))
+
+# Plot trajectories for each mouse
+for mouse_name, col in zip(
+    position.individuals.values,
+    ["r", "g", "b"],  # colors
+    strict=False,
+):
+    plot_centroid_trajectory(
+        position,
+        individual=mouse_name,
+        ax=ax,
+        c=col,
+        marker="o",
+        s=10,
+        alpha=0.2,
+    )
+    
+    # Add a text annotation with the straightness index
+    si_value = straightness.sel(individuals=mouse_name).item()
+    # Get the starting point of the trajectory
+    start_x = position.sel(individuals=mouse_name, space="x").isel(time=0).item()
+    start_y = position.sel(individuals=mouse_name, space="y").isel(time=0).item()
+    
+    # Add label with straightness index
+    ax.text(
+        start_x, start_y - 30,  # Position the text near the start
+        f"{mouse_name}: SI = {si_value:.3f}",
+        fontsize=12,
+        color=col,
+        bbox=dict(facecolor="white", alpha=0.7),
+    )
+
+ax.set_title("Mouse Trajectories with Straightness Index (SI)")
+ax.invert_yaxis()
+plt.tight_layout()
+
+# %%
+# Computing Straightness for Different Time Segments
+# ------------------------------------------------
+# We can also compute straightness for specific time segments of the trajectory.
+# This can be useful for analyzing how path complexity changes during different
+# experimental phases or time periods.
+
+# Define start and stop times (in seconds)
+time_segments = [
+    (0, 1),      # First second
+    (1, 2),      # Second second
+    (2, None),   # Remainder of trajectory
+]
+
+# Create a figure with subplots for each time segment
+fig, axes = plt.subplots(len(time_segments), 1, figsize=(10, 12))
+
+for i, (start, stop) in enumerate(time_segments):
+    ax = axes[i]
+    
+    # Compute straightness for this segment
+    segment_straightness = compute_straightness_index(
+        position, start=start, stop=stop
+    )
+    
+    # Title with time segment information
+    stop_str = f"{stop}" if stop is not None else "end"
+    ax.set_title(f"Time segment: {start} to {stop_str} seconds")
+    
+    # Plot trajectories for each mouse in this segment
+    for mouse_name, col in zip(
+        position.individuals.values,
+        ["r", "g", "b"],  # colors
+        strict=False,
+    ):
+        # Filter position data to the time segment
+        if stop is not None:
+            segment_pos = position.sel(
+                time=slice(start, stop), individuals=mouse_name
+            )
+        else:
+            segment_pos = position.sel(
+                time=slice(start, None), individuals=mouse_name
+            )
+        
+        # Plot the trajectory segment
+        ax.scatter(
+            segment_pos.sel(space="x"),
+            segment_pos.sel(space="y"),
+            c=col,
+            s=10,
+            alpha=0.5,
+            label=f"{mouse_name}: SI = {segment_straightness.sel(individuals=mouse_name).item():.3f}"
+        )
+        
+        # Connect points with lines
+        ax.plot(
+            segment_pos.sel(space="x"),
+            segment_pos.sel(space="y"),
+            c=col,
+            alpha=0.3,
+        )
+    
+    ax.legend()
+    ax.invert_yaxis()
+    ax.set_xlabel("x (pixels)")
+    ax.set_ylabel("y (pixels)")
+
+plt.tight_layout()
+
+# %%
+# Conclusion
+# ---------
+# The straightness index provides a simple but effective measure of path 
+# complexity. Values close to 1 indicate more direct movement, while values
+# closer to 0 indicate more tortuous or complex movement patterns.
+#
+# In this example, we've seen how to:
+#
+# 1. Compute the straightness index for entire trajectories
+# 2. Visualize trajectories alongside their straightness index values
+# 3. Analyze straightness for specific time segments
+#
+# This metric is useful for quantifying movement patterns across different
+# experimental conditions or comparing movement behavior between individuals. 

--- a/movement/__init__.py
+++ b/movement/__init__.py
@@ -15,3 +15,6 @@ xr.set_options(keep_attrs=True, display_expand_data=False)
 
 # initialize logger upon import
 configure_logging()
+
+# Import trajectory complexity functions to make them available at package level
+from movement.trajectory_complexity import compute_straightness_index

--- a/movement/trajectory_complexity.py
+++ b/movement/trajectory_complexity.py
@@ -1,0 +1,85 @@
+"""Compute trajectory complexity measures.
+
+This module provides functions to compute various measures of trajectory 
+complexity, which quantify how straight or tortuous a path is. These metrics 
+are useful for analyzing animal movement patterns across space.
+"""
+
+import numpy as np
+import xarray as xr
+
+from movement.kinematics import compute_displacement, compute_path_length
+from movement.utils.logging import log_error, log_to_attrs, log_warning
+from movement.utils.vector import compute_norm
+from movement.validators.arrays import validate_dims_coords
+
+
+@log_to_attrs
+def compute_straightness_index(
+    data: xr.DataArray,
+    start: float | None = None,
+    stop: float | None = None,
+) -> xr.DataArray:
+    """Compute the straightness index of a trajectory.
+    
+    The straightness index is defined as the ratio of the Euclidean distance 
+    between the start and end points of a trajectory to the total path length. 
+    Values range from 0 to 1, where 1 indicates a perfectly straight path,
+    and values closer to 0 indicate more tortuous paths.
+    
+    Parameters
+    ----------
+    data : xarray.DataArray
+        The input data containing position information, with ``time``
+        and ``space`` (in Cartesian coordinates) as required dimensions.
+    start : float, optional
+        The start time of the trajectory. If None (default),
+        the minimum time coordinate in the data is used.
+    stop : float, optional
+        The end time of the trajectory. If None (default),
+        the maximum time coordinate in the data is used.
+        
+    Returns
+    -------
+    xarray.DataArray
+        An xarray DataArray containing the computed straightness index,
+        with dimensions matching those of the input data,
+        except ``time`` and ``space`` are removed.
+        
+    Notes
+    -----
+    The straightness index (SI) is calculated as:
+    
+    SI = Euclidean distance / Path length
+    
+    where the Euclidean distance is the straight-line distance between the
+    start and end points, and the path length is the total distance traveled
+    along the trajectory.
+    
+    References
+    ----------
+    .. [1] Batschelet, E. (1981). Circular statistics in biology.
+           London: Academic Press.
+    """
+    validate_dims_coords(data, {"time": [], "space": []})
+
+    # Determine start and stop points
+    if start is None:
+        start = data.time.min().item()
+    if stop is None:
+        stop = data.time.max().item()
+
+    # Extract start and end positions
+    start_pos = data.sel(time=start, method="nearest")
+    end_pos = data.sel(time=stop, method="nearest")
+
+    # Calculate Euclidean distance between start and end points
+    euclidean_distance = compute_norm(end_pos - start_pos)
+
+    # Calculate path length
+    path_length = compute_path_length(data, start=start, stop=stop)
+
+    # Compute straightness index
+    straightness_index = euclidean_distance / path_length
+
+    return straightness_index 

--- a/tests/test_unit/test_trajectory_complexity.py
+++ b/tests/test_unit/test_trajectory_complexity.py
@@ -1,0 +1,101 @@
+"""Unit tests for the trajectory complexity module."""
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from movement.trajectory_complexity import compute_straightness_index
+
+
+@pytest.fixture
+def straight_trajectory():
+    """Create a straight line trajectory."""
+    position = np.zeros((20, 2, 1, 1))
+    # x-coordinate increases linearly from 0 to 19
+    position[:, 0, 0, 0] = np.arange(20)
+    # y-coordinate stays at 0
+    position[:, 1, 0, 0] = 0
+
+    return xr.DataArray(
+        position,
+        dims=["time", "space", "keypoints", "individual"],
+        coords={
+            "time": np.arange(20) / 10,  # time in seconds
+            "space": ["x", "y"],
+            "keypoints": ["centroid"],
+            "individual": ["test_subject"],
+        },
+    )
+
+
+@pytest.fixture
+def zigzag_trajectory():
+    """Create a zigzag trajectory."""
+    position = np.zeros((20, 2, 1, 1))
+    # x-coordinate increases linearly from 0 to 19
+    position[:, 0, 0, 0] = np.arange(20)
+    # y-coordinate alternates between -1 and 1
+    position[:, 1, 0, 0] = np.sin(np.arange(20) * np.pi / 2)
+
+    return xr.DataArray(
+        position,
+        dims=["time", "space", "keypoints", "individual"],
+        coords={
+            "time": np.arange(20) / 10,  # time in seconds
+            "space": ["x", "y"],
+            "keypoints": ["centroid"],
+            "individual": ["test_subject"],
+        },
+    )
+
+
+@pytest.fixture
+def circular_trajectory():
+    """Create a circular trajectory."""
+    position = np.zeros((20, 2, 1, 1))
+    # x and y follow a circular path
+    t = np.linspace(0, 2 * np.pi, 20)
+    position[:, 0, 0, 0] = 5 * np.cos(t) + 10  # center at x=10
+    position[:, 1, 0, 0] = 5 * np.sin(t) + 10  # center at y=10
+
+    return xr.DataArray(
+        position,
+        dims=["time", "space", "keypoints", "individual"],
+        coords={
+            "time": np.arange(20) / 10,  # time in seconds
+            "space": ["x", "y"],
+            "keypoints": ["centroid"],
+            "individual": ["test_subject"],
+        },
+    )
+
+
+def test_straightness_index_straight_line(straight_trajectory):
+    """Test that a straight line has straightness index close to 1."""
+    result = compute_straightness_index(straight_trajectory)
+    # Should be very close to 1 for a straight line
+    assert result.sel(keypoints="centroid", individual="test_subject").item() > 0.99
+
+
+def test_straightness_index_zigzag(zigzag_trajectory):
+    """Test that a zigzag path has straightness index less than 1."""
+    result = compute_straightness_index(zigzag_trajectory)
+    # Should be less than 1 for a zigzag path
+    assert result.sel(keypoints="centroid", individual="test_subject").item() < 0.9
+
+
+def test_straightness_index_circle(circular_trajectory):
+    """Test that a circular path that returns to start has low straightness."""
+    result = compute_straightness_index(circular_trajectory)
+    # Should be very low for a circle that nearly returns to starting point
+    assert result.sel(keypoints="centroid", individual="test_subject").item() < 0.2
+
+
+def test_straightness_index_with_time_range(straight_trajectory):
+    """Test compute_straightness_index with explicit time range."""
+    # Use only first half of trajectory
+    result = compute_straightness_index(
+        straight_trajectory, start=0.0, stop=1.0
+    )
+    # Should still be very close to 1 for partial straight line
+    assert result.sel(keypoints="centroid", individual="test_subject").item() > 0.99 


### PR DESCRIPTION
movement/trajectory_complexity.py - The module containing the compute_straightness_index function
tests/test_unit/test_trajectory_complexity.py - Unit tests for the straightness index
examples/trajectory_straightness.py - Example 
movement/__init__.py - Updated to expose the new function


This is the implementation of just compute_straightness_index  as mentioned by @niksirbi in Methods to measure complexity of trajectories (paths) #406 Open #506