### PR TITLE
Add Mahi7828 as contributor and change str to locate section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -307,7 +307,7 @@ The way to add them differs depending on whether they are GitHub users or not.
 
 ::::{tab-set}
 :::{tab-item} GitHub users
-To add a contributor who has a GitHub account, locate the section marked with `<!-- MANUAL: OTHER GITHUB CONTRIBUTORS -->` in `docs/source/community/people.md`.
+To add a contributor who has a GitHub account, locate the section marked with `MANUAL: OTHER GITHUB CONTRIBUTORS` in `docs/source/community/people.md`.
 
 Next, add their GitHub username (e.g. `newcontributor`) to the `<!-- readme: -start -->` and `<!-- readme: -end -->` lines as follows:
 ```html
@@ -320,7 +320,7 @@ The aforementioned GitHub actions workflow will then automatically update the co
 :::
 
 :::{tab-item} Non-GitHub users
-To add a contributor who does not have a GitHub account, locate the section marked with `<!-- MANUAL: OTHER NON-GITHUB CONTRIBUTORS -->` in `docs/source/community/people.md`.
+To add a contributor who does not have a GitHub account, locate the section marked with `MANUAL: OTHER NON-GITHUB CONTRIBUTORS` in `docs/source/community/people.md`.
 
 Next, add a row containing the contributor's image, name, and link to their website to the existing `list-table` as follows:
 ```markdown

--- a/docs/source/community/people.md
+++ b/docs/source/community/people.md
@@ -160,7 +160,7 @@ This section contains other manually added contributors (on GitHub) who have not
 contributed to the movement repository, but have contributed in other ways (e.g. by
 providing sample data, or by actively participating in discussions).
 =============================================================================== -->
-<!-- readme: Sepidak,sannatitus,lkatsouri,athenaakrami,dimokaramanlis,shailajaAkella,mehulrastogi,NeuroDuan,roaldarbol -start -->
+<!-- readme: Sepidak,sannatitus,lkatsouri,athenaakrami,dimokaramanlis,shailajaAkella,mehulrastogi,NeuroDuan,roaldarbol,Mahi7828 -start -->
 <table>
 	<tbody>
 		<tr>
@@ -232,7 +232,7 @@ providing sample data, or by actively participating in discussions).
 		</tr>
 	<tbody>
 </table>
-<!-- readme: Sepidak,sannatitus,lkatsouri,athenaakrami,dimokaramanlis,shailajaAkella,mehulrastogi,NeuroDuan,roaldarbol -end -->
+<!-- readme: Sepidak,sannatitus,lkatsouri,athenaakrami,dimokaramanlis,shailajaAkella,mehulrastogi,NeuroDuan,roaldarbol,Mahi7828 -end -->
 
 <!-- =================== MANUAL: OTHER NON-GITHUB CONTRIBUTORS ===================
 This section contains other manually added contributors (not on GitHub) who have not


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
- To acknowledge data contribution by @Mahi7828
- To clarify the string to search for to manually edit the contributors list.

**What does this PR do?**
- Adds Mahi7828 as contributor
- Changes the string to search in order to locate the contributors section in the docs. 

I suggest the change in the string because initially I copy+pasted it as is and didn't find any matches in `/movement/docs/source/community/people.md`

## References

\

## How has this PR been tested?

Tests pass locally and in CI.

## Is this a breaking change?
No.

## Does this PR require an update to the documentation?

Yes, it involves one.

## Checklist:

- [x] The code has been tested locally
- [ n/a ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
