### PR TITLE
Fix remaining napari future warning

### DIFF
--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -650,8 +650,9 @@ def test_add_points_and_tracks_layer_style(
     # Check the color of the markers follows the expected property
     # (we check there are as many unique colors as there are unique
     # values in the expected property)
+    points_layer_colormap_sorted = np.unique(points_layer.face_color, axis=0)
     assert (
-        np.unique(points_layer.face_color, axis=0).shape[0]
+        points_layer_colormap_sorted.shape[0]
         == np.unique(points_layer.properties[expected_color_property]).shape[0]
     )
 
@@ -665,14 +666,15 @@ def test_add_points_and_tracks_layer_style(
     # name
     assert tracks_layer.colormap == points_layer.face_colormap.name
     # values
-    list_colormap_keys = points_layer._face.categorical_colormap.colormap
+    text_colormap_sorted = np.r_[
+        [
+            np.array(v)
+            for v in points_layer.text.color.colormap.colormap.values()
+        ]
+    ]
+    text_colormap_sorted = text_colormap_sorted[
+        text_colormap_sorted[:, 0].argsort()
+    ]
     np.testing.assert_array_equal(
-        [
-            points_layer._face.categorical_colormap.colormap[ky]
-            for ky in list_colormap_keys
-        ],
-        [
-            points_layer.text.color.colormap.colormap[ky]
-            for ky in list_colormap_keys
-        ],
+        points_layer_colormap_sorted, text_colormap_sorted
     )


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
In PR #476 [I removed one](https://github.com/neuroinformatics-unit/movement/pull/476/commits/a4ad46a293cc5762d177b564e61e8fdadb490bd5) FutureWarning but missed another neighbouring one. 

This PR should remove the remaining FutureWarning.

**What does this PR do?** 
Follows the FutureWarning advice to avoid using private attributes that will be unavailable in the future.

## References

Closes #593.

It should avoid the need of filtering FutureWarnings from napari in PR #592 - I wonder if we should keep these visible as they are useful. 

## Checklist:

- [x] The code has been tested locally
- [ n/a ] Tests have been added to cover all new functionality
- [ n/a ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
