### PR TITLE
Fix duplicate reference when closing and reopening napari widget

### DIFF
--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -60,7 +60,7 @@ class DataLoader(QWidget):
         # Connect frame slider range update to layer events
         for action_str in ["inserted", "removed"]:
             getattr(self.viewer.layers.events, action_str).connect(
-                self._update_frame_slider_range, ref=True
+                self._update_frame_slider_range,
             )
 
         # Enable layer tooltips from napari settings

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -56,7 +56,7 @@ def test_data_loader_widget_instantiation(make_napari_viewer_proxy):
     assert all(
         [
             data_loader_widget._update_frame_slider_range.__name__
-            in [el[1] for el in event.callbacks[1:]]
+            in [cb[1] for cb in event.callbacks[1:]]
             for event in [
                 data_loader_widget.viewer.layers.events.inserted,
                 data_loader_widget.viewer.layers.events.removed,

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -56,7 +56,7 @@ def test_data_loader_widget_instantiation(make_napari_viewer_proxy):
     assert all(
         [
             data_loader_widget._update_frame_slider_range.__name__
-            in event.callback_refs
+            in [el[1] for el in event.callbacks[1:]]
             for event in [
                 data_loader_widget.viewer.layers.events.inserted,
                 data_loader_widget.viewer.layers.events.removed,

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -21,6 +21,7 @@ from napari.layers import (
     Vectors,
 )
 from napari.settings import get_settings
+from napari.utils.events import EmitterGroup
 from pytest import DATA_PATHS
 from qtpy.QtWidgets import QComboBox, QDoubleSpinBox, QLineEdit, QPushButton
 
@@ -56,7 +57,11 @@ def test_data_loader_widget_instantiation(make_napari_viewer_proxy):
     assert all(
         [
             data_loader_widget._update_frame_slider_range.__name__
-            in [cb[1] for cb in event.callbacks[1:]]
+            in [
+                cb[1]
+                for cb in event.callbacks
+                if not isinstance(cb, EmitterGroup)
+            ]
             for event in [
                 data_loader_widget.viewer.layers.events.inserted,
                 data_loader_widget.viewer.layers.events.removed,


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
If you launch the `movement` napari widget, close it (top left cross in the **widget** window) and reopen it, we get an error:
```python
ValueError: ref "_update_frame_slider_range" is not unique
```

**What does this PR do?**
Changes the way we connect the `_update_frame_slider_range` function to the layer addition/deletion event. It uses a unique (default) identifier rather than the callback name as a reference.

This fixes the issue for now, but it may be worth inspecting further. This is because every time the widget is instantiated, a new callback (with the name `_update_frame_slider_range`) is added to the list of viewer callbacks. The fact that there was an error complaining about duplicates when I used the name as reference makes me suspicious that maybe this is not the proper way to do it...

For example if you do the following: 
1- Launch napari with our widget with `movement launch`
2- Open the console in napari and print `viewer.layers.events.inserted.callbacks`
3- Close the movement widget by clicking on the top left cross of the widget window
4- Reopen the widget via the top menu: `Plugins > movement`
5- Print the callbacks again with `viewer.layers.events.inserted.callbacks` -- now the `_update_frame_slider_range` reference appears one more time.

Is the constructor not the best place where to connect the callbacks? Or maybe this is not really a problem?

I checked our friendly neighbours over at [brainglobe-registration](https://github.com/brainglobe/brainglobe-registration/blob/2e01e129e9379d4d5f58526cc535bba1682fb650/brainglobe_registration/registration_widget.py#L230), but they seem to also connect this kind of callbacks in the constructor. I replicated their approach and still observed the continuous appending of the `_update_frame_slider_range` to the list of callbacks.

Tagging @IgorTatarnikov in case he has thoughts/ideas (thanks!)

## References

\

## How has this PR been tested?

Tests pass locally and in CI.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ n/a ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
