### PR TITLE
Change path to match GIN repo current status

### DIFF
--- a/tests/test_unit/test_load_bboxes.py
+++ b/tests/test_unit/test_load_bboxes.py
@@ -317,7 +317,7 @@ def test_from_via_tracks_file(
         (
             r"_(0\d*)_$",
             AttributeError,
-            "/crab_1/00000.jpg (row 0): "
+            "00000.jpg (row 0): "
             r"The provided frame regexp (_(0\d*)_$) did not return any "
             "matches and a frame number could not be extracted from "
             "the filename.",
@@ -325,7 +325,7 @@ def test_from_via_tracks_file(
         (
             r"(0\d*\.\w+)$",
             ValueError,
-            "/crab_1/00000.jpg (row 0): "
+            "00000.jpg (row 0): "
             "The frame number extracted from the filename "
             r"using the provided regexp ((0\d*\.\w+)$) "
             "could not be cast as an integer.",


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
I [changed](https://gin.g-node.org/neuroinformatics/movement-test-data/commit/9a34e6c6cb254f796a36fd9f12a9495aef38146f) the path to the frame files in the GIN repo for the single crab data, to facilitate loading the data using the VIA tool.

There were two tests that needed to be updated.

**What does this PR do?**
Changes the expected error message in the tests to match the current GIN repo status.


## References

\

## How has this PR been tested?

\
## Is this a breaking change?

\

## Does this PR require an update to the documentation?

\
## Checklist:

- [x] The code has been tested locally
- [ n/a ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
