### PR TITLE
Add log_to_attrs decorator to scale function

### DIFF
--- a/movement/transforms.py
+++ b/movement/transforms.py
@@ -56,33 +56,37 @@ def scale(
 
     >>> from movement.transforms import scale
     >>> ds["position"] = scale(ds["position"], factor=1/10, space_unit="cm")
-    >>> print(ds["position"].space_unit
+    >>> print(ds["position"].space_unit)
     cm
-    >>> print(ds["position"].log
-    [
-        {'operation': 'scale', 'datetime': '2025-05-30 16:07:39.402212', \
-    'factor': 0.1, 'space_unit': 'cm'}
-    ]
+    >>> print(ds["position"].log)
+    [{'operation': 'scale', 'datetime': '2025-05-30 16:07:39.402212',\
+'factor': 0.1, 'space_unit': 'cm'}]
 
     Note that the attributes of the scaled data array now contain the assigned
     ``space_unit`` as well as a ``log`` entry with the arguments passed to
     the function.
 
     We can also scale the two spatial dimensions by different factors.
-    >>> ds["position"] = scale(
-    >>>     ds["position"], factor=[10, 20], space_unit=None
-    >>> )
 
-    The second scale operation removed the ``space_unit`` attribute, restored
-    the x axis to its original scale, and scaled up the y axis to twice its
-    original size. The log should now contain two entries:
-    >>> print(ds["position"].log
+    >>> ds["position"] = scale(ds["position"], factor=[10, 20])
+
+    The second scale operation restored the x axis to its original scale,
+    and scaled up the y axis to twice its original size.
+    The log should now contain two entries:
+
+    >>> print(ds["position"].log)
     [
         {'operation': 'scale', 'datetime': '2025-05-30 16:07:39.402212', \
-    'factor': 0.1, 'space_unit': 'cm'},
+'factor': 0.1, 'space_unit': 'cm'},
         {'operation': 'scale', 'datetime': '2025-05-30 16:11:00.799668', \
-    'factor': [10, 20], 'space_unit': None}
+'factor': [10, 20]}
     ]
+
+    The ``space_unit`` attribute has been removed, as it was not provided
+    in the second call to the function.
+
+    >>> "space_unit" in ds["position"].attrs
+    False
 
     """
     if len(data.coords["space"]) == 2:

--- a/movement/transforms.py
+++ b/movement/transforms.py
@@ -4,9 +4,11 @@ import numpy as np
 import xarray as xr
 from numpy.typing import ArrayLike
 
+from movement.utils.logging import log_to_attrs
 from movement.validators.arrays import validate_dims_coords
 
 
+@log_to_attrs
 def scale(
     data: xr.DataArray,
     factor: ArrayLike | float = 1.0,
@@ -37,9 +39,50 @@ def scale(
 
     Notes
     -----
-    When scale is used multiple times on the same xarray.DataArray,
-    xarray.DataArray.attrs["space_unit"] is overwritten each time or is dropped
-    if ``None`` is passed by default or explicitly.
+    This function makes two changes to the resulting data array's attributes
+    (``xarray.DataArray.attrs``) each time it is called:
+
+    - It sets the ``space_unit`` attribute to the value of the parameter
+      with the same name, or removes it if ``space_unit=None``.
+    - It adds a new entry to the ``log`` attribute of the data array, which
+      contains a record of the operations performed, including the
+      parameters used, as well as the datetime of the function call.
+
+    Examples
+    --------
+    Let's imagine a camera viewing a 2D plane from the top, with an
+    estimated resolution of 10 pixels per cm. We can scale down
+    position data by a factor of 1/10 to express it in cm units.
+
+    >>> from movement.transforms import scale
+    >>> ds["position"] = scale(ds["position"], factor=1/10, space_unit="cm")
+    >>> print(ds["position"].space_unit
+    cm
+    >>> print(ds["position"].log
+    [
+        {'operation': 'scale', 'datetime': '2025-05-30 16:07:39.402212', \
+    'factor': 0.1, 'space_unit': 'cm'}
+    ]
+
+    Note that the attributes of the scaled data array now contain the assigned
+    ``space_unit`` as well as a ``log`` entry with the arguments passed to
+    the function.
+
+    We can also scale the two spatial dimensions by different factors.
+    >>> ds["position"] = scale(
+    >>>     ds["position"], factor=[10, 20], space_unit=None
+    >>> )
+
+    The second scale operation removed the ``space_unit`` attribute, restored
+    the x axis to its original scale, and scaled up the y axis to twice its
+    original size. The log should now contain two entries:
+    >>> print(ds["position"].log
+    [
+        {'operation': 'scale', 'datetime': '2025-05-30 16:07:39.402212', \
+    'factor': 0.1, 'space_unit': 'cm'},
+        {'operation': 'scale', 'datetime': '2025-05-30 16:11:00.799668', \
+    'factor': [10, 20], 'space_unit': None}
+    ]
 
     """
     if len(data.coords["space"]) == 2:

--- a/movement/transforms.py
+++ b/movement/transforms.py
@@ -55,7 +55,7 @@ def scale(
     position data by a factor of 1/10 to express it in cm units.
 
     >>> from movement.transforms import scale
-    >>> ds["position"] = scale(ds["position"], factor=1/10, space_unit="cm")
+    >>> ds["position"] = scale(ds["position"], factor=1 / 10, space_unit="cm")
     >>> print(ds["position"].space_unit)
     cm
     >>> print(ds["position"].log)

--- a/movement/transforms.py
+++ b/movement/transforms.py
@@ -59,8 +59,14 @@ def scale(
     >>> print(ds["position"].space_unit)
     cm
     >>> print(ds["position"].log)
-    [{'operation': 'scale', 'datetime': '2025-05-30 16:07:39.402212',\
-'factor': 0.1, 'space_unit': 'cm'}]
+    [
+        {
+            "operation": "scale",
+            "datetime": "2025-06-05 15:08:16.919947",
+            "factor": "0.1",
+            "space_unit": "'cm'"
+        }
+    ]
 
     Note that the attributes of the scaled data array now contain the assigned
     ``space_unit`` as well as a ``log`` entry with the arguments passed to
@@ -72,18 +78,8 @@ def scale(
 
     The second scale operation restored the x axis to its original scale,
     and scaled up the y axis to twice its original size.
-    The log should now contain two entries:
-
-    >>> print(ds["position"].log)
-    [
-        {'operation': 'scale', 'datetime': '2025-05-30 16:07:39.402212', \
-'factor': 0.1, 'space_unit': 'cm'},
-        {'operation': 'scale', 'datetime': '2025-05-30 16:11:00.799668', \
-'factor': [10, 20]}
-    ]
-
-    The ``space_unit`` attribute has been removed, as it was not provided
-    in the second call to the function.
+    The log will now contain two entries, but the ``space_unit`` attribute
+    has been removed, as it was not provided in the second function call.
 
     >>> "space_unit" in ds["position"].attrs
     False

--- a/movement/transforms.py
+++ b/movement/transforms.py
@@ -29,8 +29,8 @@ def scale(
         broadcasted.
     space_unit : str or None
         The unit of the scaled data stored as a property in
-        xarray.DataArray.attrs['space_unit']. In case of the default (``None``)
-        the ``space_unit`` attribute is dropped.
+        ``xarray.DataArray.attrs['space_unit']``. In case of the default
+        (``None``) the ``space_unit`` attribute is dropped.
 
     Returns
     -------

--- a/tests/test_unit/test_transforms.py
+++ b/tests/test_unit/test_transforms.py
@@ -33,7 +33,7 @@ def data_array_with_dims_and_coords(
     )
 
 
-def sanitize_attrs(attrs: str) -> str:
+def drop_attrs_log(attrs: dict) -> dict:
     """Drop the log string from attrs to faclitate testing.
     The log string will never exactly match, because datetimes differ.
     """
@@ -69,7 +69,7 @@ def sample_data_3d() -> xr.DataArray:
         pytest.param(
             {"space_unit": "elephants"},
             data_array_with_dims_and_coords(
-                nparray_0_to_23(), space_unit="elephants",
+                nparray_0_to_23(), space_unit="elephants"
             ),
             id="No scaling, add space_unit",
         ),
@@ -86,18 +86,22 @@ def sample_data_3d() -> xr.DataArray:
         pytest.param(
             {"factor": 0.5, "space_unit": "elephants"},
             data_array_with_dims_and_coords(
-                nparray_0_to_23() * 0.5, space_unit="elephants",
+                nparray_0_to_23() * 0.5, space_unit="elephants"
             ),
             id="Halve, add space_unit",
         ),
         pytest.param(
             {"factor": [0.5, 2]},
-            data_array_with_dims_and_coords(nparray_0_to_23() * [0.5, 2]),
+            data_array_with_dims_and_coords(
+                nparray_0_to_23() * [0.5, 2],
+            ),
             id="x / 2, y * 2",
         ),
         pytest.param(
             {"factor": np.array([0.5, 2]).reshape(1, 2)},
-            data_array_with_dims_and_coords(nparray_0_to_23() * [0.5, 2]),
+            data_array_with_dims_and_coords(
+                nparray_0_to_23() * [0.5, 2],
+            ),
             id="x / 2, y * 2, should squeeze to cast across space",
         ),
     ],
@@ -110,7 +114,7 @@ def test_scale(
     """Test scaling with different factors and space_units."""
     scaled_data = scale(sample_data_2d, **optional_arguments)
     xr.testing.assert_equal(scaled_data, expected_output)
-    assert sanitize_attrs(scaled_data.attrs) == expected_output.attrs
+    assert drop_attrs_log(scaled_data.attrs) == expected_output.attrs
 
 
 @pytest.mark.parametrize(
@@ -152,7 +156,7 @@ def test_scale_space_dimension(dims: list[str], data_shape):
             {"factor": 2, "space_unit": "elephants"},
             {"factor": 0.5, "space_unit": "crabs"},
             data_array_with_dims_and_coords(
-                nparray_0_to_23(), space_unit="crabs",
+                nparray_0_to_23(), space_unit="crabs"
             ),
             id="No net scaling, final crabs space_unit",
         ),
@@ -166,7 +170,7 @@ def test_scale_space_dimension(dims: list[str], data_shape):
             {"factor": 2, "space_unit": None},
             {"factor": 0.5, "space_unit": "elephants"},
             data_array_with_dims_and_coords(
-                nparray_0_to_23(), space_unit="elephants",
+                nparray_0_to_23(), space_unit="elephants"
             ),
             id="No net scaling, final elephant space_unit",
         ),
@@ -187,7 +191,7 @@ def test_scale_twice(
         **optional_arguments_2,
     )
     xr.testing.assert_equal(output_data_array, expected_output)
-    assert sanitize_attrs(output_data_array.attrs) == expected_output.attrs
+    assert drop_attrs_log(output_data_array.attrs) == expected_output.attrs
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Supersedes #553, see that PR (and the discussions below it) for a justification.

**What does this PR do?**
- [x] Adds the `log_to_attrs` decorator (previously only used for filtering functions) to the `movement.transforms.scale` function
- [x] Documents its effects in the `scale` function's docstring (as notes and examples)
- [x] Updates the tests accordingly

## References

#553 

## How has this PR been tested?

Existing test for the `scale` function were updated to check for the contents of log entries.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

The docstring has been expanded.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
