### PR TITLE
feat: add bidirectional option to filter_by_displacement

### DIFF
--- a/movement/filtering.py
+++ b/movement/filtering.py
@@ -6,12 +6,8 @@ from typing import Literal
 import xarray as xr
 from scipy import signal
 
-
 from movement.kinematics import compute_displacement
-from movement.utils.logging import log_to_attrs
-
 from movement.utils.logging import log_to_attrs, logger
-
 from movement.utils.reports import report_nan_values
 from movement.utils.vector import compute_norm
 
@@ -282,7 +278,6 @@ def rolling_filter(
     # Compute the statistic over each window
     allowed_statistics = ["mean", "median", "max", "min"]
     if statistic not in allowed_statistics:
-
         raise ValueError(
             f"Invalid statistic '{statistic}'. "
             f"Must be one of {allowed_statistics}."
@@ -294,7 +289,6 @@ def rolling_filter(
                 f"Must be one of {allowed_statistics}."
             )
         )
-
 
     data_rolled = getattr(data_windows, statistic)(skipna=True)
 
@@ -367,7 +361,6 @@ def savgol_filter(
 
     """
     if "axis" in kwargs:
-
         raise ValueError("The 'axis' argument may not be overridden.")
 
         raise logger.error(


### PR DESCRIPTION
[Mentioned Pr](https://github.com/neuroinformatics-unit/movement/pull/451/files)
Bi-directional approach
First Stage commit 
Not yet implemnted - edge cases, i.e. what happens if a point keeps jumping back-and-forth between two positions, in that case it's also hard to decide which position is correct. yet to be implemented as mentioned by @niksirbi. 