### PR TITLE
Use `eager` mode with artifact.ci on manual trigger

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -39,17 +39,12 @@ jobs:
             ~/.movement/*
           key: cached-test-data-${{ runner.os }}
           restore-keys: cached-test-data
-      - uses: neuroinformatics-unit/actions/build_sphinx_docs@eager-mode-on-deploy
+      - uses: neuroinformatics-unit/actions/build_sphinx_docs@ch-artifactci-fork
         with:
           python-version: 3.12
           use-make: true
           fetch-tags: true
-          use-artifactci: >-
-            ${{ (
-              github.event_name == 'push' && github.ref_type == 'tag'
-            ) || (
-              github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
-            ) && 'eager' || 'lazy' }}
+          use-artifactci: ${{ (github.event_name == 'workflow_dispatch') && 'eager' || 'lazy' }}
 
   deploy_sphinx_docs:
     name: Deploy Sphinx Docs

--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -49,7 +49,7 @@ jobs:
               github.event_name == 'push' && github.ref_type == 'tag'
             ) || (
               github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
-            ) && 'lazy' || 'eager' }}
+            ) && 'eager' || 'lazy' }}
 
   deploy_sphinx_docs:
     name: Deploy Sphinx Docs

--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -39,7 +39,7 @@ jobs:
             ~/.movement/*
           key: cached-test-data-${{ runner.os }}
           restore-keys: cached-test-data
-      - uses: neuroinformatics-unit/actions/build_sphinx_docs@ch-artifactci-fork
+      - uses: neuroinformatics-unit/actions/build_sphinx_docs@main
         with:
           python-version: 3.12
           use-make: true

--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -39,7 +39,7 @@ jobs:
             ~/.movement/*
           key: cached-test-data-${{ runner.os }}
           restore-keys: cached-test-data
-      - uses: neuroinformatics-unit/actions/build_sphinx_docs@main
+      - uses: neuroinformatics-unit/actions/build_sphinx_docs@eager-mode-on-deploy
         with:
           python-version: 3.12
           use-make: true

--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -49,7 +49,7 @@ jobs:
               github.event_name == 'push' && github.ref_type == 'tag'
             ) || (
               github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
-            ) && 'eager' || 'lazy' }}
+            ) && 'lazy' || 'eager' }}
 
   deploy_sphinx_docs:
     name: Deploy Sphinx Docs

--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -44,7 +44,7 @@ jobs:
           python-version: 3.12
           use-make: true
           fetch-tags: true
-          use-artifactci: lazy
+          use-artifactci: ${{ ((github.event_name == 'push' && github.ref_type == 'tag') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')) && 'eager' || 'lazy' }}
 
   deploy_sphinx_docs:
     name: Deploy Sphinx Docs

--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -44,7 +44,12 @@ jobs:
           python-version: 3.12
           use-make: true
           fetch-tags: true
-          use-artifactci: ${{ ((github.event_name == 'push' && github.ref_type == 'tag') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')) && 'eager' || 'lazy' }}
+          use-artifactci: >-
+            ${{ (
+              github.event_name == 'push' && github.ref_type == 'tag'
+            ) || (
+              github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+            ) && 'eager' || 'lazy' }}
 
   deploy_sphinx_docs:
     name: Deploy Sphinx Docs


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
In [v0.8.1](https://github.com/neuroinformatics-unit/movement/releases/tag/v0.8.1), the [docs deployment job](https://github.com/neuroinformatics-unit/movement/actions/runs/16448279641) was unable to locate the built docs, ~~presumably because we were using the default `artifactci-mode: lazy`, which does not upload the artifact until a user is logged in.~~
because of the issue with artifact.ci described [here](https://github.com/mmkal/artifact.ci/issues/10).

**What does this PR do?**
This PR configures use-artifactci to use
- `eager` mode that uploads the artifacts immediately to artifact.ci, when the workflow is manually triggered
- `lazy` mode that only uploads the artifacts to artifact.ci when triggered by a user, in all other cases.

## References
https://github.com/neuroinformatics-unit/actions/pull/90

## How has this PR been tested?
- `lazy` mode should be the default: Verified by making sure the upload only happens once I visit the [preview URL](https://www.artifact.ci/artifact/view/neuroinformatics-unit/movement/run/16503098612.1/docs-build)
- `eager` mode: Expect the preview URL to point directly to the docs website.

## Does this PR require an update to the documentation?

If any features have changed, or have been added. Please explain how the
documentation has been updated.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
