### PR TITLE
Added scale factor attribute

### DIFF
--- a/movement/transforms.py
+++ b/movement/transforms.py
@@ -65,6 +65,8 @@ def scale(
             factor = factor.reshape(factor_dims)
     scaled_data = data * factor
 
+    scaled_data.attrs["scale_factor"] = factor
+
     if space_unit is not None:
         scaled_data.attrs["space_unit"] = space_unit
     elif space_unit is None:


### PR DESCRIPTION
## Description

**What is this PR**

- [x ] Addition of a new feature

**Why is this PR needed?**

Since ROIs are often applied to the images, they are in pixel space. The scaling adjusts all the data to be into scaling space (for example, millimetres). These are not compatibles with the ROIs (and an image that is used to plot). 

To be able to programmatically re-scale things for the ROIs and image plotting to work, its nice to have the scaling factor as an attribute.

It might be useful to think about a general solution for such issues in the future.

**What does this PR do?**

It adds the scale factor used when scaling a dataset as an attribute. This is useful in case future data, such as ROIs need to be scaled too.

## References

https://github.com/neuroinformatics-unit/movement/pull/384

## How has this PR been tested?

Ran pytest. And ran the following:

```
from movement import sample_data
from movement.transforms import scale

ds = sample_data.fetch_dataset("SLEAP_three-mice_Aeon_proofread.analysis.h5")
scaled_ds = scale(ds, factor = 2, space_unit='mm')

scaled_ds
Out[7]: 
<xarray.Dataset> Size: 27kB
Dimensions:      (time: 601, space: 2, keypoints: 1, individuals: 3)
Coordinates:
  * time         (time) float64 5kB 0.0 0.02 0.04 0.06 ... 11.96 11.98 12.0
  * space        (space) <U1 8B 'x' 'y'
  * keypoints    (keypoints) <U8 32B 'centroid'
  * individuals  (individuals) <U10 120B 'AEON3B_NTP' 'AEON3B_TP1' 'AEON3B_TP2'
Data variables:
    position     (time, space, keypoints, individuals) float32 14kB 1.541e+03...
    confidence   (time, keypoints, individuals) float32 7kB nan nan ... nan nan
Attributes:
    source_software:  SLEAP
    ds_type:          poses
    fps:              50.0
    time_unit:        seconds
    source_file:      /Users/abdelhaym/.movement/data/poses/SLEAP_three-mice_...
    frame_path:       /Users/abdelhaym/.movement/data/frames/three-mice_Aeon_...
    scale_factor:     2
    space_unit:       mm

```
## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [ x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
