### PR TITLE
Remove announcement banner for Open Software Week

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -126,12 +126,6 @@ html_title = "movement"
 
 # Customize the theme
 html_theme_options = {
-    "announcement": (
-        "Get some hands-on training on movement and other open-source tools "
-        "for animal behaviour at the Neuroinformatics Unit "
-        "<a href='https://neuroinformatics.dev/open-software-week/index.html'>Open Software Week</a> "
-        ", 11th-15th August 2025 in London! "
-    ),
     "icon_links": [
         {
             # Label for this link


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other: Website

**Why is this PR needed?**

The registration for the Open Software Week closes tomorrow, so there isn't much point in keeping the announcement banner.

**What does this PR do?**

Removes the announcement banner.

## References

https://neuroinformatics.dev/open-software-week/index.html

## How has this PR been tested?

Local docs build.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [n/a] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
