### PR TITLE
Hotfix: disable artifact.ci

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -44,7 +44,7 @@ jobs:
           python-version: 3.12
           use-make: true
           fetch-tags: true
-          use-artifactci: true
+          use-artifactci: false
 
   deploy_sphinx_docs:
     name: Deploy Sphinx Docs


### PR DESCRIPTION
We suspect that the addition of artifact.ci #631 broke something in the docs deployment workflow, resulting in the website to go down following the [`v0.8.1` release](https://github.com/neuroinformatics-unit/movement/releases/tag/v0.8.1).

This PR disables artifact.ci, which will hopefully allow us to re-deploy the website.
