### PR TITLE
Fix Runtime Warning raised by ROI plot test

### DIFF
--- a/tests/test_unit/test_roi/test_plot.py
+++ b/tests/test_unit/test_roi/test_plot.py
@@ -108,7 +108,7 @@ def test_plot(
         # Simulate creation of a new axis and figure
         kwargs["ax"] = None
         _, ax = region_to_plot.plot(**kwargs)
-
+    plt.close()
     if region_to_plot.dimensions == 2:
         assert len(ax.patches) == 1 and len(ax.lines) == 0
         assert type(ax.patches[0]) is PathPatch


### PR DESCRIPTION

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
This PR is to address the warning while running pytest on the terminal. 
**What does this PR do?**
closes the plots after they have been made. its a quick fix to avoid the warning coming up during the testing. 
## References
Fixed this warning. 
![image](https://github.com/user-attachments/assets/da1546b1-d4ef-4321-8fed-18d6543f2af4)

Please reference any existing issues/PRs that relate to this PR.

## How has this PR been tested?

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.

## Is this a breaking change?

No. It doesn't change the existing code 

## Does this PR require an update to the documentation?

Not required 

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
