### PR TITLE
Fetch full commit history in `build-sphinx-docs`

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           python-version: 3.12
           use-make: true
+          fetch-tags: true
 
   deploy_sphinx_docs:
     name: Deploy Sphinx Docs


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Fixes #620 

**What does this PR do?**

Sets `fetch-tags: true` for the `build-sphinx-docs` action.

## References

See #620 for the full context.
The bug was observed in CI failures in #618 and #619.

## How has this PR been tested?

I tried the fix in #619, and the CI passed.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

N/A
- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
