### PR TITLE
Hotfix: temporarily disable linkcheck

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -45,6 +45,7 @@ jobs:
           use-make: true
           fetch-tags: true
           use-artifactci: false
+          check-links: false
 
   deploy_sphinx_docs:
     name: Deploy Sphinx Docs


### PR DESCRIPTION
This is following #640 and in necessary to allow us to re-deploy the website.
