### PR TITLE
Fix for bboxes dataset loading

### DIFF
--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -496,19 +496,18 @@ def _df_from_via_tracks_file(
     # Define desired index: all combinations of ID and frame number
     multi_index = pd.MultiIndex.from_product(
         [df["ID"].unique(), df["frame_number"].unique()],
+        # these unique lists may not be sorted!
         names=["ID", "frame_number"],
     )
 
-    # Assign desired index (ID, frame number) and
-    # reindex to fill in empty values with nans.
-    # Then reset index
+    # Set index to (ID, frame number), fill in values with nans,
+    # sort by ID and frame_number and reset to new index
     df = (
-        df.set_index(["ID", "frame_number"])  # assign desired index
-        .reindex(multi_index)  # add empty values
-        .sort_values(by=["ID", "frame_number"], axis=0)  # sort
-        .reset_index()  # reset index keeping the previous one as a column
+        df.set_index(["ID", "frame_number"])
+        .reindex(multi_index)  # fill in empty frame-ID pairs with nans
+        .sort_values(by=["ID", "frame_number"], axis=0)  # sort by ID and frame
+        .reset_index()
     )
-
     return df
 
 

--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -493,20 +493,22 @@ def _df_from_via_tracks_file(
         }
     )
 
-    # Sort dataframe by ID and frame number
-    df = df.sort_values(by=["ID", "frame_number"]).reset_index(drop=True)
-
-    # Fill in empty frames with nans
+    # Define desired index: all combinations of ID and frame number
     multi_index = pd.MultiIndex.from_product(
         [df["ID"].unique(), df["frame_number"].unique()],
         names=["ID", "frame_number"],
-    )  # desired index: all combinations of ID and frame number
-
-    # Set index to (ID, frame number), fill in values with nans and
-    # reset to original index
-    df = (
-        df.set_index(["ID", "frame_number"]).reindex(multi_index).reset_index()
     )
+
+    # Assign desired index (ID, frame number) and
+    # reindex to fill in empty values with nans.
+    # Then reset index
+    df = (
+        df.set_index(["ID", "frame_number"])  # assign desired index
+        .reindex(multi_index)  # add empty values
+        .sort_values(by=["ID", "frame_number"], axis=0)  # sort
+        .reset_index()  # reset index keeping the previous one as a column
+    )
+
     return df
 
 

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -647,11 +647,6 @@ def test_df_from_via_tracks_file(
     """Test that the `_df_from_via_tracks_file` helper function correctly
     reads the VIA tracks .csv file as a dataframe.
     """
-    # if with_nans:
-    #     via_file_path = (
-    #         "/Users/sofia/swc/tracked_detections_20250425_163726.csv"
-    #     )
-
     df = load_bboxes._df_from_via_tracks_file(via_file_path)
     assert isinstance(df, pd.DataFrame)
     assert len(df.frame_number.unique()) == expected_n_frames
@@ -669,12 +664,7 @@ def test_df_from_via_tracks_file(
         "confidence",
     ]
     # Check that the dataframe is sorted by frame_number and ID
-    # assert df.sort_values(["ID", "frame_number"]).equals(df)
-    assert df["ID"].is_monotonic_increasing
-    assert all(
-        df.loc[df["ID"] == id, "frame_number"].is_monotonic_increasing
-        for id in df["ID"].unique()
-    )
+    assert df.sort_values(["ID", "frame_number"]).equals(df)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -622,10 +622,6 @@ def test_fps_and_time_coords(
         assert_time_coordinates(ds, expected_fps, start_frame=0)
 
 
-# @pytest.mark.parametrize(
-#     "with_nans",
-#     [True, False],
-# )
 @pytest.mark.parametrize(
     "via_file_path, expected_n_frames, expected_n_individuals",
     [

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -655,6 +655,10 @@ def test_df_from_via_tracks_file(
         "h",
         "confidence",
     ]
+    # Check that the dataframe is sorted by frame_number and ID
+    assert df.sort_values(["ID", "frame_number"]).equals(df)
+    # assert df["frame_number"].is_monotonic_increasing
+    # assert df["ID"].is_monotonic_increasing
 
 
 @pytest.mark.parametrize(

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -118,15 +118,25 @@ def create_df_input_via_tracks():
 
 
 @pytest.fixture()
-def via_file_with_nans(tmp_path):
+def via_multiple_crabs_gap_id_1(tmp_path):
+    """Return a filepath to a modified VIA tracks .csv file with
+    the annotations for id=1 removed for frames 1, 2 and 3.
+    """
     filepath = pytest.DATA_PATHS.get("VIA_multiple-crabs_5-frames_labels.csv")
 
-    # Delete second row of the file
+    # Drop annotations for id=1 in frames 1, 2 and 3
     df = pd.read_csv(filepath)
-    df.drop(1)
+    filename_prefix = "04.09.2023-04-Right_RE_testframe_0000000"
+    for frame_number in range(1, 4):
+        df = df[
+            ~(
+                (df["region_attributes"] == '{"track":"1"}')
+                & (df["filename"] == f"{filename_prefix}{frame_number}.png")
+            )
+        ]
 
     # Save the modified dataframe to a new file
-    filepath = tmp_path / "VIA_multiple-crabs_5-frames_labels_with_nans.csv"
+    filepath = tmp_path / "VIA_multiple-crabs_5-frames_labels_with_gap.csv"
     df.to_csv(filepath, index=False)
 
     return filepath
@@ -644,17 +654,17 @@ def test_fps_and_time_coords(
             pytest.DATA_PATHS.get("VIA_multiple-crabs_5-frames_labels.csv"),
             5,
             86,
-        ),
+        ),  # multiple crabs present in all 5 frames
         (
             pytest.DATA_PATHS.get("VIA_single-crab_MOCA-crab-1.csv"),
             35,
             1,
-        ),
+        ),  # single crab present in 35 non-consecutive frames
         (
-            "via_file_with_nans",
+            "via_multiple_crabs_gap_id_1",
             5,
             86,
-        ),
+        ),  # multiple crabs, all but id=1 are present in all 5 frames
     ],
 )
 def test_df_from_via_tracks_file(
@@ -663,7 +673,7 @@ def test_df_from_via_tracks_file(
     """Test that the `_df_from_via_tracks_file` helper function correctly
     reads the VIA tracks .csv file as a dataframe.
     """
-    if via_file_path == "via_file_with_nans":
+    if via_file_path == "via_multiple_crabs_gap_id_1":
         via_file_path = request.getfixturevalue(via_file_path)
 
     # Read the VIA tracks .csv file as a dataframe

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -622,6 +622,10 @@ def test_fps_and_time_coords(
         assert_time_coordinates(ds, expected_fps, start_frame=0)
 
 
+# @pytest.mark.parametrize(
+#     "with_nans",
+#     [True, False],
+# )
 @pytest.mark.parametrize(
     "via_file_path, expected_n_frames, expected_n_individuals",
     [
@@ -630,7 +634,11 @@ def test_fps_and_time_coords(
             5,
             86,
         ),
-        (pytest.DATA_PATHS.get("VIA_single-crab_MOCA-crab-1.csv"), 35, 1),
+        (
+            pytest.DATA_PATHS.get("VIA_single-crab_MOCA-crab-1.csv"),
+            35,
+            1,
+        ),
     ],
 )
 def test_df_from_via_tracks_file(
@@ -639,6 +647,11 @@ def test_df_from_via_tracks_file(
     """Test that the `_df_from_via_tracks_file` helper function correctly
     reads the VIA tracks .csv file as a dataframe.
     """
+    # if with_nans:
+    #     via_file_path = (
+    #         "/Users/sofia/swc/tracked_detections_20250425_163726.csv"
+    #     )
+
     df = load_bboxes._df_from_via_tracks_file(via_file_path)
     assert isinstance(df, pd.DataFrame)
     assert len(df.frame_number.unique()) == expected_n_frames
@@ -656,9 +669,12 @@ def test_df_from_via_tracks_file(
         "confidence",
     ]
     # Check that the dataframe is sorted by frame_number and ID
-    assert df.sort_values(["ID", "frame_number"]).equals(df)
-    # assert df["frame_number"].is_monotonic_increasing
-    # assert df["ID"].is_monotonic_increasing
+    # assert df.sort_values(["ID", "frame_number"]).equals(df)
+    assert df["ID"].is_monotonic_increasing
+    assert all(
+        df.loc[df["ID"] == id, "frame_number"].is_monotonic_increasing
+        for id in df["ID"].unique()
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

When loading a bboxes dataset, the intermediate dataframe that we use to extract the required array data is not always sorted by (`ID`, `frame_number`) as expected. 

The current implementation causes errors if the input file is such that after sorting the input dataframe by (`ID`, `frame_number`) the `frame_number` column (by itself) is not sorted. 

This may happen for example if the lowest ID (say ID=1) is missing in the first few frames, but the next lowest ID (ID=2)  is not.

**What does this PR do?**
- It changes the currently implementation to ensure the data is sorted as expected
- It extends the current test to check that:
	- the dataframe is sorted by frame_number and ID
	- the test passes with a file in which all IDs are present in all 5 frames, except ID=1 which appears in frame 4.

## References
\

## How has this PR been tested?

Tests pass locally and in CI.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ n/a ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
