### PR TITLE
Speed up test data caching in CI

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -16,6 +16,7 @@ on:
   workflow_dispatch:
 
 jobs:
+
   linting:
     # scheduled workflows should not run on forks
     if: (${{ github.event_name == 'schedule' }} && ${{ github.repository_owner == 'neuroinformatics-unit' }} && ${{ github.ref == 'refs/heads/main' }}) || (${{ github.event_name != 'schedule' }})
@@ -27,6 +28,12 @@ jobs:
     name: Build Sphinx Docs
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.movement/*
+          key: cached-test-data-${{ runner.os }}
+          restore-keys: cached-test-data
       - uses: neuroinformatics-unit/actions/build_sphinx_docs@main
         with:
           python-version: 3.12

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -47,8 +47,8 @@ jobs:
         with:
           path: |
             ~/.movement/*
-          key: cached-test-data
-          enableCrossOsArchive: true
+          key: cached-test-data-${{ runner.os }}
+          restore-keys: cached-test-data
       - name: Set up Conda
         uses: conda-incubator/setup-miniconda@v3
         with:


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
We've noticed for a long time that the Windows runner in CI takes significantly longer than other runners. I suspect it's related to the cross-OS cache not working as intended, likely due to `~` resolving to a different absolute path depending on OS, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#cross-os-cache.

Moreover, I noticed a significant slowdown in the `build_sphinx_docs` action run times, manifest since we started using videos in some of the examples. They get downloaded each time because we hadn't previously implemented caching for that action.

**What does this PR do?**
- Copies @IgorTatarnikov's solution for OS-specific caches in `brainglobe-workflows`: https://github.com/brainglobe/brainglobe-workflows/pull/142
- Also adds caching to the `build_sphinx_docs` action, since that has also slowed down since we added videos to some of the examples (e.g. pupil tracking). We shouldn't have to download these each time.

## References

https://github.com/brainglobe/brainglobe-workflows/pull/142

## How has this PR been tested?

I manually ran CI several times in this PR, to observe run times, and it seems to work.
First Windows test runs were 23-32 minutes, and subsequent ones were 9-10 minutes (after windows-specific cache was populated). Similarly the `build_sphinx_docs` run times went from ~9 to ~2-3 minutes.

No jobs takes >10 minutes now!

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
