### PR TITLE
Ensure derived data variables have correct name

### DIFF
--- a/movement/kinematics.py
+++ b/movement/kinematics.py
@@ -317,7 +317,9 @@ def compute_forward_vector(
         space="z"
     )  # keep only the first 2 spatal dimensions of the result
     # Return unit vector
-    return convert_to_unit(forward_vector)
+    result = convert_to_unit(forward_vector)
+    result.name = "forward_vector"
+    return result
 
 
 def compute_head_direction_vector(
@@ -446,6 +448,7 @@ def compute_forward_vector_angle(
     if in_degrees:
         heading_array = np.rad2deg(heading_array)
 
+    heading_array.name = "forward_vector_angle"
     return heading_array
 
 
@@ -542,6 +545,7 @@ def _cdist(
         }
     )
     # Drop any squeezed coordinates
+    result.name = "distance"
     return result.squeeze(drop=True)
 
 

--- a/movement/kinematics.py
+++ b/movement/kinematics.py
@@ -365,7 +365,7 @@ def compute_head_direction_vector(
     result = compute_forward_vector(
         data, left_keypoint, right_keypoint, camera_view=camera_view
     )
-    result.name = "head_direction"
+    result.name = "head_direction_vector"
     return result
 
 

--- a/movement/kinematics.py
+++ b/movement/kinematics.py
@@ -546,8 +546,8 @@ def _cdist(
             elem2: getattr(a, labels_dim).values,
         }
     )
-    # Drop any squeezed coordinates
     result.name = "distance"
+    # Drop any squeezed coordinates
     return result.squeeze(drop=True)
 
 

--- a/movement/utils/vector.py
+++ b/movement/utils/vector.py
@@ -273,6 +273,7 @@ def compute_signed_angle_2d(
     # arctan2 returns values in [-pi, pi].
     # We need to map -pi angles to pi, to stay in the (-pi, pi] range
     angles.values[angles <= -np.pi] = np.pi
+    angles.name = "signed_angle"
     return angles
 
 

--- a/tests/test_integration/test_kinematics_vector_transform.py
+++ b/tests/test_integration/test_kinematics_vector_transform.py
@@ -61,6 +61,7 @@ def test_cart2pol_transform_on_kinematics(
     kinematic_array_cart = getattr(kin, f"compute_{kinematic_variable}")(
         ds.position
     )
+    assert kinematic_array_cart.name == kinematic_variable
     kinematic_array_pol = vector.cart2pol(kinematic_array_cart)
 
     # Build expected data array

--- a/tests/test_unit/test_kinematics.py
+++ b/tests/test_unit/test_kinematics.py
@@ -472,10 +472,9 @@ def test_compute_forward_vector_with_invalid_input(
 
     # Catch error
     with pytest.raises(expected_error, match=re.escape(expected_match_str)):
-        forward_vector = kinematics.compute_forward_vector(
+        kinematics.compute_forward_vector(
             input_data, keypoints[0], keypoints[1]
         )
-        assert forward_vector.name == "forward_vector"
 
 
 def test_nan_behavior_forward_vector(
@@ -716,10 +715,9 @@ def test_compute_pairwise_distances_with_invalid_input(
 ):
     """Test that an error is raised for invalid inputs."""
     with pytest.raises(ValueError):
-        result = kinematics.compute_pairwise_distances(
+        kinematics.compute_pairwise_distances(
             request.getfixturevalue(ds).position, dim, pairs
         )
-        assert result.name == "distance"
 
 
 class TestForwardVectorAngle:

--- a/tests/test_unit/test_kinematics.py
+++ b/tests/test_unit/test_kinematics.py
@@ -44,6 +44,7 @@ class TestComputeKinematics:
         kinematic_array = getattr(kinematics, f"compute_{kinematic_variable}")(
             position
         )
+        assert kinematic_array.name == kinematic_variable
         # Figure out which dimensions to expect in kinematic_array
         # and in the final xarray.DataArray
         expected_dims = ["time", "individuals"]
@@ -112,6 +113,7 @@ class TestComputeKinematics:
         kinematic_array = getattr(kinematics, f"compute_{kinematic_variable}")(
             position
         )
+        assert kinematic_array.name == kinematic_variable
         # compute n nans in kinematic array per individual
         n_nans_kinematics_per_indiv = [
             helpers.count_nans(kinematic_array.isel(individuals=i))
@@ -203,6 +205,7 @@ def test_path_length_across_time_ranges(
         path_length = kinematics.compute_path_length(
             position, start=start, stop=stop
         )
+        assert path_length.name == "path_length"
 
         # Expected number of segments (displacements) in selected time range
         num_segments = 9  # full time range: 10 frames - 1
@@ -266,6 +269,7 @@ def test_path_length_with_nan(
         path_length = kinematics.compute_path_length(
             position, nan_policy=nan_policy
         )
+        assert path_length.name == "path_length"
         # Get path_length for individual "id_0" as a numpy array
         path_length_id_0 = path_length.sel(individuals="id_0").values
         # Check them against the expected values
@@ -312,9 +316,10 @@ def test_path_length_nan_warn_threshold(
     """
     position = valid_poses_dataset_with_nan.position
     with expected_exception:
-        kinematics.compute_path_length(
+        result = kinematics.compute_path_length(
             position, nan_warn_threshold=nan_warn_threshold
         )
+        assert result.name == "path_length"
 
 
 @pytest.fixture
@@ -408,6 +413,10 @@ def test_compute_forward_vector(valid_data_array_for_forward_vector):
         "right_ear",
         camera_view="bottom_up",
     )
+    assert forward_vector.name == "forward_vector"
+    assert forward_vector_flipped.name == "forward_vector"
+    assert head_vector.name == "head_direction"
+
     known_vectors = np.array([[[0, -1]], [[1, 0]], [[0, 1]], [[-1, 0]]])
 
     for output_array in [forward_vector, forward_vector_flipped, head_vector]:
@@ -463,9 +472,10 @@ def test_compute_forward_vector_with_invalid_input(
 
     # Catch error
     with pytest.raises(expected_error, match=re.escape(expected_match_str)):
-        kinematics.compute_forward_vector(
+        forward_vector = kinematics.compute_forward_vector(
             input_data, keypoints[0], keypoints[1]
         )
+        assert forward_vector.name == "forward_vector"
 
 
 def test_nan_behavior_forward_vector(
@@ -480,6 +490,7 @@ def test_nan_behavior_forward_vector(
     forward_vector = kinematics.compute_forward_vector(
         valid_data_array_for_forward_vector_with_nan, "left_ear", "right_ear"
     )
+    assert forward_vector.name == "forward_vector"
     # Check coord preservation
     for preserved_coord in ["time", "space", "individuals"]:
         assert np.all(
@@ -552,6 +563,7 @@ def test_cdist_with_known_values(dim, expected_data, valid_poses_dataset):
     a = input_dataarray.sel({dim: pairs[0]})
     b = input_dataarray.sel({dim: pairs[1]})
     result = kinematics._cdist(a, b, dim)
+    assert result.name == "distance"
     xr.testing.assert_equal(
         result,
         expected,
@@ -624,7 +636,9 @@ def test_cdist_with_single_dim_inputs(valid_dataset, selection_fn, request):
         valid_dataset = request.getfixturevalue(valid_dataset)
         position = valid_dataset.position
         a, b = selection_fn(position)
-        assert isinstance(kinematics._cdist(a, b, "individuals"), xr.DataArray)
+        result = kinematics._cdist(a, b, "individuals")
+        assert result.name == "distance"
+        assert isinstance(result, xr.DataArray)
 
 
 @pytest.mark.parametrize(
@@ -662,12 +676,17 @@ def test_compute_pairwise_distances_with_valid_pairs(
         valid_poses_dataset.position, dim, pairs
     )
     if isinstance(result, dict):
+        for _, value in result.items():
+            assert isinstance(value, xr.DataArray)
+            assert value.name == "distance"
         expected_data_vars = [
             f"dist_{pair[0]}_{pair[1]}" for pair in expected_data_vars
         ]
+        print(result)
         assert set(result.keys()) == set(expected_data_vars)
     else:  # expect single DataArray
         assert isinstance(result, xr.DataArray)
+        assert result.name == "distance"
 
 
 @pytest.mark.parametrize(
@@ -697,9 +716,10 @@ def test_compute_pairwise_distances_with_invalid_input(
 ):
     """Test that an error is raised for invalid inputs."""
     with pytest.raises(ValueError):
-        kinematics.compute_pairwise_distances(
+        result = kinematics.compute_pairwise_distances(
             request.getfixturevalue(ds).position, dim, pairs
         )
+        assert result.name == "distance"
 
 
 class TestForwardVectorAngle:
@@ -803,6 +823,8 @@ class TestForwardVectorAngle:
             right_keypoint=right_keypoint,
             reference_vector=reference_vector,
         )
+        assert without_orientations_swapped.name == "forward_vector_angle"
+        assert with_orientations_swapped.name == "forward_vector_angle"
 
         expected_orientations = without_orientations_swapped.copy(deep=True)
         if swap_left_right:
@@ -841,6 +863,8 @@ class TestForwardVectorAngle:
             reference_vector=reference_vector,
             in_degrees=True,
         )
+        assert in_radians.name == "forward_vector_angle"
+        assert in_degrees.name == "forward_vector_angle"
 
         xr.testing.assert_allclose(in_degrees, np.rad2deg(in_radians))
 
@@ -900,6 +924,9 @@ class TestForwardVectorAngle:
             right_keypoint=right_keypoint,
             reference_vector=reference_vector,
         )
+
+        assert untranslated_output.name == "forward_vector_angle"
+        assert translated_output.name == "forward_vector_angle"
 
         xr.testing.assert_allclose(untranslated_output, translated_output)
 

--- a/tests/test_unit/test_kinematics.py
+++ b/tests/test_unit/test_kinematics.py
@@ -415,7 +415,7 @@ def test_compute_forward_vector(valid_data_array_for_forward_vector):
     )
     assert forward_vector.name == "forward_vector"
     assert forward_vector_flipped.name == "forward_vector"
-    assert head_vector.name == "head_direction"
+    assert head_vector.name == "head_direction_vector"
 
     known_vectors = np.array([[[0, -1]], [[1, 0]], [[0, 1]], [[-1, 0]]])
 
@@ -681,7 +681,6 @@ def test_compute_pairwise_distances_with_valid_pairs(
         expected_data_vars = [
             f"dist_{pair[0]}_{pair[1]}" for pair in expected_data_vars
         ]
-        print(result)
         assert set(result.keys()) == set(expected_data_vars)
     else:  # expect single DataArray
         assert isinstance(result, xr.DataArray)

--- a/tests/test_unit/test_vector.py
+++ b/tests/test_unit/test_vector.py
@@ -322,6 +322,9 @@ class TestComputeSignedAngle:
                 left_vector, right_vector, v_as_left_operand=True
             )
 
+            assert computed_angles.name == "signed_angle"
+            assert computed_angles_reversed.name == "signed_angle"
+
             xr.testing.assert_allclose(computed_angles, expected_angles)
             xr.testing.assert_allclose(
                 computed_angles_reversed, expected_angles_reversed
@@ -390,4 +393,5 @@ class TestComputeSignedAngle:
         )
 
         computed_angles = vector.compute_signed_angle_2d(v_left, v_right)
+        assert computed_angles.name == "signed_angle"
         xr.testing.assert_allclose(computed_angles, expected_angles)


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

This PR ensures that derived data variables retain their correct name attributes when computed as standalone arrays.

**What does this PR do?**

This PR explicitly sets the name attribute for derived data variables.

## References

#321 

## How has this PR been tested?

Tested through unit tests.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

Yes, this PR requires a documentation update to inform users that derived variables now have a default name attribute set automatically.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
