### PR TITLE
Add focus areas for 2025 to the roadmaps page

### DIFF
--- a/docs/source/community/roadmaps.md
+++ b/docs/source/community/roadmaps.md
@@ -19,7 +19,16 @@ The following features are being considered for the first stable version `v1.0`.
 navigation, social interactions, etc.
 - __Integrate with neurophysiological data analysis tools__. We eventually aim to facilitate combined analysis of motion and neural data.
 
-## Short-term milestone - `v0.1`
+## Focus areas for 2025
+
+- Annotate space by defining regions of interest programmatically and via our [GUI](target-gui).
+- Annotate time by defining events of interest programmatically and via our [GUI](target-gui).
+- Enable workflows for aligning motion tracks with concurrently recorded neurophysiological signals.
+- Enrich the interactive visualisation of motion tracks in `napari`, providing more customisation options.
+- Enable the saving of filtered tracks and derived kinematic variables to disk.
+- Implement metrics useful for analysing spatial navigation, social interactions, and collective behaviour.
+
+## Version 0.1
 We've released version `v0.1` of `movement` in March 2025, providing a basic set of features to demonstrate the project's potential and to gather feedback from users. Our minimum requirements for this milestone were:
 
 - [x] Ability to import pose tracks from [DeepLabCut](dlc:), [SLEAP](sleap:) and [LightningPose](lp:) into a common `xarray.Dataset` structure.


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Adding content to the website

**Why is this PR needed?**

After we reached `v0.1`, we hadn't really defined the next short-term goal.

**What does this PR do?**

Adds a new section called "Focus areas for 2025" to the roadmaps page. Unlike the previous milestone, this one is not linked to a specific version number, as we are now operating with (quasi-) semantic versioning.

I tried to strike the balance between being too vague (not useful for anyone) and too detailed (we have the issue tracker and the project board for that). The bullet points listed in this section are not specific hyper-defined tasks to do, but well, "focus areas".

@neuroinformatics-unit/behaviour do you think this is a fair representation of our priorities for this year? If not, what have I missed?

## How has this PR been tested?

Local docs build.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

It is itself an update of docs.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
