### PR TITLE
chore: run codespell throughout fixing a typo

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -190,7 +190,7 @@ linkcheck_anchors_ignore_for_url = [
 linkcheck_ignore = [
     "https://pubs.acs.org/doi/*",  # Checking dois is forbidden here
     "https://opensource.org/license/bsd-3-clause/",  # to avoid odd 403 error
-    "https://www.sainsburywellcome.org/",  # Occassional ConnectTimeoutError
+    "https://www.sainsburywellcome.org/",  # Occasional ConnectTimeoutError
 ]
 
 


### PR DESCRIPTION
I am not yet sure why `pre-commit run --all codespell` does not detect it :-/