### PR TITLE
Fix `_warn_about_nan_proportion` bugs

### DIFF
--- a/tests/test_unit/test_kinematics.py
+++ b/tests/test_unit/test_kinematics.py
@@ -165,9 +165,6 @@ time_points_value_error = pytest.raises(
 )
 
 
-@pytest.mark.filterwarnings(
-    "ignore:The result may be unreliable.*:UserWarning"
-)
 @pytest.mark.parametrize(
     "start, stop, expected_exception",
     [
@@ -228,9 +225,6 @@ def test_path_length_across_time_ranges(
         xr.testing.assert_allclose(path_length, expected_path_length)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:The result may be unreliable.*:UserWarning"
-)
 @pytest.mark.parametrize(
     "nan_policy, expected_path_lengths_id_0, expected_exception",
     [
@@ -265,7 +259,10 @@ def test_path_length_with_nan(
     but will not "correct" for missing values at the edges.
     """
     position = valid_poses_dataset_with_nan.position
-    with expected_exception:
+    with (
+        pytest.warns(UserWarning, match="The result may be unreliable"),
+        expected_exception,
+    ):
         path_length = kinematics.compute_path_length(
             position, nan_policy=nan_policy
         )
@@ -277,39 +274,47 @@ def test_path_length_with_nan(
         )
 
 
+# Regex patterns to match the warning messages
+exclude_id_1_and_left = r"(?s)(?!.*id_1)(?!.*left)"
+include_threshold_100 = r".*The result may be unreliable.*id_0.*right: 10/10.*"
+include_threshold_20 = (
+    r".*The result may be unreliable.*id_0.*centroid: 3/10.*right: 10/10.*"
+)
+
+
 @pytest.mark.parametrize(
     "nan_warn_threshold, expected_exception",
     [
-        (1, pytest.warns(UserWarning, match="The result may be unreliable")),
-        (0.2, pytest.warns(UserWarning, match="The result may be unreliable")),
+        (
+            1,
+            pytest.warns(
+                UserWarning,
+                match=f"{exclude_id_1_and_left}{include_threshold_100}",
+            ),
+        ),
+        (
+            0.2,
+            pytest.warns(
+                UserWarning,
+                match=f"{exclude_id_1_and_left}{include_threshold_20}",
+            ),
+        ),
         (-1, pytest.raises(ValueError, match="between 0 and 1")),
     ],
 )
 def test_path_length_nan_warn_threshold(
-    valid_poses_dataset_with_nan,
-    nan_warn_threshold,
-    expected_exception,
-    caplog,
+    valid_poses_dataset_with_nan, nan_warn_threshold, expected_exception
 ):
-    """Test that a warning is raised when the number of missing values
-    exceeds a given threshold or that an error is raised when the threshold
-    is invalid.
+    """Test that a warning is raised with matching message containing
+    information on the individuals and keypoints whose number of missing
+    values exceeds the given threshold or that an error is raised
+    when the threshold is invalid.
     """
     position = valid_poses_dataset_with_nan.position
     with expected_exception:
         kinematics.compute_path_length(
             position, nan_warn_threshold=nan_warn_threshold
         )
-        if 0.1 < nan_warn_threshold < 0.5:
-            # Make sure that the NaN report only mentions
-            # the individual and keypoint that violate the threshold
-            info_msg = caplog.records[0].message
-            assert caplog.records[0].levelname == "INFO"
-            assert "Individual: id_0" in info_msg
-            assert "Individual: id_1" not in info_msg
-            assert "centroid: 3/10 (30.0%)" in info_msg
-            assert "right: 10/10 (100.0%)" in info_msg
-            assert "left" not in info_msg
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Closes #538 #539 #540

**What does this PR do?**
This PR fixes `_warn_about_nan_proportion` by 
- using the appropriate `>=` comparator instead of `>` to include the upper bound when selecting the data to warn about
- replaces `len(data)` with `data.size` to determine the total number of elements in `data`

The affected tests are updated accordingly by
- removing warning filters where warnings are not expected (i.e. when using valid dataset fixtures without NaNs)
- removing warning filters and checking explicitly for warnings with matching messages where expected (i.e. when using valid dataset fixtures with NaNs)
- removing unnecessary asserts in test as these are accounted for with the check mentioned in the previous point.

The relevant docstrings are also updated to reflect the use of `>=` with "at least" instead of "more than".

## How has this PR been tested?
Tests passing locally and on CI

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
