### PR TITLE
Add announcement banner for open software week

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -124,6 +124,12 @@ html_title = "movement"
 
 # Customize the theme
 html_theme_options = {
+    "announcement": (
+        "Get some hands-on training on movement and other open-source tools "
+        "for animal behaviour at the Neuroinformatics Unit "
+        "<a href='https://neuroinformatics.dev/open-software-week/index.html'>Open Software Week</a> "
+        ", 11th-15th August 2025 in London! "
+    ),
     "icon_links": [
         {
             # Label for this link


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Docs

**Why is this PR needed?**

To further advertise out [open software week](https://neuroinformatics.dev/open-software-week/index.html), which will include some `movement` training.

**What does this PR do?**

Add's an announcement banner to the website. This is how it looks:

![image](https://github.com/user-attachments/assets/1277c463-86fa-4132-8afb-04ce8cfb1e88)

## Note

Need to rebase after we fix the Sphinx issue currently causing CI failures.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
