### PR TITLE
Replace numpy legacy random generation

### DIFF
--- a/docs/source/user_guide/input_output.md
+++ b/docs/source/user_guide/input_output.md
@@ -109,8 +109,9 @@ with three keypoints each: ``snout``, ``centre``, and ``tail_base``. These keypo
 ```python
 import numpy as np
 
+rng = np.random.default_rng(seed=42)
 ds = load_poses.from_numpy(
-    position_array=np.random.rand(100, 2, 3, 2),
+    position_array=rng.random((100, 2, 3, 2)),
     confidence_array=np.ones((100, 3, 2)),
     individual_names=["Alice", "Bob"],
     keypoint_names=["snout", "centre", "tail_base"],
@@ -167,8 +168,9 @@ both with the same width (40 pixels) and height (30 pixels). These are tracked i
 ```python
 import numpy as np
 
+rng = np.random.default_rng(seed=42)
 ds = load_bboxes.from_numpy(
-    position_array=np.random.rand(100, 2, 2),
+    position_array=rng.random((100, 2, 2)),
     shape_array=np.ones((100, 2, 2)) * [40, 30],
     confidence_array=np.ones((100, 2)) * 0.5,
     individual_names=["id_0", "id_1"]

--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -86,8 +86,9 @@ def from_numpy(
 
     >>> import numpy as np
     >>> from movement.io import load_bboxes
+    >>> rng = np.random.default_rng(seed=42)
     >>> ds = load_bboxes.from_numpy(
-    ...     position_array=np.random.rand(100, 2, 2),
+    ...     position_array=rng.random((100, 2, 2)),
     ...     shape_array=np.ones((100, 2, 2)) * [40, 30],
     ...     confidence_array=np.ones((100, 2)) * 0.5,
     ...     individual_names=["id_0", "id_1"],
@@ -102,7 +103,7 @@ def from_numpy(
     20.033,... 21.65 s.
 
     >>> ds = load_bboxes.from_numpy(
-    ...     position_array=np.random.rand(100, 2, 2),
+    ...     position_array=rng.random((100, 2, 2)),
     ...     shape_array=np.ones((100, 2, 2)) * [40, 30],
     ...     confidence_array=np.ones((100, 2)) * 0.5,
     ...     individual_names=["id_0", "id_1"],
@@ -115,7 +116,7 @@ def from_numpy(
     To do this, we simply omit the ``frame_array`` input argument.
 
     >>> ds = load_bboxes.from_numpy(
-    ...     position_array=np.random.rand(100, 2, 2),
+    ...     position_array=rng.random((100, 2, 2)),
     ...     shape_array=np.ones((100, 2, 2)) * [40, 30],
     ...     confidence_array=np.ones((100, 2)) * 0.5,
     ...     individual_names=["id_0", "id_1"],
@@ -127,7 +128,7 @@ def from_numpy(
     and pass an ``fps`` value.
 
     >>> ds = load_bboxes.from_numpy(
-    ...     position_array=np.random.rand(100, 2, 2),
+    ...     position_array=rng.random((100, 2, 2)),
     ...     shape_array=np.ones((100, 2, 2)) * [40, 30],
     ...     confidence_array=np.ones((100, 2)) * 0.5,
     ...     individual_names=["id_0", "id_1"],

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -71,8 +71,9 @@ def from_numpy(
 
     >>> import numpy as np
     >>> from movement.io import load_poses
+    >>> rng = np.random.default_rng(seed=42)
     >>> ds = load_poses.from_numpy(
-    ...     position_array=np.random.rand(100, 2, 3, 2),
+    ...     position_array=rng.random((100, 2, 3, 2)),
     ...     confidence_array=np.ones((100, 3, 2)),
     ...     individual_names=["Alice", "Bob"],
     ...     keypoint_names=["snout", "centre", "tail_base"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from glob import glob
 
+import numpy as np
 import pytest
 from _pytest.logging import LogCaptureFixture
 
@@ -52,3 +53,9 @@ def caplog(caplog: LogCaptureFixture):
     )
     yield caplog
     logger.remove(handler_id)
+
+
+@pytest.fixture(scope="session")
+def rng():
+    """Return a random number generator with a fixed seed."""
+    return np.random.default_rng(seed=42)

--- a/tests/fixtures/napari.py
+++ b/tests/fixtures/napari.py
@@ -127,26 +127,25 @@ def valid_poses_path_and_ds_nan_end(
 
 
 @pytest.fixture
-def sample_layer_data():
+def sample_layer_data(rng):
     """Return a dictionary of sample data for each napari layer type."""
     n_frames = 2000
-
-    sample_points_data = np.random.rand(n_frames, 3)
-    sample_image_data = np.random.rand(n_frames, 200, 200)
+    sample_points_data = rng.random((n_frames, 3))
+    sample_image_data = rng.random((n_frames, 200, 200))
     sample_tracks_data = np.hstack(
         (
             np.tile([1, 2, 3, 4], (1, n_frames // 4)).T,
-            np.random.rand(n_frames, 3),
+            rng.random((n_frames, 3)),
         )
     )
-    sample_labels_data = np.random.randint(0, 2, (200, 200))
-    sample_shapes_data = np.random.rand(4, 2)
+    sample_labels_data = rng.integers(0, 2, (200, 200))
+    sample_shapes_data = rng.random((4, 2))
     sample_surface_data = (
-        np.random.rand(4, 2),  # vertices
+        rng.random((4, 2)),  # vertices
         np.array([[0, 1, 2], [1, 2, 3]]),  # faces
         np.linspace(0, 1, 4),  # values
     )
-    sample_vector_data = np.random.rand(100, 2, 2)
+    sample_vector_data = rng.random((100, 2, 2))
 
     return {
         "Points": sample_points_data,

--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -177,15 +177,13 @@ def update_attribute_column(
 
 
 @pytest.fixture()
-def create_valid_from_numpy_inputs():
+def create_valid_from_numpy_inputs(rng):
     """Define a factory of valid inputs to "from_numpy" function."""
     n_frames = 5
     n_space = 2
     n_individuals = 86
     individual_names_array = np.arange(n_individuals).reshape(-1, 1)
     first_frame_number = 1  # should match sample file
-
-    rng = np.random.default_rng(seed=42)
 
     def _create_valid_from_numpy_inputs(with_frame_array=False):
         """Return a dictionary of valid inputs to the `from_numpy` function."""


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Closes #596 

**What does this PR do?**
Replaces remaining numpy legacy random generation with Generator ([`numpy.random.default_rng()`](https://numpy.org/doc/2.2/reference/random/generator.html#numpy.random.default_rng))

## References
#596 

## How has this PR been tested?
Added rng fixture and updated tests 

## Is this a breaking change?
No, but the tests in PR #360 need to be updated once the current PR is merged.

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
