### PR TITLE
Fix deprecated license syntax

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
       hooks:
           - id: check-manifest
             args: [--no-build-isolation]
-            additional_dependencies: ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"] #[setuptools-scm, wheel]
+            additional_dependencies: ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"]
     - repo: https://github.com/codespell-project/codespell
       # Configuration for codespell is in pyproject.toml
       rev: v2.4.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
       hooks:
           - id: check-manifest
             args: [--no-build-isolation]
-            additional_dependencies: [setuptools-scm, wheel]
+            additional_dependencies: ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"] #[setuptools-scm, wheel]
     - repo: https://github.com/codespell-project/codespell
       # Configuration for codespell is in pyproject.toml
       rev: v2.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ readme = "README.md"
 requires-python = ">=3.11.0"
 dynamic = ["version"]
 
-license = { text = "BSD-3-Clause" }
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 
 dependencies = [
   "numpy",
@@ -24,8 +25,8 @@ dependencies = [
   "xarray[accel,viz]",
   "PyYAML",
   "napari-video",
-  "pyvideoreader>=0.5.3",  # since switching to depend on openCV-headless
-  "qt-niu",  # needed for collapsible widgets
+  "pyvideoreader>=0.5.3", # since switching to depend on openCV-headless
+  "qt-niu",               # needed for collapsible widgets
   "loguru",
 ]
 
@@ -37,7 +38,6 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: BSD License",
   "Framework :: napari",
 ]
 
@@ -52,9 +52,7 @@ entry-points."napari.manifest".movement = "movement.napari:napari.yaml"
 "User Support" = "https://neuroinformatics.zulipchat.com/#narrow/stream/406001-Movement"
 
 [project.optional-dependencies]
-napari = [
-  "napari[all]>=0.5.0",
-]
+napari = ["napari[all]>=0.5.0"]
 dev = [
   "pytest",
   "pytest-cov",


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
In CI we are getting two warnings re the syntax used to specify the license in `pyproject.toml`:

* The [first](https://github.com/neuroinformatics-unit/movement/actions/runs/14338671321/job/40240109996#step:5:198) one says:
	> SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated

	This follows [PEP 639](https://peps.python.org/pep-0639/) and is also explained in the [Python packing guide](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files).

* The [second](https://github.com/neuroinformatics-unit/movement/actions/runs/14338671321/job/40240109996#step:5:212) one says:
	> SetuptoolsDeprecationWarning: License classifiers are deprecated.

	This is also explained in the same [PEP](https://peps.python.org/pep-0639/#deprecate-license-classifiers) and in the packaging guide [here](https://packaging.python.org/en/latest/specifications/core-metadata/#classifier-multiple-use).

**What does this PR do?**
- It changes the syntax to specify the license
- It adds a license-files field
- It removes the license as a classifier
- It adds the necessary dependencies to `check-manifest --no-build-isolation` (taken from `pyproject.toml` > `build-system.requires`)

## References

\

## How has this PR been tested?
- `pre-commits` pass
- `check-manifest --no-build-isolation` throws no warnings locally
- No warnings are thrown in CI

## Is this a breaking change?

\

## Does this PR require an update to the documentation?

\

## Checklist:

- [x] The code has been tested locally
- [ n/a ] Tests have been added to cover all new functionality
- [ n/a ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
