### PR TITLE
Ignore SWC URL in linkcheck

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -190,6 +190,7 @@ linkcheck_anchors_ignore_for_url = [
 linkcheck_ignore = [
     "https://pubs.acs.org/doi/*",  # Checking dois is forbidden here
     "https://opensource.org/license/bsd-3-clause/",  # to avoid odd 403 error
+    "https://www.sainsburywellcome.org/",  # Occassional ConnectTimeoutError
 ]
 
 


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
We ocassionally get a [ConnectionTimeoutRequest error during linkcheck](https://github.com/neuroinformatics-unit/movement/actions/runs/15323218396/job/43111382053#step:3:1310) for the SWC URL 

**What does this PR do?**
Adds the SWC URL to `linkcheck_ignore`

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
