### PR TITLE
Replace external links to movement docs with explicit targets

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -45,7 +45,6 @@ jobs:
           use-make: true
           fetch-tags: true
           use-artifactci: false
-          check-links: false
 
   deploy_sphinx_docs:
     name: Deploy Sphinx Docs

--- a/docs/source/blog/arc-collaboration.md
+++ b/docs/source/blog/arc-collaboration.md
@@ -57,7 +57,7 @@ Currently, the submodule has two wrappers to use:
 - `plot_occupancy`, which creates an occupancy plot of an individual, given its position data. Collections of individuals are aggregated over, and if multiple keypoints are provided, the occupancy of the centroid is calculated. Introduced in [#403](movement-github:pull/403).
 
 Examples to showcase the use of these plotting functions are currently [being produced](movement-github:issues/415).
-[Our other examples](https://movement.neuroinformatics.dev/examples/index.html) have also been updated to use these functions where possible.
+[Our other examples](target-examples) have also been updated to use these functions where possible.
 
 ### Broadcasting Methods
 


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
In case the movement website is not available and needs to be redeployed, `linkcheck` will fail on these external URL references (see for example the recent [linkcheck loop](https://github.com/neuroinformatics-unit/movement/actions/runs/16449971843/job/46492310327) which prevented the docs from being redeployed). The better option here is hence to use "internal" links when cross-referencing within movement docs, since `linkcheck` will only check external links.

**What does this PR do?**
This PR replaces external URL references to movement docs with explicit targets to prevent unnecessary linkcheck. 

## How has this PR been tested?
https://movement.neuroinformatics.dev/examples/index.html is [no longer checked](https://github.com/neuroinformatics-unit/movement/actions/runs/16466968499/job/46546625095?pr=642#step:3:1345)

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
