### PR TITLE
Add ShigrafS to github contributors

### DIFF
--- a/docs/source/community/people.md
+++ b/docs/source/community/people.md
@@ -160,7 +160,7 @@ This section contains other manually added contributors (on GitHub) who have not
 contributed to the movement repository, but have contributed in other ways (e.g. by
 providing sample data, or by actively participating in discussions).
 =============================================================================== -->
-<!-- readme: Sepidak,sannatitus,lkatsouri,athenaakrami,dimokaramanlis,shailajaAkella,mehulrastogi,NeuroDuan,roaldarbol,Mahi7828 -start -->
+<!-- readme: Sepidak,sannatitus,lkatsouri,athenaakrami,dimokaramanlis,shailajaAkella,mehulrastogi,NeuroDuan,roaldarbol,Mahi7828,ShigrafS -start -->
 <table>
 	<tbody>
 		<tr>
@@ -232,7 +232,7 @@ providing sample data, or by actively participating in discussions).
 		</tr>
 	<tbody>
 </table>
-<!-- readme: Sepidak,sannatitus,lkatsouri,athenaakrami,dimokaramanlis,shailajaAkella,mehulrastogi,NeuroDuan,roaldarbol,Mahi7828 -end -->
+<!-- readme: Sepidak,sannatitus,lkatsouri,athenaakrami,dimokaramanlis,shailajaAkella,mehulrastogi,NeuroDuan,roaldarbol,Mahi7828,ShigrafS -end -->
 
 <!-- =================== MANUAL: OTHER NON-GITHUB CONTRIBUTORS ===================
 This section contains other manually added contributors (not on GitHub) who have not


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other: adding a contributors to the website

**Why is this PR needed?**

I thought that manually triggering the contributors action would automatically add this user (ShigrafS) to `people.md`, as they are shown among the GitHub contributors. However, this is not the case, see [closed PR](https://github.com/neuroinformatics-unit/movement/pull/586).

Perhaps we are hitting an edge case here, because I've added them as a co-author of a PR (the commits were not directly written by them).

**What does this PR do?**

Adds them via the manual route for GitHub users.

## References

#583: PR that includes the aforementioned user as a co-author.
#586: action-initiated PR not including them in `people.md`.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
