### PR TITLE
Remove "easily" from some longer examples

### DIFF
--- a/docs/source/user_guide/input_output.md
+++ b/docs/source/user_guide/input_output.md
@@ -325,7 +325,7 @@ for file in nwb_files:
 (target-saving-bboxes-tracks)=
 ### Saving bounding box tracks
 
-We currently do not provide explicit methods to export a movement bounding boxes dataset in a specific format. However, you can easily save the bounding box tracks to a .csv file using the standard Python library `csv`.
+We currently do not provide explicit methods to export a movement bounding boxes dataset in a specific format. However, you can save the bounding box tracks to a .csv file using the standard Python library `csv`.
 
 Here is an example of how you can save a bounding boxes dataset to a .csv file:
 

--- a/examples/load_and_upsample_bboxes.py
+++ b/examples/load_and_upsample_bboxes.py
@@ -367,7 +367,7 @@ fig.tight_layout()
 #
 # Note that currently we do not provide explicit methods to export a
 # ``movement`` bounding boxes dataset in a specific format. However, we can
-# easily save the bounding boxes’ trajectories to a .csv file using the
+# save the bounding boxes’ trajectories to a .csv file using the
 # standard Python library ``csv``.
 
 # define name for output csv file


### PR DESCRIPTION
The word "easily" is used 4 times in the movement docs. In two cases what follows is relatively straightforward (2/3 LOC). In two cases (about saving bounding box tracks), the following example is ~10 LOC. It's pretty minor, but in these cases I don't want a user to see something described as "easy" that they may find intimidating. 