### PR TITLE
Upper pin numpy to 2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dynamic = ["version"]
 license = { text = "BSD-3-Clause" }
 
 dependencies = [
-  "numpy>=2.0.0",
+  "numpy>=2.0.0,<2.3.0",  # Upper pin is because of numba incompatibility
   "pandas",
   "h5py",
   "attrs",
@@ -24,8 +24,8 @@ dependencies = [
   "xarray[accel,io,viz]",
   "PyYAML",
   "napari-video",
-  "pyvideoreader>=0.5.3",  # since switching to depend on openCV-headless
-  "qt-niu",  # needed for collapsible widgets
+  "pyvideoreader>=0.5.3", # since switching to depend on openCV-headless
+  "qt-niu",               # needed for collapsible widgets
   "loguru",
   "pynwb",
   "ndx-pose>=0.2.1",
@@ -54,9 +54,7 @@ entry-points."napari.manifest".movement = "movement.napari:napari.yaml"
 "User Support" = "https://neuroinformatics.zulipchat.com/#narrow/stream/406001-Movement"
 
 [project.optional-dependencies]
-napari = [
-  "napari[all]>=0.6.0",
-]
+napari = ["napari[all]>=0.6.0"]
 dev = [
   "pytest",
   "pytest-cov",


### PR DESCRIPTION
## Description

**What is this PR**

- [ x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

This is a temporary measure, because numba is currently incompatible with NumPy=2.3, see https://github.com/numba/numba/issues/10105

The fix is underway https://github.com/numba/numba/pull/10147, so hopefully we can remove this soon.
But I think we have to do this for now, because I've already gotten failures to install in some environments because of this.

**What does this PR do?**

Upper pins NumPy to 2.3, exactly matching what we already had to do on the conda feedstock side, see [conda-forge recipe](https://github.com/conda-forge/movement-feedstock/blob/main/recipe/meta.yaml).

## References
- https://github.com/numba/numba/issues/10105

I've opened issues as reminders to remove the pin when we can:
- https://github.com/neuroinformatics-unit/movement/issues/639
- https://github.com/conda-forge/movement-feedstock/issues/17

## How has this PR been tested?

Local environment updated and tests passed.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
