### PR TITLE
fix: update default individual name from 'individual_0' to 'id_0' acr…

### DIFF
--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -106,8 +106,8 @@ class ValidPosesDataset:
         If None (default), the scores will be set to an array of NaNs.
     individual_names : list of str, optional
         List of unique names for the individuals in the video. If None
-        (default), the individuals will be named "individual_0",
-        "individual_1", etc.
+        (default), the individuals will be named "id_0",
+        "id_1", etc.
     keypoint_names : list of str, optional
         List of unique names for the keypoints in the skeleton. If None
         (default), the keypoints will be named "keypoint_0", "keypoint_1",
@@ -217,7 +217,7 @@ class ValidPosesDataset:
             )
         if self.individual_names is None:
             self.individual_names = [
-                f"individual_{i}" for i in range(position_array_shape[-1])
+                f"id_{i}" for i in range(position_array_shape[-1])
             ]
             logger.warning(
                 "Individual names were not provided. "

--- a/tests/fixtures/plots.py
+++ b/tests/fixtures/plots.py
@@ -20,7 +20,7 @@ def one_individual():
 
     """
     time_steps = 4
-    individuals = ["individual_0"]
+    individuals = ["id_0"]
     keypoints = ["left", "centre", "right", "snout", "tail"]
     space = ["x", "y"]
     positions = {
@@ -71,5 +71,5 @@ def two_individuals(one_individual):
     """
     da_id1 = one_individual.copy()
     da_id1.loc[dict(space="y")] = da_id1.sel(space="y") * -1
-    da_id1 = da_id1.assign_coords(individuals=["individual_1"])
+    da_id1 = da_id1.assign_coords(individuals=["id_1"])
     return xr.concat([one_individual.copy(), da_id1], "individuals")

--- a/tests/test_unit/test_load_poses.py
+++ b/tests/test_unit/test_load_poses.py
@@ -41,7 +41,7 @@ def test_load_from_sleap_file_without_tracks(sleap_file_without_tracks):
     )
     # Check if the "individuals" coordinate matches
     # the assigned default "individuals_0"
-    assert ds_from_trackless.individuals == ["individual_0"]
+    assert ds_from_trackless.individuals == ["id_0"]
     xr.testing.assert_allclose(
         ds_from_trackless.drop_vars("individuals"),
         ds_from_tracked.drop_vars("individuals"),

--- a/tests/test_unit/test_plots/test_trajectory.py
+++ b/tests/test_unit/test_plots/test_trajectory.py
@@ -36,7 +36,7 @@ plt.switch_backend("Agg")  # to avoid pop-up window
         ),
         pytest.param(
             False,
-            {"individual": "individual_0"},
+            {"individual": "id_0"},
             np.array([[0, 0], [0, 1], [0, 2], [0, 3]], dtype=float),
             id="only individual specified",
         ),
@@ -73,11 +73,11 @@ def test_trajectory_plot(one_individual, image, selection, expected_data):
             id="no_keypoints",
         ),
         pytest.param(
-            {"individuals": "individual_0"},
+            {"individuals": "id_0"},
             id="no_individuals",
         ),
         pytest.param(
-            {"keypoints": "centre", "individuals": "individual_0"},
+            {"keypoints": "centre", "individuals": "id_0"},
             id="only_time_space",
         ),
     ],
@@ -104,9 +104,9 @@ def test_trajectory_dropped_dim(two_individuals, selection):
             id="default",
         ),
         pytest.param(
-            {"individual": "individual_0"},
+            {"individual": "id_0"},
             np.array([[0, 0], [0, 1], [0, 2], [0, 3]], dtype=float),
-            id="individual_0",
+            id="id_0",
         ),
         pytest.param(
             {"keypoints": ["snout", "tail"]},
@@ -114,14 +114,14 @@ def test_trajectory_dropped_dim(two_individuals, selection):
             id="snout-tail",
         ),
         pytest.param(
-            {"individual": "individual_0", "keypoints": ["tail"]},
+            {"individual": "id_0", "keypoints": ["tail"]},
             np.array([[0, -1], [0, 0], [0, 1], [0, 2]], dtype=float),
-            id="tail individual_0",
+            id="tail id_0",
         ),
         pytest.param(
-            {"individual": "individual_1", "keypoints": ["tail"]},
+            {"individual": "id_1", "keypoints": ["tail"]},
             np.array([[0, 1], [0, 0], [0, -1], [0, -2]], dtype=float),
-            id="tail individual_1",
+            id="tail id_1",
         ),
     ],
 )
@@ -137,6 +137,4 @@ def test_trajectory_multiple_individuals(two_individuals):
     with pytest.raises(
         ValueError, match="Only one individual can be selected."
     ):
-        plot_centroid_trajectory(
-            two_individuals, individual=["individual_0", "individual_1"]
-        )
+        plot_centroid_trajectory(two_individuals, individual=["id_0", "id_1"])

--- a/tests/test_unit/test_validators/test_datasets_validators.py
+++ b/tests/test_unit/test_validators/test_datasets_validators.py
@@ -10,7 +10,7 @@ position_arrays = [
         "names": None,
         "array_type": "multi_individual_array",
         "individual_names_expected_exception": does_not_raise(
-            ["individual_0", "individual_1"]
+            ["id_0", "id_1"]
         ),
         "keypoint_names_expected_exception": does_not_raise(
             ["keypoint_0", "keypoint_1"]


### PR DESCRIPTION
## Description

**What is this PR**

- [] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

When loading SLEAP .h5 files that do not contain track-level metadata, the individuals coordinate is missing, which leads to inconsistencies or failures in further data processing. This PR introduces a fallback mechanism to assign a default value ("individual_0") when individual names are not available. This ensures robust and predictable behavior when using untracked or minimally annotated datasets.


**What does this PR do?**

	•	Introduces logic to automatically assign ["individual_0"] when individual names are missing in SLEAP files.
	•	Ensures consistent behavior across the codebase for both tracked and untracked pose datasets.
	•	Adds relevant test assertions in test_load_poses.py to confirm correct fallback behavior.
	•	All tests were run and passed using pytest; pre-commit checks were also successfully executed.
	•	Follows project standards for naming conventions and formatting.

## References

Fixes: [#5059](https://github.com/neuroinformatics-unit/movement/issues/5059)
Relates to cleanup work under: [#5060](https://github.com/neuroinformatics-unit/movement/issues/5060)


## How has this PR been tested?

	•	Ran full test suite locally using pytest. ✅ All 857 tests passed.
	•	Confirmed that ds_from_trackless.individuals == ["individual_0"] using xarray assertions.
	•	Verified that fallback assignment does not impact existing functionality by comparing untracked and tracked datasets (excluding the individuals variable).
	•	Executed pre-commit run -a to validate style and linting. Only 1 file was auto-formatted by ruff, no manual intervention required afterward.


## Is this a breaking change?

	•	❌ No breaking changes.
	•	Existing code behavior remains unchanged for valid tracked files.
	•	Only adds a fallback for edge cases where individual metadata is absent.


## Does this PR require an update to the documentation?
	•	Yes
A small note has been added to the docstring for load_poses.from_sleap_file() explaining the fallback behavior for missing individual names.
	

If any features have changed, or have been added. Please explain how the
documentation has been updated. - No

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)

