### PR TITLE
Removed warning about package being in early development

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,6 @@ Find out more on our [mission and scope](https://movement.neuroinformatics.dev/c
 
 <!-- Start Admonitions -->
 
-> [!Warning]
-> 🏗️ The package is currently in early development and the interface is subject to change. Feel free to play around and provide feedback.
-
 > [!Tip]
 > If you prefer analysing your data in R, we recommend checking out the
 > [animovement](https://www.roald-arboel.com/animovement/) toolbox, which is similar in scope.


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other: change in docs

**Why is this PR needed?**

The package is quite mature by now, the warning may give the false impression that we are still at a very volatile stage.

**What does this PR do?**

Removes the warning from the README.
The warning on the website's homepage will be automatically removed upon next release (because it's auto-generated from the README).

## How has this PR been tested?

Local rendering of README and docs.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

It is an update in docs.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
