### PR TITLE
Restrict napari version to >=0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ entry-points."napari.manifest".movement = "movement.napari:napari.yaml"
 
 [project.optional-dependencies]
 napari = [
-  "napari[all]>=0.5.0",
+  "napari[all]>=0.6.0",
 ]
 dev = [
   "pytest",


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Closes https://github.com/neuroinformatics-unit/movement/issues/433

**What does this PR do?**

Restricts napari>=0.6.0, because the aforementioned bug is solved in that release.

## References

https://github.com/napari/napari/issues/7668
https://github.com/napari/napari/pull/7866

## How has this PR been tested?

We'll see if CI passed without problems. I've already played with napari=0.6.0 locally without encountering any issues.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
