### PR TITLE
Add movement specific issue and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,66 @@
+---
+name: Bug report
+about: Report a bug in movement
+title:
+labels: bug
+---
+
+<!-- If you're not sure it's a bug, feel free to ask in Zulip:
+https://neuroinformatics.zulipchat.com/#narrow/channel/406001-Movement. -->
+
+### Describe the bug
+
+<!-- A clear and concise description of the issue. If possible, please provide a [minimal reproducible example](https://en.wikipedia.org/wiki/Minimal_reproducible_example). -->
+
+---
+
+### To Reproduce
+
+<!-- Provide set of steps to reproduce this bug. Include code to reproduce, if relevant -->
+
+---
+
+### Expected behavior
+
+<!-- What did you expect to happen instead? -->
+
+---
+
+### Actual behavior
+
+<!-- What happens instead? -->
+
+---
+
+### Possible fix
+
+<!-- Not obligatory, but suggest a fix or reason for the bug -->
+
+---
+
+### Log file
+
+<!-- If relevant, please attach or copy relevant log output here. -->
+
+---
+
+### Screenshots
+
+<!-- If applicable, include screenshots to help illustrate the issue. -->
+
+---
+
+### System Info
+
+<!-- Please complete the following: -->
+
+- OS: e.g. Linux, Windows, macOS (if macOS, note if Intel or Apple Silicon)
+- OS Version: e.g. Ubuntu 22.04, Windows 11
+- movement Version: e.g. 0.3.1
+- Hardware Specs: e.g. 16 GB RAM, M1 chip
+
+---
+
+### Additional context
+
+<!-- Add any other context that might be useful (e.g. related configuration, dataset used, prior steps taken). -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,39 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement for movement
+title:
+labels: enhancement
+---
+
+<!-- If this is an early-stage idea or you're unsure how to frame it, feel free to start a conversation in Zulip:
+https://neuroinformatics.zulipchat.com/#narrow/channel/406001-Movement. -->
+
+### Problem or use case
+
+<!-- Provide a detailed description of the change or addition you are proposing. -->
+
+---
+
+### Context
+
+<!-- Why is this change important to you? How would you use it? How can it benefit other users? -->
+
+---
+
+### Proposed solution
+
+<!-- Not obligatory, but suggest an idea for implementing addition or change. -->
+
+---
+
+### Alternatives considered
+
+<!-- Have you considered other approaches or workarounds? If so, describe them briefly. -->
+
+---
+
+### Additional context
+
+<!-- Include any extra context or references, such as:
+- Examples of similar features elsewhere
+- Relevant screenshots or sketches -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+<!---
+Thanks for contributing to movement!
+
+Before submitting a pull request, please read the contributing guide:
+https://github.com/neuroinformatics-unit/movement/blob/main/CONTRIBUTING.md
+
+If you have any questions, feel free to ask in Zulip:
+https://neuroinformatics.zulipchat.com/#narrow/channel/406001-Movement
+--->
+
+## Description
+
+**Type of PR:**
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation update
+- [ ] Other (please describe below)
+
+**What does this PR do?**
+<!--- Describe your changes in detail -->
+
+**Why is it needed?**
+<!--- Why is this change required? What problem does it solve? -->
+
+## Related Issues / PRs
+<!--- Please link to any related issues or pull requests --->
+
+## Screenshots (if appropriate):
+
+## How Has This Been Tested?
+<!--- Describe in detail how you tested your changes -->
+
+## Breaking Changes
+<!--- Is this a fix or feature that would cause existing functionality to change? --->
+<!--- If yes, explain what breaks and what users need to change --->
+
+## Checklist
+
+- [ ] The code has been tested locally
+- [ ] Tests have been added to cover all new functionality
+- [ ] The documentation has been updated to reflect any changes
+- [ ] Code is formatted with [pre-commit](https://pre-commit.com/)


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**

This PR is needed to improve the contribution process by providing movement-specific issue and PR templates.

**What does this PR do?**

This PR adds movement-specific issue and PR templates to replace the generic ones. It provides clear structure for bug reports, feature requests, and pull requests, and includes links to the contributing guide and Zulip for better contributor support.

## References

#552 

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
