### PR TITLE
Small fixes to the ROI distances and angles example

### DIFF
--- a/examples/boundary_angles.py
+++ b/examples/boundary_angles.py
@@ -416,11 +416,11 @@ angle_plot.show()
 # Egocentric angles, on the other hand, fluctuate more due to their sensitivity
 # to changes in the forward vector. Outside frames 200-400, we see trends:
 #
-# - ``AEON3B_TP2`` moves clockwise around the ring, so its egocentric
+# - ``AEON3B_TP2`` moves counter-clockwise around the ring, so its egocentric
 #   angle decreases ever so slightly with time - almost hitting an angle of 0
 #   degrees as it moves along the direction of closest approach after passing
 #   the other individuals.
-# - The other two individuals move counter-clockwise, so their angles show a
+# - The other two individuals move clockwise, so their angles show a
 #   gradual increase with time. Because the two individuals occasionally get in
 #   each others' way, we see frequent "spikes" in their egocentric angles as
 #   their forward vectors rapidly change.

--- a/examples/boundary_angles.py
+++ b/examples/boundary_angles.py
@@ -144,15 +144,9 @@ arena_fig, arena_ax = plt.subplots(1, 1)
 # Overlay an image of the experimental arena
 arena_ax.imshow(plt.imread(arena_image))
 
-central_region.plot(
-    arena_ax, facecolor="lightblue", alpha=0.25, label=central_region.name
-)
-nest_region.plot(
-    arena_ax, facecolor="green", alpha=0.25, label=nest_region.name
-)
-ring_region.plot(
-    arena_ax, facecolor="blue", alpha=0.25, label=ring_region.name
-)
+central_region.plot(arena_ax, facecolor="lightblue", alpha=0.25)
+nest_region.plot(arena_ax, facecolor="green", alpha=0.25)
+ring_region.plot(arena_ax, facecolor="blue", alpha=0.25)
 
 # Plot trajectories of the individuals
 mouse_names_and_colours = list(


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

While reading the example as published on the website. I spotted a few minor issues. I decided to fix them right away, to avoid forgetting about it.

**What does this PR do?**

- It removes the redundant `label=ragion.name` parameter from calls to the `.plot()` method. That method assigns that label name by default.
- Mentions of (counter)-clockwise directions towards the end of the example were flipped. The updated ones should be correct (based on the video).

## References

#440 

## How has this PR been tested?

Local docs build.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

It is in itself and update of docs.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
