### PR TITLE
Clarify x,y data in VIA-tracks

### DIFF
--- a/docs/source/user_guide/input_output.md
+++ b/docs/source/user_guide/input_output.md
@@ -178,7 +178,7 @@ The resulting data structure `ds` will include the centroid trajectories for eac
 
 :::{note}
 Note that the x,y coordinates in the input VIA tracks .csv file represent the the top-left corner of each bounding box.
-Instead the corresponding ``movement`` dataset holds the centroid of each bounding box in its `position` array.
+Instead the corresponding ``movement`` dataset holds in its `position` array the centroid of each bounding box.
 :::
 
 For more information on the bounding boxes data structure, see the [movement dataset](target-poses-and-bboxes-dataset) page.

--- a/docs/source/user_guide/input_output.md
+++ b/docs/source/user_guide/input_output.md
@@ -176,7 +176,12 @@ ds = load_bboxes.from_numpy(
 
 The resulting data structure `ds` will include the centroid trajectories for each tracked bounding box, the boxes' widths and heights, and their associated confidence values if provided.
 
-For more information on the bounding boxes data structure, see the [movement bounding boxes dataset](target-poses-and-bboxes-dataset) page.
+:::{note}
+Note that the x,y coordinates in the input VIA tracks .csv file represent the the top-left corner of each bounding box.
+Instead the corresponding ``movement`` dataset holds the centroid of each bounding box in its `position` array.
+:::
+
+For more information on the bounding boxes data structure, see the [movement dataset](target-poses-and-bboxes-dataset) page.
 
 
 (target-saving-pose-tracks)=

--- a/docs/source/user_guide/input_output.md
+++ b/docs/source/user_guide/input_output.md
@@ -153,6 +153,10 @@ ds = load_bboxes.from_file(
     fps=30,
 )
 ```
+
+Note that the x,y coordinates in the input VIA tracks .csv file represent the the top-left corner of each bounding box. Instead the corresponding ``movement`` dataset `ds` will hold in its `position` array the centroid of each bounding box.
+
+
 :::
 
 :::{tab-item} From NumPy
@@ -176,10 +180,7 @@ ds = load_bboxes.from_numpy(
 
 The resulting data structure `ds` will include the centroid trajectories for each tracked bounding box, the boxes' widths and heights, and their associated confidence values if provided.
 
-:::{note}
-Note that the x,y coordinates in the input VIA tracks .csv file represent the the top-left corner of each bounding box.
-Instead the corresponding ``movement`` dataset holds in its `position` array the centroid of each bounding box.
-:::
+
 
 For more information on the bounding boxes data structure, see the [movement dataset](target-poses-and-bboxes-dataset) page.
 

--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -276,8 +276,8 @@ def from_via_tracks_file(
     -----
     Note that the x,y coordinates in the input VIA tracks .csv file
     represent the the top-left corner of each bounding box. Instead the
-    corresponding ``movement`` dataset holds the centroid of each bounding
-    box in its `position` array.
+    corresponding ``movement`` dataset holds in its `position` array the
+    centroid of each bounding box.
 
     Additionally, the bounding boxes IDs specified in the "track" field of
     the VIA tracks .csv file are mapped to the "individual_name" column of

--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -276,13 +276,13 @@ def from_via_tracks_file(
     -----
     Note that the x,y coordinates in the input VIA tracks .csv file
     represent the the top-left corner of each bounding box. Instead the
-    corresponding ``movement`` dataset holds in its `position` array the
+    corresponding ``movement`` dataset holds in its ``position`` array the
     centroid of each bounding box.
 
     Additionally, the bounding boxes IDs specified in the "track" field of
-    the VIA tracks .csv file are mapped to the "individual_name" column of
-    the ``movement`` dataset. The individual names follow the format
-    ``id_<N>``, with N being the bounding box ID.
+    the VIA tracks .csv file are mapped to the ``individuals`` dimension in the
+    ``movement`` dataset. The individual names follow the format ``id_<N>``,
+    with N being the bounding box ID.
 
     References
     ----------

--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -274,10 +274,15 @@ def from_via_tracks_file(
 
     Notes
     -----
-    The bounding boxes IDs specified in the "track" field of the VIA
-    tracks .csv file are mapped to the "individual_name" column of the
-    ``movement`` dataset. The individual names follow the format ``id_<N>``,
-    with N being the bounding box ID.
+    Please note that the x,y coordinates in the input VIA tracks .csv file
+    refer to the the top-left corner of each bounding box. Instead the
+    corresponding ``movement`` dataset represents the position of each
+    bounding box as the position of its centroid.
+
+    Additionally, the bounding boxes IDs specified in the "track" field of
+    the VIA tracks .csv file are mapped to the "individual_name" column of
+    the ``movement`` dataset. The individual names follow the format
+    ``id_<N>``, with N being the bounding box ID.
 
     References
     ----------

--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -274,10 +274,10 @@ def from_via_tracks_file(
 
     Notes
     -----
-    Please note that the x,y coordinates in the input VIA tracks .csv file
-    refer to the the top-left corner of each bounding box. Instead the
-    corresponding ``movement`` dataset represents the position of each
-    bounding box as the position of its centroid.
+    Note that the x,y coordinates in the input VIA tracks .csv file
+    represent the the top-left corner of each bounding box. Instead the
+    corresponding ``movement`` dataset holds the centroid of each bounding
+    box in its `position` array.
 
     Additionally, the bounding boxes IDs specified in the "track" field of
     the VIA tracks .csv file are mapped to the "individual_name" column of


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Fixes #536 

**What does this PR do?**
It clarifies what the x,y coordinates represent in a VIA tracks file, in the relevant docstring and in the user guide

## References

#536 

## How has this PR been tested?

Tests pass locally and in CI.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

It involves one.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
