### PR TITLE
Add gallery of examples in API documentation

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -44,7 +44,6 @@ jobs:
           python-version: 3.12
           use-make: true
           fetch-tags: true
-          use-artifactci: eager
 
   deploy_sphinx_docs:
     name: Deploy Sphinx Docs

--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -44,7 +44,7 @@ jobs:
           python-version: 3.12
           use-make: true
           fetch-tags: true
-          use-artifactci: false
+          use-artifactci: eager
 
   deploy_sphinx_docs:
     name: Deploy Sphinx Docs

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ docs/source/api/
 docs/source/api_index.rst
 docs/source/snippets/admonitions.md
 sg_execution_times.rst
+docs/source/gen_modules/
 
 # MkDocs documentation
 /site/

--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,6 @@ docs/source/api/
 docs/source/api_index.rst
 docs/source/snippets/admonitions.md
 sg_execution_times.rst
-docs/source/gen_modules/
 
 # MkDocs documentation
 /site/

--- a/docs/source/_templates/autosummary/class.rst
+++ b/docs/source/_templates/autosummary/class.rst
@@ -29,3 +29,6 @@
    {%- endfor %}
    {% endif %}
    {% endblock %}
+
+   .. minigallery:: {{ module }}.{{ objname }}
+      :add-heading: Examples using ``{{ objname }}``

--- a/docs/source/_templates/autosummary/class.rst
+++ b/docs/source/_templates/autosummary/class.rst
@@ -30,5 +30,5 @@
    {% endif %}
    {% endblock %}
 
-   .. minigallery:: {{ module }}.{{ objname }}
-      :add-heading: Examples using ``{{ objname }}``
+.. minigallery:: {{ module }}.{{ objname }}
+   :add-heading: Examples using ``{{ objname }}``

--- a/docs/source/_templates/autosummary/function.rst
+++ b/docs/source/_templates/autosummary/function.rst
@@ -5,4 +5,4 @@
 .. auto{{ objtype }}:: {{ objname }}
 
 .. minigallery:: {{ module }}.{{ objname }}
-    :add-heading: Examples using ``{{ objname }}``
+   :add-heading: Examples using ``{{ objname }}``

--- a/docs/source/_templates/autosummary/function.rst
+++ b/docs/source/_templates/autosummary/function.rst
@@ -3,3 +3,6 @@
 .. currentmodule:: {{ module }}
 
 .. auto{{ objtype }}:: {{ objname }}
+
+.. minigallery:: {{ module }}.{{ objname }}
+    :add-heading: Examples using ``{{ objname }}``

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -118,7 +118,7 @@ sphinx_gallery_conf = {
     # Do not render config comments with the pattern # sphinx_gallery_config [= value]
     "remove_config_comments": True,
     # Mini-galleries config, see https://sphinx-gallery.github.io/stable/configuration.html#add-mini-galleries-for-api-documentation
-    "backreferences_dir": "gen_modules/backreferences",  # directory where function/class granular galleries are stored
+    "backreferences_dir": "api/backreferences",  # directory where function/class granular galleries are stored
     "doc_module": ("movement",),  # module for which to generate mini-galleries
 }
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -226,8 +226,8 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "loguru": ("https://loguru.readthedocs.io/en/stable/", None),
     "pynwb": ("https://pynwb.readthedocs.io/en/stable/", None),
+    "matplotlib": ("https://matplotlib.org/stable/", None),
 }
-
 
 # What to show on the 404 page
 notfound_context = {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -227,6 +227,7 @@ intersphinx_mapping = {
     "loguru": ("https://loguru.readthedocs.io/en/stable/", None),
     "pynwb": ("https://pynwb.readthedocs.io/en/stable/", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
 }
 
 # What to show on the 404 page

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -115,8 +115,11 @@ sphinx_gallery_conf = {
     },
     "reference_url": {"movement": None},
     "default_thumb_file": "source/_static/data_icon.png",  # default thumbnail image
+    # Do not render config comments with the pattern # sphinx_gallery_config [= value]
     "remove_config_comments": True,
-    # do not render config params set as # sphinx_gallery_config [= value]
+    # Mini-galleries config, see https://sphinx-gallery.github.io/stable/configuration.html#add-mini-galleries-for-api-documentation
+    "backreferences_dir": "gen_modules/backreferences",  # directory where function/class granular galleries are stored
+    "doc_module": ("movement",),  # module for which to generate mini-galleries
 }
 
 

--- a/docs/source/user_guide/input_output.md
+++ b/docs/source/user_guide/input_output.md
@@ -54,7 +54,7 @@ The pose tracks loading functionalities are provided by the
 from movement.io import load_poses
 ```
 
-To read a pose tracks file into a [movement poses dataset](target-poses-and-bboxes-dataset), we provide specific functions for each of the supported formats. We additionally provide a more general `from_numpy()` method, with which we can build a [movement poses dataset](target-poses-and-bboxes-dataset) from a set of NumPy arrays.
+To read a pose tracks file into a [movement poses dataset](target-poses-and-bboxes-dataset), we provide specific functions for each of the supported formats. We additionally provide a more general {func}`from_numpy()<movement.io.load_poses.from_numpy>` function, with which we can build a [movement poses dataset](target-poses-and-bboxes-dataset) from a set of NumPy arrays.
 
 ::::{tab-set}
 
@@ -225,7 +225,7 @@ To load bounding box tracks into a [movement bounding boxes dataset](target-pose
 from movement.io import load_bboxes
 ```
 
-We currently support loading bounding box tracks in the VGG Image Annotator (VIA) format only. However, like in the poses datasets, we additionally provide a `from_numpy()` method, with which we can build a [movement bounding boxes dataset](target-poses-and-bboxes-dataset) from a set of NumPy arrays.
+We currently support loading bounding box tracks in the VGG Image Annotator (VIA) format only. However, like in the poses datasets, we additionally provide a {func}`from_numpy()<movement.io.load_bboxes.from_numpy>` function, with which we can build a [movement bounding boxes dataset](target-poses-and-bboxes-dataset) from a set of NumPy arrays.
 
 ::::{tab-set}
 :::{tab-item} VGG Image Annotator

--- a/examples/advanced/broadcasting_your_own_methods.py
+++ b/examples/advanced/broadcasting_your_own_methods.py
@@ -1,8 +1,7 @@
 """Broadcast functions across multi-dimensional data
 =====================================================
 
-Use the :func:`movement.utils.broadcasting.make_broadcastable` decorator
-(:func:`@make_broadcastable()<movement.utils.broadcasting.make_broadcastable>`)
+Use the @make_broadcastable decorator
 to efficiently apply functions across any data dimension.
 """
 

--- a/examples/advanced/broadcasting_your_own_methods.py
+++ b/examples/advanced/broadcasting_your_own_methods.py
@@ -1,14 +1,16 @@
 """Broadcast functions across multi-dimensional data
 =====================================================
 
-Use the ``make_broadcastable`` decorator to efficiently
-apply functions across any data dimension.
+Use the :func:`movement.utils.broadcasting.make_broadcastable` decorator
+(:func:`@make_broadcastable()<movement.utils.broadcasting.make_broadcastable>`)
+to efficiently apply functions across any data dimension.
 """
 
 # %%
 # Summary
 # -------
-# The ``make_broadcastable`` decorator is particularly useful when you need to
+# :func:`@make_broadcastable()<movement.utils.broadcasting.\
+# make_broadcastable>` is particularly useful when you need to
 # apply the same operation to multiple individuals or time points
 # while avoiding the need to write complex loops.
 #
@@ -183,7 +185,7 @@ was_in_slippery_region
 
 # %%
 # We could get the first and last time that an individual was inside the
-# slippery region now, by examining this DataArray
+# slippery region now, by examining this ``DataArray``.
 i_id = "AEON3B_NTP"
 individual_0_centroid = was_in_slippery_region.sel(
     individuals=i_id, keypoints="centroid"
@@ -215,11 +217,12 @@ print(
 # ---------------------------------
 # To combat this problem, we can make the observation that given any
 # ``DataArray``, we always want to broadcast our ``in_slippery_region``
-# function
-# along the ``"space"`` dimension. By "broadcast", we mean that we always want
-# to run our function for each 1D-slice in the ``"space"`` dimension, since
-# these are the (x, y) coordinates. As such, we can decorate our function with
-# the ``make_broadcastable`` decorator:
+# function along the ``"space"`` dimension. By "broadcast", we mean that
+# we always want to run our function for each 1D-slice in the ``"space"``
+# dimension, since these are the (x, y) coordinates.
+# As such, we can decorate our function with
+# :func:`@make_broadcastable()\
+# <movement.utils.broadcasting.make_broadcastable>`:
 
 
 @make_broadcastable()
@@ -230,7 +233,8 @@ def in_slippery_region_broadcastable(xy_position) -> float:
 # %%
 # Note that when writing your own methods, there is no need to have both
 # ``in_slippery_region`` and ``in_slippery_region_broadcastable``, simply apply
-# the ``make_broadcastable`` decorator to ``in_slippery_region`` directly.
+# :func:`@make_broadcastable()<movement.utils.broadcasting.make_broadcastable>`
+# to ``in_slippery_region`` directly.
 # We've made two separate functions here to illustrate what's going on.
 
 # %%
@@ -326,7 +330,8 @@ print(in_slippery_region_general((0.5, 0.5), (0.0, 0.0), (1.0, 1.0)))
 print(in_slippery_region_general((0.5, 0.5), (1.0, 1.0), (2.0, 2.0)))
 
 # %%
-# We will find that ``make_broadcastable`` retains the additional arguments to
+# We will find that :func:`@make_broadcastable()<movement.utils.broadcasting.\
+# make_broadcastable>` retains the additional arguments to
 # the function we define, however the ``xy_position`` argument has to be the
 # first argument to the function, that appears in the ``def`` statement.
 
@@ -341,7 +346,8 @@ in_slippery_region_general(positions, xy_min=(100, 0), xy_max=(400, 1000))
 # %%
 # Only Broadcast Along Select Dimensions
 # --------------------------------------
-# The ``make_broadcastable`` decorator has some flexibility with its input
+# :func:`@make_broadcastable()<movement.utils.broadcasting.\
+# make_broadcastable>` has some flexibility with its input
 # arguments, to help you avoid unintentional behaviour. You may have noticed,
 # for example, that there is nothing stopping someone who wants to use your
 # analysis code from trying to broadcast along the wrong dimension.
@@ -362,7 +368,8 @@ silly_broadcast
 # our function to be used.
 #
 # We can pass the ``only_broadcastable_along`` keyword argument to
-# ``make_broadcastable`` to prevent these kinds of mistakes, and make our
+# :func:`@make_broadcastable()<movement.utils.broadcasting.\
+# make_broadcastable>` to prevent these kinds of mistakes, and make our
 # intentions clearer.
 
 
@@ -400,14 +407,18 @@ xr.testing.assert_equal(
 
 # %%
 # It is worth noting that there is a "helper" decorator,
-# ``space_broadcastable``, that essentially does the same thing as
-# ``make_broadcastable(only_broadcastable_along="space")``.
+# :func:`@space_broadcastable()\
+# <movement.utils.broadcasting.space_broadcastable>`,
+# that essentially does the same thing as
+# :func:`@make_broadcastable(only_broadcastable_along="space")\
+# <movement.utils.broadcasting.make_broadcastable>`.
 # You can use this decorator for your own convenience.
 
 # %%
 # Extending to Class Methods
 # --------------------------
-# ``make_broadcastable`` can also be applied to class methods, though it needs
+# :func:`@make_broadcastable()<movement.utils.broadcasting.make_broadcastable>`
+# can also be applied to class methods, though it needs
 # to be told that you are doing so via the ``is_classmethod`` parameter.
 
 
@@ -440,9 +451,12 @@ xr.testing.assert_equal(
 )
 
 # %%
-# The ``broadcastable_method`` decorator is provided as a helpful alias for
-# ``make_broadcastable(is_classmethod=True)``, and otherwise works in the same
-# way (and accepts the same parameters).
+# :func:`@broadcastable_method()\
+# <movement.utils.broadcasting.broadcastable_method>` is
+# provided as a helpful alias for
+# :func:`@make_broadcastable(is_classmethod=True)\
+# <movement.utils.broadcasting.make_broadcastable>`,
+# and otherwise works in the same way (and accepts the same parameters).
 
 
 class RectangleAlternative:
@@ -478,8 +492,8 @@ xr.testing.assert_equal(
 xr.testing.assert_equal(was_in_region_clsmethod_alt, was_in_region_clsmethod)
 
 # %%
-# In fact, if you look at the Regions of Interest submodule, and in particular
-# the classes inside it, you'll notice that we use the ``broadcastable_method``
-# decorator ourselves in some of these methods!
-
-# %%
+# In fact, if you look at the :mod:`movement.roi` module, and in particular
+# the classes inside it, you'll notice that we use
+# :func:`@broadcastable_method()\
+# <movement.utils.broadcasting.broadcastable_method>`
+# ourselves in some of these methods!

--- a/examples/boundary_angles.py
+++ b/examples/boundary_angles.py
@@ -63,8 +63,8 @@ habitat_fig.show()
 # In order to ask questions about the behaviour of our individuals with respect
 # to the habitat, we first need to define the RoIs to represent the separate
 # pieces of the habitat programmatically. Since each part of the habitat is
-# two-dimensional, we will use a ``PolygonOfInterest`` to describe each of
-# them.
+# two-dimensional, we will use :class:`movement.roi.PolygonOfInterest`
+# to describe each of them.
 #
 # In the future, the
 # `movement plugin for napari <../user_guide/gui.md>`_
@@ -117,9 +117,9 @@ nest_region = PolygonOfInterest(nest_corners, name="Nest region")
 # %%
 # To create an RoI representing the ring region, we need to provide an interior
 # boundary so that ``movement`` knows our ring region has a "hole".
-# ``movement``'s ``PolygonsOfInterest`` can actually support multiple
-# (non-overlapping) holes, which is why the ``holes`` argument takes a
-# ``list``.
+# :class:`PolygonOfInterest<movement.roi.PolygonOfInterest>`
+# can actually support multiple (non-overlapping) holes, which is why the
+# ``holes`` argument takes a ``list``.
 ring_region = PolygonOfInterest(
     ring_outer_boundary, holes=[core_boundary], name="Ring region"
 )
@@ -220,17 +220,22 @@ distances_fig.show()
 # is when the individuals meet in the ``ring_region``, and remain largely
 # stationary in a group until they can pass each other.
 #
-# One other thing to note is that ``compute_distance_to`` is returning the
-# distance "as the crow flies" to the ``nest_region``. This means that
-# structures potentially in the way (such as the ``ring_region`` walls) are not
-# accounted for in this distance calculation. Further to this, the "distance to
-# a RoI" should always be understood as "the distance from a point to the
-# closest point within an RoI".
+# One other thing to note is that
+# :meth:`PolygonOfInterest.compute_distance_to()<movement.roi.\
+# PolygonOfInterest.compute_distance_to>`
+# is returning the distance "as the crow flies" to the ``nest_region``.
+# This means that structures potentially in the way
+# (such as the ``ring_region`` walls) are not accounted for in this distance
+# calculation. Further to this, the "distance to a RoI" should always be
+# understood as "the distance from a point to the closest point within an RoI".
 #
 # If we wanted to check the direction of closest approach to a region, referred
-# to as the **approach vector**, we can use the ``compute_approach_vector``
-# method.
-# The distances that we computed via ``compute_distance_to`` are just the
+# to as the **approach vector**, we can use
+# :meth:`PolygonOfInterest.compute_approach_vector()<movement.roi.\
+# PolygonOfInterest.compute_approach_vector>`.
+# The distances that we computed via
+# :meth:`PolygonOfInterest.compute_distance_to()<movement.roi.\
+# PolygonOfInterest.compute_distance_to>` are just the
 # magnitudes of the approach vectors.
 
 approach_vectors = nest_region.compute_approach_vector(positions)
@@ -273,8 +278,8 @@ distances_fig.show()
 # To find distances to the ring's walls instead, we can use
 # ``boundary_only=True``, which tells ``movement`` to only look at points on
 # the boundary of the region, not inside it.
-# Note that for 1D regions (``LineOfInterest``), the "boundary" is just the
-# endpoints of the line.
+# Note that for 1D regions (:class:`movement.roi.LineOfInterest`),
+# the "boundary" is just the endpoints of the line.
 #
 # Let's try again with ``boundary_only=True``:
 
@@ -364,8 +369,8 @@ distances_exterior_fig.show()
 #
 # For the purposes of our example, we will define our "forward vector" as the
 # velocity vector between successive time-points, for each individual - we can
-# compute this from ``positions`` using the ``compute_velocity`` function in
-# ``movement.kinematics``.
+# compute this from ``positions`` using
+# :func:`movement.kinematics.compute_velocity`.
 # We will also define our reference frame, or "global north" direction, to be
 # the direction of the positive x-axis.
 

--- a/examples/compute_head_direction.py
+++ b/examples/compute_head_direction.py
@@ -38,7 +38,7 @@ print(f"Keypoints: {ds.keypoints.values}")
 # %%
 # The loaded dataset ``ds`` contains two data arrays:``position`` and
 # ``confidence``. In this tutorial, we will only use the ``position`` data
-# array. We use the ``squeeze()`` method to remove
+# array. We use :meth:`xarray.DataArray.squeeze` to remove
 # the redundant ``individuals`` dimension, as there is only one individual
 # in this dataset.
 
@@ -53,7 +53,7 @@ position = ds.position.squeeze()
 # as part of the sample dataset.
 #
 # The :func:`plot_centroid_trajectory()\
-# <movement.plots.trajectory.plot_centroid_trajectory>`
+# <movement.plots.plot_centroid_trajectory>`
 # function can help you visualise the trajectory of any keypoint in the data.
 # Passing a list of keypoints, in this case ``["left_ear", "right_ear"]``,
 # will plot the centroid (midpoint) of the selected keypoints.
@@ -219,8 +219,9 @@ print(head_to_snout_polar)
 #     :alt: Schematic comparing cartesian and polar coordinates
 
 # %%
-# ``movement`` also provides a ``pol2cart`` function to transform
-# data in polar coordinates to cartesian.
+# ``movement`` also provides a
+# :func:`pol2cart()<movement.utils.vector.pol2cart>` function
+# to transform data in polar coordinates to cartesian.
 # Note that the resulting ``head_to_snout_cart`` array has a ``space``
 # dimension with two coordinates: ``x`` and ``y``.
 
@@ -267,8 +268,10 @@ print(forward_vector)
 
 
 # %%
-# You can use ``compute_forward_vector`` to compute the perpendicular
-# vector to any line connecting two bilaterally symmetric keypoints.
+# You can use
+# :func:`compute_forward_vector()<movement.kinematics.compute_forward_vector>`
+# to compute the perpendicular vector to any line connecting two bilaterally
+# symmetric keypoints.
 # For example, you could estimate the forward direction for the pelvis given
 # two keypoints at the hips.
 #

--- a/examples/compute_kinematics.py
+++ b/examples/compute_kinematics.py
@@ -49,11 +49,11 @@ position = ds.position
 # Visualise the data
 # ---------------------------
 # First, let's visualise the trajectories of the mice in the XY plane,
-# colouring them by individual. We use the ``plot_centroid_trajectory``
-# function from ``movement.plots`` which is a wrapper around
-# ``matplotlib.pyplot.scatter`` that simplifies plotting the trajectories of
-# individuals in the dataset. The fig and ax objects returned can be used to
-# further customise the plot.
+# colouring them by individual.
+# We use :func:`movement.plots.plot_centroid_trajectory` which is a wrapper
+# around :func:`matplotlib.pyplot.scatter` that simplifies plotting the
+# trajectories of individuals in the dataset.
+# The fig and ax objects returned can be used to further customise the plot.
 
 # Create a single figure and axes
 fig, ax = plt.subplots(1, 1)
@@ -86,8 +86,8 @@ fig.show()
 # follows the convention for SLEAP and most image processing tools.
 
 # %%
-# By default the ``plot_centroid_trajectory`` function in ``movement.plots``
-# colours data points based on their timestamps:
+# By default :func:`plot_centroid_trajectory()<movement.plots.\
+# plot_centroid_trajectory>` colours data points based on their timestamps:
 fig, axes = plt.subplots(3, 1, sharey=True)
 for mouse_name, ax in zip(position.individuals.values, axes, strict=False):
     ax.invert_yaxis()
@@ -126,8 +126,8 @@ plt.gcf().show()
 # %%
 # Compute displacement
 # ---------------------
-# The :mod:`movement.kinematics` module provides functions to compute
-# various kinematic quantities,
+# The :mod:`movement.kinematics` module
+# provides functions to compute various kinematic quantities,
 # such as displacement, velocity, and acceleration.
 # We can start off by computing the distance travelled by the mice along
 # their trajectories:

--- a/examples/filter_and_interpolate.py
+++ b/examples/filter_and_interpolate.py
@@ -167,7 +167,7 @@ print(ds.position.log)
 
 # %%
 # If you want to retrieve a certain parameter from the log, you can use
-# ``json.loads()`` to parse the log string into a list of dictionaries.
+# :func:`json.loads` to parse the log string into a list of dictionaries.
 
 log_entries = json.loads(ds.position.log)  # A list of dictionaries
 

--- a/examples/load_and_explore_poses.py
+++ b/examples/load_and_explore_poses.py
@@ -47,7 +47,8 @@ position = ds.position
 # %%
 # Select and plot data with xarray
 # --------------------------------
-# You can use the ``sel`` method to index into ``xarray`` objects.
+# You can use :meth:`xarray.DataArray.sel` or :meth:`xarray.Dataset.sel` to
+# index into ``xarray`` data arrays and datasets.
 # For example, we can get a ``DataArray`` containing only data
 # for a single keypoint of the first individual:
 
@@ -70,9 +71,9 @@ da.plot.line(x="time", row="individuals", aspect=2, size=2.5)
 # Trajectory plots
 # ----------------
 # We are not limited to ``xarray``'s built-in plots.
-# The ``movement.plots`` module provides some additional
-# visualisations, like ``plot_centroid_trajectory()``.
-
+# The :mod:`movement.plots` module provides some additional
+# visualisations, like :func:`plot_centroid_trajectory()\
+# <movement.plots.plot_centroid_trajectory>`.
 
 mouse_name = "AEON3B_TP1"
 fig, ax = plot_centroid_trajectory(position, individual=mouse_name)

--- a/examples/load_and_upsample_bboxes.py
+++ b/examples/load_and_upsample_bboxes.py
@@ -152,7 +152,7 @@ for i, frame_idx in enumerate(list_frames):
 fig.tight_layout()
 
 # %%
-# We used ``xarray``'s ``.sel()`` method to select the data for the
+# We used :meth:`xarray.DataArray.sel` to select the data for the
 # relevant frames directly.
 #
 # The centroid at each frame is marked with a red marker. The past centroid
@@ -271,8 +271,8 @@ print(ds_nan.shape.isel(time=slice(0, 10), individuals=0).data)
 # between the two annotated values, and its width and height change linearly
 # as well.
 #
-# We use the dataset with NaN values as an input to the
-# ``interpolate_over_time`` function.
+# We use the dataset with NaN values as an input to
+# :func:`movement.filtering.interpolate_over_time`.
 ds_interp = ds_nan.copy()
 
 for data_array_str in ["position", "shape"]:
@@ -368,7 +368,7 @@ fig.tight_layout()
 # Note that currently we do not provide explicit methods to export a
 # ``movement`` bounding boxes dataset in a specific format. However, we can
 # save the bounding boxes’ trajectories to a .csv file using the
-# standard Python library ``csv``.
+# standard Python library :mod:`csv`.
 
 # define name for output csv file
 filepath = "tracking_output.csv"

--- a/examples/mouse_eye_movements.py
+++ b/examples/mouse_eye_movements.py
@@ -72,8 +72,8 @@ plt.show()
 # %%
 # Pupil trajectory
 # ----------------
-# A quick plot of the trajectory of the centre of the pupil using the
-# ``plot_centroid_trajectory`` function from ``movement.plots``.
+# A quick plot of the trajectory of the centre of the pupil using
+# :func:`movement.plots.plot_centroid_trajectory`.
 time_window = slice(1, 24)  # seconds
 position_black = ds_black.position.sel(time=time_window)  # data array to plot
 fig, ax = plot_centroid_trajectory(
@@ -128,7 +128,7 @@ plt.show()
 # %%
 # Normalised keypoint positions over time
 # ---------------------------------------
-# Normalizing the pupil's position relative to the midpoint of the eye reduces
+# Normalising the pupil's position relative to the midpoint of the eye reduces
 # the impact of head movements or artefacts caused by camera movement. By
 # subtracting the position of the eye's midpoint, we effectively transform the
 # data into a moving coordinate system, with the eye's midpoint as the origin.
@@ -146,7 +146,7 @@ plt.show()
 # To look at pupil position—and later also velocity—over time, we use the
 # pupil centroid (in this case the midpoint between keypoints ``pupil-L`` and
 # ``pupil-R``). The keypoint ``pupil-C`` is assigned using
-# ``xarray.DataArray.assign_coords``.
+# :meth:`xarray.DataArray.assign_coords`.
 
 pupil_centroid = (
     positions_norm.sel(keypoints=["pupil-L", "pupil-R"])
@@ -155,7 +155,7 @@ pupil_centroid = (
 )
 # %%
 # The pupil centroid keypoint ``pupil-C`` is be added to the ``positions_norm``
-# using ``xarray.concat``.
+# using :func:`xarray.concat`.
 positions_norm = xr.concat([positions_norm, pupil_centroid], dim="keypoints")
 # %%
 # Now the position of the pupil centroid ``pupil-C`` can be plotted.
@@ -176,9 +176,9 @@ plt.show()
 # can compensate for, a quick, ballistic eye movement is triggered to
 # shift gaze to a new fixation point. These fast eye movements are seen in the
 # previous plot but become even more obvious when the velocity of the pupil
-# centroid is plotted. To do this, we use ``compute_velocity`` from the
-# ``movement.kinematics`` module to calculate the velocity of the eye
-# movements.
+# centroid is plotted. To do this, we use
+# :func:`movement.kinematics.compute_velocity`
+# to calculate the velocity of the eye movements.
 pupil_velocity = kin.compute_velocity(positions_norm.sel(keypoints="pupil-C"))
 pupil_velocity.name = "pupil velocity"
 pupil_velocity.sel(**sel).squeeze().plot.line(
@@ -193,7 +193,7 @@ plt.show()
 # Pupil diameter
 # --------------
 # Here we define the pupil diameter as the distance between the two pupil
-# keypoints. We use ``compute_pairwise_distances`` from ``movement.kinematics``
+# keypoints. We use :func:`movement.kinematics.compute_pairwise_distances`
 # to calculate the Euclidean distance between ``pupil-L`` and ``pupil-R``.
 pupil_diameter: xr.DataArray = kin.compute_pairwise_distances(
     positions_norm, dim="keypoints", pairs={"pupil-L": "pupil-R"}
@@ -245,8 +245,8 @@ plt.show()
 # ---------------------
 # A rolling mean (moving average) filter is used here to smooth the data by
 # averaging a specified number of data points (``window_len``).
-# We achieve this by calling the :func:`movement.filtering.rolling_filter`
-# function with the ``statistic="mean"`` option.
+# We achieve this by calling :func:`movement.filtering.rolling_filter`
+# with the ``statistic="mean"`` option.
 
 window_len = 80
 mean_filter = rolling_filter(

--- a/examples/smooth.py
+++ b/examples/smooth.py
@@ -125,8 +125,9 @@ def plot_raw_and_smooth_timeseries_and_psd(
 #
 # Here we use the default ``statistic="median"`` option, which is a sensible
 # choice for smoothing time-series data while being robust to outliers.
-# You can also use the ``rolling_filter`` function to compute the rolling
-# mean, maximum, and minimum values (instead of the median), by
+# You can also use
+# :func:`rolling_filter()<movement.filtering.rolling_filter>` to compute
+# the rolling mean, maximum, and minimum values (instead of the median), by
 # setting ``statistic`` to ``"mean"``, ``"max"``, or ``"min"``, respectively.
 
 window = int(0.1 * ds_wasp.fps)

--- a/movement/plots/occupancy.py
+++ b/movement/plots/occupancy.py
@@ -22,9 +22,9 @@ def plot_occupancy(
     """Create a 2D occupancy histogram.
 
     - If there are multiple keypoints selected, the occupancy of the centroid
-        of these keypoints is computed.
-    - If there are multiple individuals selected, the their occupancies are
-        aggregated.
+      of these keypoints is computed.
+    - If there are multiple individuals selected, their occupancies are
+      aggregated.
 
     Points whose corresponding spatial coordinates have NaN values
     are ignored.
@@ -45,7 +45,7 @@ def plot_occupancy(
         Axes object on which to draw the histogram. If not provided, a new
         figure and axes are created and returned.
     kwargs : Any
-        Keyword arguments passed to ``matplotlib.pyplot.hist2d``
+        Keyword arguments passed to :meth:`matplotlib.axes.Axes.hist2d`.
 
     Returns
     -------
@@ -61,9 +61,9 @@ def plot_occupancy(
     Notes
     -----
     The third return value of this method exposes the outputs from
-    ``matplotlib.pyplot.hist2d`` that would otherwise be lost if only the
-    figure and axes handles were returned. This information is returned as a
-    dictionary.
+    :meth:`matplotlib.axes.Axes.hist2d` that would otherwise be lost if only
+    the figure and axes handles were returned. This information is returned
+    as a dictionary.
 
     For data with ``Nx`` bins in the 1st spatial dimension, and ``Ny`` bins in
     the 2nd spatial dimension, the dictionary output has key-value pairs;
@@ -75,7 +75,7 @@ def plot_occupancy(
 
     ``counts[x, y]`` is the number of datapoints in the
     ``(xedges[x], xedges[x+1]), (yedges[y], yedges[y+1])`` bin. These values
-    are those returned from ``matplotlib.pyplot.Axes.hist2d``.
+    are those returned from :meth:`matplotlib.axes.Axes.hist2d`.
 
     Examples
     --------
@@ -122,7 +122,7 @@ def plot_occupancy(
 
     See Also
     --------
-    matplotlib.pyplot.Axes.hist2d : The underlying plotting function.
+    :meth:`matplotlib.axes.Axes.hist2d` : The underlying plotting function.
 
     """
     # Collapse dimensions if necessary

--- a/movement/plots/trajectory.py
+++ b/movement/plots/trajectory.py
@@ -43,7 +43,7 @@ def plot_centroid_trajectory(
         figure and axes are created.
     **kwargs : dict
         Additional keyword arguments passed to
-        ``matplotlib.axes.Axes.scatter()``.
+        :meth:`matplotlib.axes.Axes.scatter`.
 
     Returns
     -------

--- a/movement/roi/base.py
+++ b/movement/roi/base.py
@@ -535,8 +535,8 @@ class BaseRegionOfInterest:
             `DataArray` of spatial positions, considered the origin of the
             ``direction`` vector.
         boundary_only : bool
-            Passed to ``compute_approach_vector`` (see Notes). Default
-            ``False``.
+            Passed to :func:`compute_approach_vector`
+            (see Notes). Default ``False``.
         in_degrees : bool
             If ``True``, angles are returned in degrees. Otherwise angles are
             returned in radians. Default ``False``.
@@ -576,7 +576,7 @@ class BaseRegionOfInterest:
             ``matplotlib.pyplot.Axes`` object to draw the region on. A new
             ``Figure`` and ``Axes`` will be created if not provided.
         matplotlib_kwargs : Any
-            Keyword arguments passed to the ``matplotlib.pyplot`` plotting
+            Keyword arguments passed to the :mod:`matplotlib.pyplot` plotting
             function.
 
         """

--- a/movement/roi/line.py
+++ b/movement/roi/line.py
@@ -52,8 +52,9 @@ class LineOfInterest(BaseRegionOfInterest):
         -----
         The constructor supports 'rings' or 'closed loops' via the ``loop``
         argument. However, if you want to define an enclosed region for your
-        analysis, we recommend you create a ``PolygonOfInterest`` and use
-        its ``boundary`` property instead.
+        analysis, we recommend you create a
+        :class:`PolygonOfInterest<movement.roi.PolygonOfInterest>`
+        and use its ``boundary`` property instead.
 
         See Also
         --------

--- a/movement/roi/polygon.py
+++ b/movement/roi/polygon.py
@@ -28,7 +28,8 @@ class PolygonOfInterest(BaseRegionOfInterest):
     joined (in sequence) by straight lines between consecutive pairs of points,
     to form the exterior boundary of the RoI. Note that the exterior boundary
     (accessible as via the ``.exterior`` property) is a (closed)
-    ``LineOfInterest``, and may be treated accordingly.
+    :class:`LineOfInterest<movement.roi.LineOfInterest>`, and may be treated
+    accordingly.
 
     The class also supports holes - subregions properly contained inside the
     region that are not part of the region itself. These can be specified by
@@ -125,7 +126,7 @@ class PolygonOfInterest(BaseRegionOfInterest):
 
         In addition, ``matplotlib`` requires hole coordinates to be listed in
         the reverse orientation to the exterior boundary. Running
-        ``numpy.flip`` on the exterior coordinates is a cheap way to ensure
+        :func:`numpy.flip` on the exterior coordinates is a cheap way to ensure
         that we adhere to this convention, since our geometry is normalised
         upon creation, so this amounts to reversing the order of the
         coordinates.

--- a/movement/transforms.py
+++ b/movement/transforms.py
@@ -40,7 +40,7 @@ def scale(
     Notes
     -----
     This function makes two changes to the resulting data array's attributes
-    (``xarray.DataArray.attrs``) each time it is called:
+    (:attr:`xarray.DataArray.attrs`) each time it is called:
 
     - It sets the ``space_unit`` attribute to the value of the parameter
       with the same name, or removes it if ``space_unit=None``.

--- a/movement/utils/broadcasting.py
+++ b/movement/utils/broadcasting.py
@@ -1,7 +1,7 @@
 r"""Broadcasting operations across ``xarray.DataArray`` dimensions.
 
 This module essentially provides an equivalent functionality to
-``numpy.apply_along_axis``, but for ``xarray.DataArray`` objects.
+:func:`numpy.apply_along_axis`, but for ``xarray.DataArray`` objects.
 This functionality is provided as a decorator, so it can be applied to both
 functions within the package and be available to users who would like to use it
 in their analysis.
@@ -12,10 +12,11 @@ Typically, one would either have to call this function successively in a
 need to be examined, or re-write the function to be able to broadcast along the
 necessary dimension of the data structure.
 
-The ``make_broadcastable`` decorator takes care of the latter piece of work,
-allowing us to write functions that operate on 1D slices, then apply this
-decorator to have them work across ``xarray.DataArray`` dimensions. The
-function
+The :func:`make_broadcastable()\
+<movement.utils.broadcasting.make_broadcastable>` decorator takes care of the
+latter piece of work, allowing us to write functions that operate on 1D slices,
+then apply this decorator to have them work across ``xarray.DataArray``
+dimensions. The function
 
 >>> def my_function(input_1d, *args, **kwargs):
 ...     # do something
@@ -74,9 +75,9 @@ def apply_along_da_axis(
 ) -> xr.DataArray:
     """Apply a function ``f`` across ``dimension`` of ``data``.
 
-    ``f`` should be callable as ``f(input_1D)`` where ``input_1D`` is a one-
-    dimensional ``numpy.typing.ArrayLike`` object. It should return either a
-    scalar or one-dimensional ``numpy.typing.ArrayLike`` object.
+    ``f`` should be callable as ``f(input_1D)`` where ``input_1D`` is a
+    one-dimensional :data:`numpy.typing.ArrayLike` object. It should return
+    either a scalar or one-dimensional :data:`numpy.typing.ArrayLike` object.
 
     Parameters
     ----------
@@ -202,7 +203,7 @@ def make_broadcastable(  # noqa: C901
     ... my_function(data_array, *args, **kwargs)
     ```
 
-    Make a class method broadcast along any axis of an `xarray.DataArray`.
+    Make a class method broadcast along any axis of an ``xarray.DataArray``.
 
     >>> from dataclasses import dataclass
     >>>


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
This PR closes #569 

**What does this PR do?**
This PR
- configures [mini-galleries](https://sphinx-gallery.github.io/stable/configuration.html#references-to-examples) for the API docs (see [example](https://www.artifact.ci/artifact/view/neuroinformatics-unit/movement/branch/mini-galleries/docs-build/html/api/movement.kinematics.compute_velocity.html#examples-using-compute-velocity) in artifact.ci preview)
- updates, adds, and fixes references to API docs in the examples and module docstrings

## References
#569 #648

## How has this PR been tested?
Docs built locally and on [CI](https://www.artifact.ci/artifact/view/neuroinformatics-unit/movement/branch/mini-galleries/docs-build/html/index.html)

## Checklist:

- [x] Remove squashed commit of PR #648 
- [x] Revert d6f8da3
- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
