### PR TITLE
Completely remove deprecated median_filter function

### DIFF
--- a/movement/filtering.py
+++ b/movement/filtering.py
@@ -1,6 +1,5 @@
 """Filter and interpolate tracks in ``movement`` datasets."""
 
-import warnings
 from typing import Literal
 
 import xarray as xr
@@ -252,7 +251,7 @@ def savgol_filter(
     stretch of NaNs present in the input data will be propagated
     proportionally to the size of the window (specifically, by
     ``floor(window/2)``). Note that, unlike
-    :func:`movement.filtering.median_filter`, there is no ``min_periods``
+    :func:`movement.filtering.rolling_filter`, there is no ``min_periods``
     option to control this behaviour.
 
     """
@@ -272,22 +271,3 @@ def savgol_filter(
         print(report_nan_values(data, "input"))
         print(report_nan_values(data_smoothed, "output"))
     return data_smoothed
-
-
-def median_filter(*args, **kwargs):
-    """Smooth data by applying a median filter over time (deprecated).
-
-    .. deprecated:: 0.3.0
-       This function is deprecated and will be removed in a future release.
-       Use :func:`rolling_filter` with `statistic="median"` instead.
-
-    """
-    warnings.warn(
-        "The function `movement.filtering.median_filter` is deprecated and "
-        "will be removed in a future release. "
-        "Please use `movement.filtering.rolling_filter` instead, "
-        "with `statistic='median'`.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return rolling_filter(*args, statistic="median", **kwargs)

--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -6,7 +6,6 @@ import xarray as xr
 from movement.filtering import (
     filter_by_confidence,
     interpolate_over_time,
-    median_filter,
     rolling_filter,
     savgol_filter,
 )
@@ -243,26 +242,3 @@ def test_filter_by_confidence_on_position(
     n_low_confidence_kpts = 5
     assert isinstance(position_filtered, xr.DataArray)
     assert n_nans == valid_input_dataset.sizes["space"] * n_low_confidence_kpts
-
-
-def test_median_filter_deprecation(valid_poses_dataset):
-    """Test that calling median_filter raises a DeprecationWarning.
-
-    And that it forwards to rolling_filter with statistic='median'.
-    """
-    test_args = (valid_poses_dataset.position, 3)  # data array, window
-    test_kwargs = {"min_periods": None, "print_report": False}
-
-    with pytest.warns(
-        DeprecationWarning, match="median_filter.*deprecated.*rolling_filter"
-    ):
-        result = median_filter(*test_args, **test_kwargs)
-
-    # Ensure that median_filter correctly forwards to rolling_filter
-    expected_result = rolling_filter(
-        *test_args, statistic="median", **test_kwargs
-    )
-    assert result.equals(expected_result), (
-        "median_filter should produce the same output as "
-        "rolling_filter with statistic='median'"
-    )


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other: Docs cleanup

**Why is this PR needed?**

`movement.filtering.median_filter` has been deprecated since v0.3.0, replaced by the more general `rolling_filter`. I think it's time to remove it completely; users have had sufficient warning.

**What does this PR do?**

Remove the `median_filter` and all its associated warning, tests and mentions.

## References

#455 

## How has this PR been tested?

Locally run tests and docs build.

## Is this a breaking change?

Yes, the `median_filter` is no longer part of the API.

## Does this PR require an update to the documentation?

Auto-updated.

## Checklist:

- [x] The code has been tested locally
- [n/a] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
