### PR TITLE
Rename source format

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -58,13 +58,17 @@ jobs:
           activate-environment: movement-env
       - name: "Ensure D: Drive on Windows"
         if: matrix.os == 'windows-latest'
+        shell: cmd
         run: |
           echo Current directory: %CD%
           if not "%CD:~0,2%"=="D:" (
             echo Switching to D: drive
             D:
-            cd D:\test_dir
-            mkdir D:\test_dir 2>nul
+            cd "%GITHUB_WORKSPACE%"
+            if not "%CD:~0,2%"=="D:" (
+              echo ERROR: Failed to switch to D: drive
+              exit 1
+            )
             echo Now on: %CD%
           ) else (
             echo Already on D: drive

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -56,6 +56,19 @@ jobs:
           auto-update-conda: true
           channels: conda-forge,defaults
           activate-environment: movement-env
+      - name: "Ensure D: Drive on Windows"
+        if: matrix.os == 'windows-latest'
+        run: |
+          echo Current directory: %CD%
+          if not "%CD:~0,2%"=="D:" (
+            echo Switching to D: drive
+            D:
+            cd D:\test_dir
+            mkdir D:\test_dir 2>nul
+            echo Now on: %CD%
+          ) else (
+            echo Already on D: drive
+          )
       - uses: neuroinformatics-unit/actions/test@v2
         with:
           python-version: ${{ matrix.python-version }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -415,7 +415,7 @@ To add a new file, you will need to:
 ```yaml
 "SLEAP_three-mice_Aeon_proofread.analysis.h5":
   sha256sum: "82ebd281c406a61536092863bc51d1a5c7c10316275119f7daf01c1ff33eac2a"
-  source_software: "SLEAP"
+  source_format: "SLEAP"
   type: "poses"  # "poses" or "bboxes" depending on the type of tracked data
   fps: 50
   species: "mouse"

--- a/docs/source/user_guide/input_output.md
+++ b/docs/source/user_guide/input_output.md
@@ -44,7 +44,7 @@ ds = load_poses.from_sleap_file("/path/to/file.analysis.h5", fps=30)
 
 # or equivalently
 ds = load_poses.from_file(
-    "/path/to/file.analysis.h5", source_software="SLEAP", fps=30
+    "/path/to/file.analysis.h5", source_format="SLEAP", fps=30
 )
 ```
 To load [SLEAP analysis files](sleap:tutorials/analysis) in .slp format (experimental, see notes in {func}`movement.io.load_poses.from_sleap_file`):
@@ -62,7 +62,7 @@ ds = load_poses.from_dlc_file("/path/to/file.h5", fps=30)
 
 # or equivalently
 ds = load_poses.from_file(
-    "/path/to/file.h5", source_software="DeepLabCut", fps=30
+    "/path/to/file.h5", source_format="DeepLabCut", fps=30
 )
 ```
 
@@ -80,7 +80,7 @@ ds = load_poses.from_lp_file("/path/to/file.analysis.csv", fps=30)
 
 # or equivalently
 ds = load_poses.from_file(
-    "/path/to/file.analysis.csv", source_software="LightningPose", fps=30
+    "/path/to/file.analysis.csv", source_format="LightningPose", fps=30
 )
 ```
 :::
@@ -95,7 +95,7 @@ ds = load_poses.from_anipose_file(
 
 # or equivalently
 ds = load_poses.from_file(
-    "/path/to/file.analysis.csv", source_software="Anipose", fps=30, individual_name="individual_0"
+    "/path/to/file.analysis.csv", source_format="Anipose", fps=30, individual_name="individual_0"
 )
 
 ```
@@ -149,7 +149,7 @@ ds = load_bboxes.from_via_tracks_file("path/to/file.csv", fps=30)
 # or equivalently
 ds = load_bboxes.from_file(
     "path/to/file.csv",
-    source_software="VIA-tracks",
+    source_format="VIA-tracks",
     fps=30,
 )
 ```

--- a/docs/source/user_guide/movement_dataset.md
+++ b/docs/source/user_guide/movement_dataset.md
@@ -55,7 +55,7 @@ Data variables:
 Attributes:
     fps:              50.0
     time_unit:        seconds
-    source_software:  SLEAP
+    source_format:  SLEAP
     source_file:      /home/user/.movement/data/poses/SLEAP_three-mice_Aeon...
     ds_type:          poses
     frame_path:       /home/user/.movement/data/frames/three-mice_Aeon_fram...
@@ -88,7 +88,7 @@ Data variables:
     confidence   (time, individuals) float64 3kB nan nan nan nan ... nan nan nan
 Attributes:
     time_unit:        frames
-    source_software:  VIA-tracks
+    source_format:  VIA-tracks
     source_file:      /home/user/.movement/data/bboxes/VIA_multiple-crabs_5...
     ds_type:          bboxes
 ```
@@ -175,7 +175,7 @@ Both poses and bounding boxes datasets in `movement` have associated metadata. T
 Right after loading a `movement` dataset, the following **attributes** are created:
 - `fps`: the number of frames per second in the video (absent if not provided by the user during loading).
 - `time_unit`: the unit of the `time` **coordinates** (either `frames` or `seconds`).
-- `source_software`: the software that produced the pose or bounding box tracks.
+- `source_format`: the software that produced the pose or bounding box tracks.
 - `source_file`: the path to the file from which the data were loaded (absent if the dataset was not loaded from a file).
 - `ds_type`: the type of dataset loaded (either `poses` or `bboxes`).
 

--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -29,7 +29,7 @@ def from_numpy(
     individual_names: list[str] | None = None,
     frame_array: np.ndarray | None = None,
     fps: float | None = None,
-    source_software: str | None = None,
+    source_format: str | None = None,
 ) -> xr.Dataset:
     """Create a ``movement`` bounding boxes dataset from NumPy arrays.
 
@@ -70,7 +70,7 @@ def from_numpy(
         the ``time`` coordinates are in seconds, they will indicate the
         elapsed time from the capture of the first frame (assumed to be frame
         0).
-    source_software : str, optional
+    source_format : str, optional
         Name of the software that generated the data. Defaults to None.
 
     Returns
@@ -145,14 +145,14 @@ def from_numpy(
         individual_names=individual_names,
         frame_array=frame_array,
         fps=fps,
-        source_software=source_software,
+        source_format=source_format,
     )
     return _ds_from_valid_data(valid_bboxes_data)
 
 
 def from_file(
     file_path: Path | str,
-    source_software: Literal["VIA-tracks"],
+    source_format: Literal["VIA-tracks"],
     fps: float | None = None,
     use_frame_numbers_from_file: bool = False,
     frame_regexp: str = DEFAULT_FRAME_REGEXP,
@@ -166,7 +166,7 @@ def from_file(
     file_path : pathlib.Path or str
         Path to the file containing the tracked bounding boxes. Currently
         only VIA-tracks .csv files are supported.
-    source_software : "VIA-tracks".
+    source_format : "VIA-tracks".
         The source software of the file. Currently only files from the
         VIA 2.0.12 annotator [1]_ ("VIA-tracks") are supported.
         See .
@@ -216,12 +216,12 @@ def from_file(
     >>> from movement.io import load_bboxes
     >>> ds = load_bboxes.from_file(
     >>>     "path/to/file.csv",
-    >>>     source_software="VIA-tracks",
+    >>>     source_format="VIA-tracks",
     >>>     fps=30,
     >>> )
 
     """
-    if source_software == "VIA-tracks":
+    if source_format == "VIA-tracks":
         return from_via_tracks_file(
             file_path,
             fps,
@@ -230,7 +230,7 @@ def from_file(
         )
     else:
         raise log_error(
-            ValueError, f"Unsupported source software: {source_software}"
+            ValueError, f"Unsupported source software: {source_format}"
         )
 
 
@@ -356,11 +356,11 @@ def from_via_tracks_file(
             else None
         ),
         fps=fps,
-        source_software="VIA-tracks",
+        source_format="VIA-tracks",
     )  # it validates the dataset via ValidBboxesDataset
 
     # Add metadata as attributes
-    ds.attrs["source_software"] = "VIA-tracks"
+    ds.attrs["source_format"] = "VIA-tracks"
     ds.attrs["source_file"] = file.path.as_posix()
 
     logger.info(f"Loaded tracks of the bounding boxes from {via_file.path}:")
@@ -666,7 +666,7 @@ def _ds_from_valid_data(data: ValidBboxesDataset) -> xr.Dataset:
     time_unit = "frames"
 
     dataset_attrs: dict[str, str | float | None] = {
-        "source_software": data.source_software,
+        "source_format": data.source_format,
         "ds_type": "bboxes",
     }
     # if fps is provided:

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -52,7 +52,7 @@ class DataLoader(QWidget):
         self.setLayout(QFormLayout())
 
         # Create widgets
-        self._create_source_software_widget()
+        self._create_source_format_widget()
         self._create_fps_widget()
         self._create_file_path_widget()
         self._create_load_button()
@@ -60,12 +60,12 @@ class DataLoader(QWidget):
         # Enable layer tooltips from napari settings
         self._enable_layer_tooltips()
 
-    def _create_source_software_widget(self):
+    def _create_source_format_widget(self):
         """Create a combo box for selecting the source software."""
-        self.source_software_combo = QComboBox()
-        self.source_software_combo.setObjectName("source_software_combo")
-        self.source_software_combo.addItems(SUPPORTED_DATA_FILES.keys())
-        self.layout().addRow("source software:", self.source_software_combo)
+        self.source_format_combo = QComboBox()
+        self.source_format_combo.setObjectName("source_format_combo")
+        self.source_format_combo.addItems(SUPPORTED_DATA_FILES.keys())
+        self.layout().addRow("source software:", self.source_format_combo)
 
     def _create_fps_widget(self):
         """Create a spinbox for selecting the frames per second (fps)."""
@@ -116,7 +116,7 @@ class DataLoader(QWidget):
         file_suffixes = (
             "*." + suffix
             for suffix in SUPPORTED_DATA_FILES[
-                self.source_software_combo.currentText()
+                self.source_format_combo.currentText()
             ]
         )
 
@@ -137,7 +137,7 @@ class DataLoader(QWidget):
         """Load the file and add as a Points layer to the viewer."""
         # Get data from user input
         fps = self.fps_spinbox.value()
-        source_software = self.source_software_combo.currentText()
+        source_format = self.source_format_combo.currentText()
         file_path = self.file_path_edit.text()
 
         # Load data
@@ -145,11 +145,11 @@ class DataLoader(QWidget):
             show_warning("No file path specified.")
             return
 
-        if source_software in SUPPORTED_POSES_FILES:
+        if source_format in SUPPORTED_POSES_FILES:
             loader = load_poses
         else:
             loader = load_bboxes
-        ds = loader.from_file(file_path, source_software, fps)
+        ds = loader.from_file(file_path, source_format, fps)
 
         # Convert to napari Tracks array
         self.data, self.props = ds_to_napari_tracks(ds)

--- a/movement/sample_data.py
+++ b/movement/sample_data.py
@@ -295,7 +295,7 @@ def fetch_dataset(
         if file_paths.get(key):
             ds = load_module.from_file(
                 file_paths[key],
-                source_software=metadata[filename]["source_software"],
+                source_format=metadata[filename]["source_format"],
                 fps=metadata[filename]["fps"],
             )
 

--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -85,7 +85,7 @@ class ValidPosesDataset:
       if provided, match the number of individuals and keypoints
       in the dataset, respectively; otherwise, default names are assigned.
     - The optional ``fps`` is a positive float; otherwise, it defaults to None.
-    - The optional ``source_software`` is a string; otherwise,
+    - The optional ``source_format`` is a string; otherwise,
       it defaults to None.
 
     Attributes
@@ -107,7 +107,7 @@ class ValidPosesDataset:
         etc.
     fps : float, optional
         Frames per second of the video. Defaults to None.
-    source_software : str, optional
+    source_format : str, optional
         Name of the software from which the poses were loaded.
         Defaults to None.
 
@@ -138,7 +138,7 @@ class ValidPosesDataset:
             converters.optional(float), _convert_fps_to_none_if_invalid
         ),
     )
-    source_software: str | None = field(
+    source_format: str | None = field(
         default=None,
         validator=validators.optional(validators.instance_of(str)),
     )
@@ -181,7 +181,7 @@ class ValidPosesDataset:
 
     @individual_names.validator
     def _validate_individual_names(self, attribute, value):
-        if self.source_software == "LightningPose":
+        if self.source_format == "LightningPose":
             # LightningPose only supports a single individual
             _validate_list_length(attribute, value, 1)
         else:
@@ -243,7 +243,7 @@ class ValidBboxesDataset:
       with the frame numbers; otherwise, it defaults to an array of
       0-based integers.
     - The optional ``fps`` is a positive float; otherwise, it defaults to None.
-    - The optional ``source_software`` is a string; otherwise, it defaults to
+    - The optional ``source_format`` is a string; otherwise, it defaults to
       None.
 
     Attributes
@@ -274,7 +274,7 @@ class ValidBboxesDataset:
     fps : float, optional
         Frames per second defining the sampling rate of the data.
         Defaults to None.
-    source_software : str, optional
+    source_format : str, optional
         Name of the software that generated the data. Defaults to None.
 
     Raises
@@ -304,7 +304,7 @@ class ValidBboxesDataset:
             converters.optional(float), _convert_fps_to_none_if_invalid
         ),
     )
-    source_software: str | None = field(
+    source_format: str | None = field(
         default=None,
         validator=validators.optional(validators.instance_of(str)),
     )

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -106,7 +106,7 @@ def valid_bboxes_dataset(valid_bboxes_arrays):
         },
         attrs={
             "time_unit": "frames",
-            "source_software": "test",
+            "source_format": "test",
             "source_file": "test_bboxes.csv",
             "ds_type": "bboxes",
         },
@@ -263,7 +263,7 @@ def valid_poses_dataset(valid_poses_arrays, request):
         },
         attrs={
             "time_unit": "frames",
-            "source_software": "test",
+            "source_format": "test",
             "source_file": "test_poses.h5",
             "ds_type": "poses",
         },

--- a/tests/fixtures/helpers.py
+++ b/tests/fixtures/helpers.py
@@ -37,7 +37,7 @@ class Helpers:
 
             - file_path: Path to the source file
             - fps: int, frames per second
-            - source_software: str, name of the software used to generate
+            - source_format: str, name of the software used to generate
               the dataset
 
         """
@@ -76,8 +76,8 @@ class Helpers:
             if expected_file_path is not None
             else None
         )
-        assert dataset.source_software == expected_values.get(
-            "source_software"
+        assert dataset.source_format == expected_values.get(
+            "source_format"
         )
         fps = getattr(dataset, "fps", None)
         assert fps == expected_values.get("fps")

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -205,33 +205,33 @@ def assert_time_coordinates(ds, fps, start_frame=None, frame_array=None):
     )
 
 
-@pytest.mark.parametrize("source_software", ["Unknown", "VIA-tracks"])
+@pytest.mark.parametrize("source_format", ["Unknown", "VIA-tracks"])
 @pytest.mark.parametrize("fps", [None, 30, 60.0])
 @pytest.mark.parametrize("use_frame_numbers_from_file", [True, False])
 @pytest.mark.parametrize("frame_regexp", [None, r"frame_(\d+)"])
 def test_from_file(
-    source_software, fps, use_frame_numbers_from_file, frame_regexp
+    source_format, fps, use_frame_numbers_from_file, frame_regexp
 ):
     """Test that the from_file() function delegates to the correct
-    loader function according to the source_software.
+    loader function according to the source_format.
     """
     software_to_loader = {
         "VIA-tracks": "movement.io.load_bboxes.from_via_tracks_file",
     }
-    if source_software == "Unknown":
+    if source_format == "Unknown":
         with pytest.raises(ValueError, match="Unsupported source"):
             load_bboxes.from_file(
                 "some_file",
-                source_software,
+                source_format,
                 fps,
                 use_frame_numbers_from_file=use_frame_numbers_from_file,
                 frame_regexp=frame_regexp,
             )
     else:
-        with patch(software_to_loader[source_software]) as mock_loader:
+        with patch(software_to_loader[source_format]) as mock_loader:
             load_bboxes.from_file(
                 "some_file",
-                source_software,
+                source_format,
                 fps,
                 use_frame_numbers_from_file=use_frame_numbers_from_file,
                 frame_regexp=frame_regexp,
@@ -275,7 +275,7 @@ def test_from_via_tracks_file(
     ds = load_bboxes.from_via_tracks_file(**kwargs)
     expected_values = {
         **expected_values_bboxes,
-        "source_software": "VIA-tracks",
+        "source_format": "VIA-tracks",
         "fps": fps,
         "file_path": via_file_path,
     }
@@ -332,12 +332,12 @@ def test_from_via_tracks_file_invalid_frame_regexp(
     [True, False],
 )
 @pytest.mark.parametrize("fps", [None, 30, 60.0])
-@pytest.mark.parametrize("source_software", [None, "VIA-tracks"])
+@pytest.mark.parametrize("source_format", [None, "VIA-tracks"])
 def test_from_numpy(
     create_valid_from_numpy_inputs,
     with_frame_array,
     fps,
-    source_software,
+    source_format,
     helpers,
 ):
     """Test that loading bounding boxes trajectories from the input
@@ -349,11 +349,11 @@ def test_from_numpy(
     ds = load_bboxes.from_numpy(
         **from_numpy_inputs,
         fps=fps,
-        source_software=source_software,
+        source_format=source_format,
     )
     expected_values = {
         **expected_values_bboxes,
-        "source_software": source_software,
+        "source_format": source_format,
         "fps": fps,
     }
     helpers.assert_valid_dataset(ds, expected_values)

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -26,7 +26,7 @@ def test_data_loader_widget_instantiation(make_napari_viewer_proxy):
 
     # Check that the expected widgets are present in the layout
     expected_widgets = [
-        (QComboBox, "source_software_combo"),
+        (QComboBox, "source_format_combo"),
         (QDoubleSpinBox, "fps_spinbox"),
         (QLineEdit, "file_path_edit"),
         (QPushButton, "load_button"),
@@ -94,7 +94,7 @@ def test_on_browse_clicked(file_path, make_napari_viewer_proxy, mocker):
 
 
 @pytest.mark.parametrize(
-    "source_software, expected_file_filter",
+    "source_format, expected_file_filter",
     [
         ("DeepLabCut", "*.h5 *.csv"),
         ("SLEAP", "*.h5 *.slp"),
@@ -102,12 +102,12 @@ def test_on_browse_clicked(file_path, make_napari_viewer_proxy, mocker):
         ("VIA-tracks", "*.csv"),
     ],
 )
-def test_file_filters_per_source_software(
-    source_software, expected_file_filter, make_napari_viewer_proxy, mocker
+def test_file_filters_per_source_format(
+    source_format, expected_file_filter, make_napari_viewer_proxy, mocker
 ):
     """Test that the file dialog is opened with the correct filters."""
     data_loader_widget = DataLoader(make_napari_viewer_proxy)
-    data_loader_widget.source_software_combo.setCurrentText(source_software)
+    data_loader_widget.source_format_combo.setCurrentText(source_format)
     mock_file_dialog = mocker.patch(
         "movement.napari.loader_widgets.QFileDialog.getOpenFileName",
         return_value=("", None),
@@ -132,7 +132,7 @@ def test_on_load_clicked_without_file_path(make_napari_viewer_proxy, capsys):
 
 
 @pytest.mark.parametrize(
-    "filename, source_software, tracks_array_shape",
+    "filename, source_format, tracks_array_shape",
     [
         ("DLC_single-wasp.predictions.h5", "DeepLabCut", (2170, 4)),
         ("VIA_single-crab_MOCA-crab-1.csv", "VIA-tracks", (35, 4)),
@@ -140,7 +140,7 @@ def test_on_load_clicked_without_file_path(make_napari_viewer_proxy, capsys):
 )
 def test_on_load_clicked_with_valid_file_path(
     filename,
-    source_software,
+    source_format,
     tracks_array_shape,
     make_napari_viewer_proxy,
     caplog,
@@ -162,7 +162,7 @@ def test_on_load_clicked_with_valid_file_path(
     data_loader_widget.file_path_edit.setText(file_path.as_posix())
 
     # Set the source software
-    data_loader_widget.source_software_combo.setCurrentText(source_software)
+    data_loader_widget.source_format_combo.setCurrentText(source_format)
 
     # Set the fps to 60
     data_loader_widget.fps_spinbox.setValue(60)
@@ -236,7 +236,7 @@ def test_dimension_slider_matches_frames(
     # Read sample data with a NaN at the specified
     # location (start, middle, or end)
     poses_loader_widget.file_path_edit.setText(file_path.as_posix())
-    poses_loader_widget.source_software_combo.setCurrentText("DeepLabCut")
+    poses_loader_widget.source_format_combo.setCurrentText("DeepLabCut")
 
     # Check the data contains nans where expected
     assert (
@@ -261,7 +261,7 @@ def test_dimension_slider_matches_frames(
 
 @pytest.mark.parametrize(
     (
-        "filename, source_software, "
+        "filename, source_format, "
         "expected_text_property, expected_color_property"
     ),
     [
@@ -299,7 +299,7 @@ def test_dimension_slider_matches_frames(
 )
 def test_add_points_layer_style(
     filename,
-    source_software,
+    source_format,
     make_napari_viewer_proxy,
     expected_text_property,
     expected_color_property,
@@ -315,7 +315,7 @@ def test_add_points_layer_style(
     # Load data as a points layer
     file_path = pytest.DATA_PATHS.get(filename)
     loader_widget.file_path_edit.setText(file_path.as_posix())
-    loader_widget.source_software_combo.setCurrentText(source_software)
+    loader_widget.source_format_combo.setCurrentText(source_format)
     loader_widget._on_load_clicked()
 
     # Check no warnings were emitted

--- a/tests/test_unit/test_sample_data.py
+++ b/tests/test_unit/test_sample_data.py
@@ -44,7 +44,7 @@ def validate_metadata(metadata: dict[str, dict]) -> None:
     metadata_fields = [
         "sha256sum",
         "type",
-        "source_software",
+        "source_format",
         "type",
         "fps",
         "species",

--- a/tests/test_unit/test_validators/test_datasets_validators.py
+++ b/tests/test_unit/test_validators/test_datasets_validators.py
@@ -177,7 +177,7 @@ def test_poses_dataset_validator_individual_names(
 
 
 @pytest.mark.parametrize(
-    "source_software, expected_exception",
+    "source_format, expected_exception",
     [
         (None, does_not_raise()),
         ("SLEAP", does_not_raise()),
@@ -187,10 +187,10 @@ def test_poses_dataset_validator_individual_names(
         (5, pytest.raises(TypeError)),  # not a string
     ],
 )
-def test_poses_dataset_validator_source_software(
-    valid_poses_arrays, source_software, expected_exception
+def test_poses_dataset_validator_source_format(
+    valid_poses_arrays, source_format, expected_exception
 ):
-    """Test that the source_software attribute is validated properly.
+    """Test that the source_format attribute is validated properly.
     LightnigPose is incompatible with multi-individual arrays.
     """
     with expected_exception:
@@ -198,13 +198,13 @@ def test_poses_dataset_validator_source_software(
             position_array=valid_poses_arrays("multi_individual_array")[
                 "position"
             ],
-            source_software=source_software,
+            source_format=source_format,
         )
 
-        if source_software is not None:
-            assert ds.source_software == source_software
+        if source_format is not None:
+            assert ds.source_format == source_format
         else:
-            assert ds.source_software is None
+            assert ds.source_format is None
 
 
 # Tests bboxes dataset


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**

This PR addresses issue #422, which requested renaming the `source_software` attribute to `source_format` for better clarity and consistency in the `movement` package.

**What does this PR do?**

This PR renames `source_software` to `source_format` across the codebase, including all relevant Python files, test files, and documentation. It updates function arguments, attributes, and references to ensure consistency.

## References

- Issue #422: https://github.com/neuroinformatics-unit/movement/issues/422

## How has this PR been tested?

I set up the project locally using Conda as per the contribution guidelines. Initially, running `pytest --cov=movement` showed 630 passed and 70 failed tests. After updating the tests to reflect the `source_software` to `source_format` change, the results improved to 682 passed and 18 failed. The remaining failures include:
- 14 failures due to `numpy.linalg.LinAlgError` in filtering tests (unrelated to my changes).
- 2 failures due to `KeyError: 'source_format'` in `test_sample_data.py` (minor issue, possibly needs a small tweak).

## Is this a breaking change?

No, this PR should not break existing functionality—it’s a rename of an attribute and its references. Downstream code using `source_software` will need to update to `source_format`.

## Does this PR require an update to the documentation?

Yes, I’ve updated the documentation in the `docs` folder to replace `source_software` with `source_format`.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
