### PR TITLE
improve resulting displacement vectors

### DIFF
--- a/examples/compute_kinematics.py
+++ b/examples/compute_kinematics.py
@@ -213,6 +213,7 @@ fig.colorbar(sc, ax=ax, label="time (s)")
 # position to the previous one:
 backward_displacement = kin.compute_backward_displacement(position)
 
+# %%
 # In this case, the backward displacement vector at the first timestep
 # is defined as the zero vector, since there is no previous position.
 

--- a/examples/compute_kinematics.py
+++ b/examples/compute_kinematics.py
@@ -132,25 +132,25 @@ plt.gcf().show()
 # We can start off by computing the distance travelled by the mice along
 # their trajectories:
 
-displacement = kin.compute_displacement(position)
+displacement_forward = kin.compute_forward_displacement(position)
 
 # %%
-# The :func:`movement.kinematics.compute_displacement`
+# The :func:`movement.kinematics.compute_forward_displacement`
 # function will return a data array equivalent to the ``position`` one,
 # but holding displacement data along the ``space`` axis, rather than
 # position data.
 #
-# The ``displacement`` data array holds, for a given individual and keypoint
-# at timestep ``t``, the vector that goes from its previous position at time
-# ``t-1`` to its current position at time ``t``.
+# The ``displacement_forward`` data array holds, for a given individual and
+# keypoint at timestep ``t``, the vector that goes from its current position
+# at time ``t`` to its next position at time ``t+1``.
 
 # %%
-# And what happens at ``t=0``, since there is no previous timestep?
-# We define the displacement vector at time ``t=0`` to be the zero vector.
+# And what happens at the last timestep, since there is no next timepoint?
+# We define the displacement vector at the last timestep to be the zero vector.
 # This way the shape of the ``displacement`` data array is the
 # same as the  ``position`` array:
 print(f"Shape of position: {position.shape}")
-print(f"Shape of displacement: {displacement.shape}")
+print(f"Shape of displacement: {displacement_forward.shape}")
 
 # %%
 # We can visualise these displacement vectors with a quiver plot. In this case
@@ -169,12 +169,12 @@ sc = ax.scatter(
     cmap="viridis",
 )
 
-# plot displacement vectors: at t, vector from t-1 to t
+# plot displacement vectors: at t, vector from t to t+1
 ax.quiver(
     position.sel(individuals=mouse_name, space="x"),
     position.sel(individuals=mouse_name, space="y"),
-    displacement.sel(individuals=mouse_name, space="x"),
-    displacement.sel(individuals=mouse_name, space="y"),
+    displacement_forward.sel(individuals=mouse_name, space="x"),
+    displacement_forward.sel(individuals=mouse_name, space="y"),
     angles="xy",
     scale=1,
     scale_units="xy",
@@ -183,60 +183,6 @@ ax.quiver(
     headaxislength=9,
 )
 
-ax.axis("equal")
-ax.set_xlim(450, 575)
-ax.set_ylim(950, 1075)
-ax.set_xlabel("x (pixels)")
-ax.set_ylabel("y (pixels)")
-ax.set_title(f"Zoomed in trajectory of {mouse_name}")
-ax.invert_yaxis()
-fig.colorbar(sc, ax=ax, label="time (s)")
-
-# %%
-# Notice that this figure is not very useful as a visual check:
-# we can see that there are vectors defined for each point in
-# the trajectory, but we have no easy way to verify they are indeed
-# the displacement vectors from ``t-1`` to ``t``.
-
-# %%
-# If instead we plot
-# the opposite of the displacement vector, we will see that at every time
-# ``t``, the vectors point to the position at ``t-1``.
-# Remember that the displacement vector is defined as the vector at
-# time ``t``, that goes from the previous position ``t-1`` to the
-# current position at ``t``. Therefore, the opposite vector will point
-# from the position point at ``t``, to the position point at ``t-1``.
-
-# %%
-# We can easily do this by flipping the sign of the displacement vector in
-# the plot above:
-mouse_name = "AEON3B_TP2"
-
-fig = plt.figure()
-ax = fig.add_subplot()
-
-# plot position data
-sc = ax.scatter(
-    position.sel(individuals=mouse_name, space="x"),
-    position.sel(individuals=mouse_name, space="y"),
-    s=15,
-    c=position.time,
-    cmap="viridis",
-)
-
-# plot displacement vectors: at t, vector from t-1 to t
-ax.quiver(
-    position.sel(individuals=mouse_name, space="x"),
-    position.sel(individuals=mouse_name, space="y"),
-    -displacement.sel(individuals=mouse_name, space="x"),  # flipped sign
-    -displacement.sel(individuals=mouse_name, space="y"),  # flipped sign
-    angles="xy",
-    scale=1,
-    scale_units="xy",
-    headwidth=7,
-    headlength=9,
-    headaxislength=9,
-)
 ax.axis("equal")
 ax.set_xlim(450, 575)
 ax.set_ylim(950, 1075)
@@ -257,7 +203,7 @@ fig.colorbar(sc, ax=ax, label="time (s)")
 
 # length of each displacement vector
 displacement_vectors_lengths = compute_norm(
-    displacement.sel(individuals=mouse_name)
+    displacement_forward.sel(individuals=mouse_name)
 )
 
 # sum the lengths of all displacement vectors (in pixels)

--- a/examples/compute_kinematics.py
+++ b/examples/compute_kinematics.py
@@ -215,6 +215,10 @@ print(
 )
 
 # %%
+# Internally, that's what :func:`movement.kinematics.compute_path_length` does.
+kin.compute_path_length(ds.position).sel(individuals=mouse_name).values[0]
+
+# %%
 # Compute velocity
 # ----------------
 # We can easily compute the velocity vectors for all individuals in our data

--- a/examples/compute_kinematics.py
+++ b/examples/compute_kinematics.py
@@ -1,4 +1,4 @@
-"""Compute and visualise kinematics.
+"""Compute and visualise kinematics
 ====================================
 
 Compute displacement, velocity and acceleration, and
@@ -12,6 +12,7 @@ visualise the results.
 # For interactive plots: install ipympl with `pip install ipympl` and uncomment
 # the following line in your notebook
 # %matplotlib widget
+import numpy as np
 from matplotlib import pyplot as plt
 
 import movement.kinematics as kin
@@ -50,9 +51,8 @@ position = ds.position
 # ---------------------------
 # First, let's visualise the trajectories of the mice in the XY plane,
 # colouring them by individual.
-# We use :func:`movement.plots.plot_centroid_trajectory` which is a wrapper
-# around :func:`matplotlib.pyplot.scatter` that simplifies plotting the
-# trajectories of individuals in the dataset.
+# For this we can use :func:`movement.plots.plot_centroid_trajectory`
+# which is a wrapper around :func:`matplotlib.pyplot.scatter`.
 # The fig and ax objects returned can be used to further customise the plot.
 
 # Create a single figure and axes
@@ -77,6 +77,8 @@ for mouse_name, col in zip(
         label=mouse_name,
     )
     ax.legend().set_alpha(1)
+ax.set_xlabel("x (pixels)")
+ax.set_ylabel("y (pixels)")
 fig.show()
 
 # %%
@@ -86,10 +88,15 @@ fig.show()
 # follows the convention for SLEAP and most image processing tools.
 
 # %%
-# By default :func:`plot_centroid_trajectory()<movement.plots.\
-# plot_centroid_trajectory>` colours data points based on their timestamps:
-fig, axes = plt.subplots(3, 1, sharey=True)
-for mouse_name, ax in zip(position.individuals.values, axes, strict=False):
+# We can also plot the trajectories of the mice in the XY plane independently,
+# colouring the data points based on their timestamps. This is the default
+# behaviour of
+# :func:`plot_centroid_trajectory()<movement.plots.plot_centroid_trajectory>`
+# when the ``c`` argument is not provided:
+fig, axes = plt.subplots(2, 2, sharey=True)
+for mouse_name, ax in zip(
+    position.individuals.values, axes.flat, strict=False
+):
     ax.invert_yaxis()
     fig, ax = plot_centroid_trajectory(
         position,
@@ -97,10 +104,15 @@ for mouse_name, ax in zip(position.individuals.values, axes, strict=False):
         ax=ax,
         s=2,
     )
+    ax.set_aspect("equal")
+    ax.set_xlim(150, 1250)
+    ax.set_ylim(500, 1100)
     ax.set_title(f"Trajectory {mouse_name}")
     ax.set_xlabel("x (pixels)")
     ax.set_ylabel("y (pixels)")
     ax.collections[0].colorbar.set_label("Time (frames)")
+# Hide the unused subplot (4th one)
+axes[1, 1].set_visible(False)
 fig.tight_layout()
 fig.show()
 
@@ -111,7 +123,7 @@ fig.show()
 # the third mouse (``AEON3B_TP2``) followed an anti-clockwise direction.
 
 # %%
-# We can also easily plot the components of the position vector against time
+# We can also inspect the components of the position vector against time
 # using ``xarray``'s built-in plotting methods. We use
 # :meth:`xarray.DataArray.squeeze` to
 # remove the dimension of length 1 from the data (the ``keypoints`` dimension).
@@ -124,37 +136,36 @@ plt.gcf().show()
 # and the ``x`` and ``y`` coordinates of the ``position`` are in pixels.
 
 # %%
-# Compute displacement
-# ---------------------
+# Compute displacement vectors
+# ----------------------------
 # The :mod:`movement.kinematics` module
-# provides functions to compute various kinematic quantities,
-# such as displacement, velocity, and acceleration.
-# We can start off by computing the distance travelled by the mice along
-# their trajectories:
-
-displacement_forward = kin.compute_forward_displacement(position)
+# provides functions to compute various kinematic variables,
+# such as displacement, velocity, and acceleration. Below we showcase
+# how these functions can be used.
+#
+# We can compute the forward displacement vectors as follows:
+forward_displacement = kin.compute_forward_displacement(position)
 
 # %%
 # The :func:`movement.kinematics.compute_forward_displacement`
 # function will return a data array equivalent to the ``position`` one,
-# but holding displacement data along the ``space`` axis, rather than
-# position data.
+# but holding displacement data along the ``space`` axis.
 #
-# The ``displacement_forward`` data array holds, for a given individual and
+# The ``forward_displacement`` data array holds, for a given individual and
 # keypoint at timestep ``t``, the vector that goes from its current position
 # at time ``t`` to its next position at time ``t+1``.
 
 # %%
-# And what happens at the last timestep, since there is no next timepoint?
-# We define the displacement vector at the last timestep to be the zero vector.
-# This way the shape of the ``displacement`` data array is the
-# same as the  ``position`` array:
+# And what happens in the last timestep, when there is no next timepoint?
+# We define the forward displacement vector then to be the
+# zero vector. This way the shape of the ``forward_displacement`` data array
+# is the same as the ``position`` array:
 print(f"Shape of position: {position.shape}")
-print(f"Shape of displacement: {displacement_forward.shape}")
+print(f"Shape of displacement: {forward_displacement.shape}")
 
 # %%
-# We can visualise these displacement vectors with a quiver plot. In this case
-# we focus on the mouse ``AEON3B_TP2``:
+# We can visualise the forward displacement vectors with a quiver plot. In
+# this case we focus on the mouse ``AEON3B_TP2``:
 mouse_name = "AEON3B_TP2"
 
 fig = plt.figure()
@@ -169,12 +180,12 @@ sc = ax.scatter(
     cmap="viridis",
 )
 
-# plot displacement vectors: at t, vector from t to t+1
+# plot forward displacement vectors: at t, vector from t to t+1
 ax.quiver(
     position.sel(individuals=mouse_name, space="x"),
     position.sel(individuals=mouse_name, space="y"),
-    displacement_forward.sel(individuals=mouse_name, space="x"),
-    displacement_forward.sel(individuals=mouse_name, space="y"),
+    forward_displacement.sel(individuals=mouse_name, space="x"),
+    forward_displacement.sel(individuals=mouse_name, space="y"),
     angles="xy",
     scale=1,
     scale_units="xy",
@@ -183,9 +194,8 @@ ax.quiver(
     headaxislength=9,
 )
 
-ax.axis("equal")
-ax.set_xlim(450, 575)
-ax.set_ylim(950, 1075)
+ax.set_xlim(480, 600)
+ax.set_ylim(980, 1080)
 ax.set_xlabel("x (pixels)")
 ax.set_ylabel("y (pixels)")
 ax.set_title(f"Zoomed in trajectory of {mouse_name}")
@@ -194,34 +204,116 @@ fig.colorbar(sc, ax=ax, label="time (s)")
 
 
 # %%
-# Now we can visually verify that indeed the displacement vector
+# We can visually verify that indeed the forward displacement vector
 # connects the previous and current positions as expected.
 
 # %%
-# With the displacement data we can compute the distance travelled by the
-# mouse along its trajectory.
+# Similarly, with :func:`movement.kinematics.compute_backward_displacement`
+# we can compute the backward displacement vectors, which connect the current
+# position to the previous one:
+backward_displacement = kin.compute_backward_displacement(position)
 
-# length of each displacement vector
-displacement_vectors_lengths = compute_norm(
-    displacement_forward.sel(individuals=mouse_name)
+# In this case, the backward displacement vector at the first timestep
+# is defined as the zero vector, since there is no previous position.
+
+# %%
+# Adapting the code snippet from above, we can visually check that the
+# backward displacement vector is indeed the reverse of the forward
+# displacement vector.
+
+fig = plt.figure()
+ax = fig.add_subplot()
+
+sc = ax.scatter(
+    position.sel(individuals=mouse_name, space="x"),
+    position.sel(individuals=mouse_name, space="y"),
+    s=15,
+    c=position.time,
+    cmap="viridis",
+)
+
+ax.quiver(
+    position.sel(individuals=mouse_name, space="x"),
+    position.sel(individuals=mouse_name, space="y"),
+    backward_displacement.sel(individuals=mouse_name, space="x"),
+    backward_displacement.sel(individuals=mouse_name, space="y"),
+    angles="xy",
+    scale=1,
+    scale_units="xy",
+    headwidth=7,
+    headlength=9,
+    headaxislength=9,
+)
+
+ax.set_xlim(480, 600)
+ax.set_ylim(980, 1080)
+ax.set_xlabel("x (pixels)")
+ax.set_ylabel("y (pixels)")
+ax.set_title(f"Zoomed in trajectory of {mouse_name}")
+ax.invert_yaxis()
+fig.colorbar(sc, ax=ax, label="time (s)")
+
+
+# %%
+# Compute path length
+# --------------------
+# We can compute the distance travelled by the
+# mouse as the sum of the lengths of all
+# displacement vectors along its trajectory.
+# Both backward and forward displacement vectors
+# should give the same result:
+
+# length of each forward displacement vector
+forward_displacement_lengths = compute_norm(
+    forward_displacement.sel(individuals=mouse_name)
+)
+
+# length of each backward displacement vector
+backward_displacement_lengths = compute_norm(
+    backward_displacement.sel(individuals=mouse_name)
+)
+
+# check their lengths are the same
+np.testing.assert_almost_equal(
+    forward_displacement_lengths.values[:-1],  # exclude last timestep
+    backward_displacement_lengths.values[1:],  # exclude first timestep
 )
 
 # sum the lengths of all displacement vectors (in pixels)
-total_displacement = displacement_vectors_lengths.sum(dim="time").values[0]
+total_displacement_fwd = forward_displacement_lengths.sum(dim="time").values[0]
+total_displacement_bwd = backward_displacement_lengths.sum(dim="time").values[
+    0
+]
 
 print(
-    f"The mouse {mouse_name}'s trajectory is {total_displacement:.2f} "
-    "pixels long"
+    f"The mouse {mouse_name}'s path length is {total_displacement_fwd:.2f} "
+    "pixels long (using forward displacement)"
+)
+print(
+    f"The mouse {mouse_name}'s path length is {total_displacement_bwd:.2f} "
+    "pixels long (using backward displacement)"
 )
 
+
 # %%
-# Internally, that's what :func:`movement.kinematics.compute_path_length` does.
-kin.compute_path_length(ds.position).sel(individuals=mouse_name).values[0]
+# We provide a convenience function
+# :func:`movement.kinematics.compute_path_length`
+# to compute the path length for all individuals and keypoints in a position
+# data array. We can verify that using this function gives the same result
+# as before for the ``AEON3B_TP2`` mouse:
+
+path_lengths = kin.compute_path_length(ds.position)
+
+for mouse_name in path_lengths.individuals.values:
+    print(
+        f"Path length for {mouse_name}: "
+        f"{path_lengths.sel(individuals=mouse_name).values[0]:.2f} pixels"
+    )
 
 # %%
 # Compute velocity
 # ----------------
-# We can easily compute the velocity vectors for all individuals in our data
+# We can also compute the velocity vectors for all individuals in our data
 # array:
 velocity = kin.compute_velocity(position)
 
@@ -244,9 +336,9 @@ plt.gcf().show()
 # %%
 # The components of the velocity vector seem noisier than the components of
 # the position vector.
-# This is expected, since we are deriving the velocity using differences in
+# This is expected, since we are estimating the velocity using differences in
 # position (which is somewhat noisy), over small stepsizes.
-# More specifically, we use numpy's gradient implementation, which
+# More specifically, we use :func:`numpy.gradient` internally, which
 # uses second order central differences.
 
 # %%
@@ -265,7 +357,7 @@ fig.tight_layout()
 
 # %%
 # To visualise the direction of the velocity vector at each timestep, we can
-# use a quiver plot:
+# again use a quiver plot:
 mouse_name = "AEON3B_TP2"
 fig = plt.figure()
 ax = fig.add_subplot()

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -287,7 +287,7 @@ def from_sleap_file(
     ----------
     .. [1] https://docs.sleap.ai/latest/learnings/export-analysis/
     .. [2] https://github.com/talmolab/sleap/blob/v1.3.3/sleap/info/write_tracking_h5.py#L59
-    .. [3] https://docs.sleap.ai/latest/how-to-guides/tracking-and-proofreading/
+    .. [3] https://docs.sleap.ai/latest/guides/tracking-and-proofreading/
 
     Examples
     --------

--- a/movement/kinematics/__init__.py
+++ b/movement/kinematics/__init__.py
@@ -4,6 +4,8 @@ from movement.kinematics.distances import compute_pairwise_distances
 from movement.kinematics.kinematics import (
     compute_acceleration,
     compute_displacement,
+    compute_forward_displacement,
+    compute_backward_displacement,
     compute_path_length,
     compute_speed,
     compute_time_derivative,
@@ -18,6 +20,8 @@ from movement.kinematics.kinetic_energy import compute_kinetic_energy
 
 __all__ = [
     "compute_displacement",
+    "compute_forward_displacement",
+    "compute_backward_displacement",
     "compute_velocity",
     "compute_acceleration",
     "compute_speed",

--- a/movement/kinematics/kinematics.py
+++ b/movement/kinematics/kinematics.py
@@ -63,6 +63,11 @@ def compute_time_derivative(data: xr.DataArray, order: int) -> xr.DataArray:
 def compute_displacement(data: xr.DataArray) -> xr.DataArray:
     """Compute displacement array in Cartesian coordinates.
 
+    .. deprecated:: 0.9.1
+        This function is deprecated and will be removed in a future release.
+        Use :func:`compute_forward_displacement` or
+        :func:`compute_backward_displacement` instead.
+
     The displacement array is defined as the difference between the position
     array at time point ``t`` and the position array at time point ``t-1``.
 
@@ -95,11 +100,6 @@ def compute_displacement(data: xr.DataArray) -> xr.DataArray:
     For the ``shape`` array of a ``bboxes`` dataset, the
     ``displacement`` array will hold vectors with the change in width and
     height per bounding box, between consecutive time points.
-
-    .. deprecated:: 0.9.1
-       This function is deprecated and will be removed in a future release.
-       Use :func:`compute_forward_displacement` or
-       :func:`compute_backward_displacement` instead.
 
     """
     warnings.warn(

--- a/movement/kinematics/kinematics.py
+++ b/movement/kinematics/kinematics.py
@@ -139,7 +139,7 @@ def compute_forward_displacement(data: xr.DataArray) -> xr.DataArray:
 
     As a result, for a given individual and keypoint, the forward displacement
     vector at time point ``t``, is the vector pointing from the current ``t``
-    position to the next ``(t+1)``, in Cartesian coordinates.
+    position to the next ``t+1``, in Cartesian coordinates.
 
     Parameters
     ----------
@@ -182,7 +182,7 @@ def compute_backward_displacement(data: xr.DataArray) -> xr.DataArray:
 
     As a result, for a given individual and keypoint, the backward displacement
     vector at time point ``t``, is the vector pointing from the current ``t``
-    position to the previous ``(t-1)`` in Cartesian coordinates.
+    position to the previous ``t-1`` in Cartesian coordinates.
 
     Parameters
     ----------

--- a/movement/kinematics/kinematics.py
+++ b/movement/kinematics/kinematics.py
@@ -138,7 +138,7 @@ def compute_forward_displacement(data: xr.DataArray) -> xr.DataArray:
     ``t``.
 
     As a result, for a given individual and keypoint, the forward displacement
-    vector at time point ``t``, is the vector pointing from the current ``t`
+    vector at time point ``t``, is the vector pointing from the current ``t``
     position to the next ``(t+1)``, in Cartesian coordinates.
 
     Parameters
@@ -181,7 +181,7 @@ def compute_backward_displacement(data: xr.DataArray) -> xr.DataArray:
     ``t``.
 
     As a result, for a given individual and keypoint, the backward displacement
-    vector at time point ``t``, is the vector pointing from the current ``t`
+    vector at time point ``t``, is the vector pointing from the current ``t``
     position to the previous ``(t-1)`` in Cartesian coordinates.
 
     Parameters

--- a/movement/utils/vector.py
+++ b/movement/utils/vector.py
@@ -115,7 +115,7 @@ def cart2pol(data: xr.DataArray) -> xr.DataArray:
     -----
     To compute the angle ``phi`` we rely on the :obj:`numpy.arctan2`
     function, which follows the C standard [1]_. The C standard considers
-    the case in which the inputs to the `arctan2`[2]_ function are signed
+    the case in which the inputs to the ``arctan2`` [2]_ function are signed
     zeros [3]_. For simplicity and interpretability, in ``movement`` we
     only consider the case of unsigned (positive) zeros. We implement it
     by setting the angle ``phi`` to 0 when the norm ``rho`` of the vector is 0.

--- a/movement/utils/vector.py
+++ b/movement/utils/vector.py
@@ -119,6 +119,7 @@ def cart2pol(data: xr.DataArray) -> xr.DataArray:
         data.sel(space="y"),
         data.sel(space="x"),
     )
+    phi = phi.where(rho != 0, 0)
     # Replace space dim with space_pol
     dims = list(data.dims)
     dims[dims.index("space")] = "space_pol"

--- a/tests/test_integration/test_kinematics_vector_transform.py
+++ b/tests/test_integration/test_kinematics_vector_transform.py
@@ -7,6 +7,19 @@ import xarray as xr
 import movement.kinematics as kin
 from movement.utils import vector
 
+# Displacement vectors in polar coordinates
+# for individual 0, with 10 time points and 2 space dimensions
+# moving along x = y in the x positive, y positive direction
+
+# forward displacement (rho = √2, phi = π/4)
+forward_displacement_polar = np.vstack(
+    [
+        np.tile([math.sqrt(2), math.pi / 4], (9, 1)),
+        np.zeros((1, 2)),
+        # at time t=10, the forward displacement Cartesian vector is (x=0,y=0)
+    ]
+)
+
 
 @pytest.mark.parametrize(
     "valid_dataset", ["valid_poses_dataset", "valid_bboxes_dataset"]
@@ -15,31 +28,40 @@ from movement.utils import vector
     "kinematic_variable, expected_kinematics_polar",
     [
         (
-            "displacement",
+            "forward_displacement",
             [
-                np.vstack(
-                    [
-                        np.zeros((1, 2)),
-                        np.tile([math.sqrt(2), math.atan(1)], (9, 1)),
-                    ],
-                ),  # Individual 0, rho=sqrt(2), phi=45deg
-                np.vstack(
-                    [
-                        np.zeros((1, 2)),
-                        np.tile([math.sqrt(2), -math.atan(1)], (9, 1)),
-                    ]
-                ),  # Individual 1, rho=sqrt(2), phi=-45deg
+                forward_displacement_polar,
+                # Individual 0, rho = √2, phi = 45deg = π/4
+                forward_displacement_polar * np.array([[1, -1]]),
+                # Individual 1, rho = √2, phi = -45deg = -π/4
+            ],
+        ),
+        (
+            "backward_displacement",
+            [
+                np.roll(
+                    forward_displacement_polar * np.array([[1, -3]]),
+                    shift=1,
+                    axis=0,
+                ),
+                # Individual 0, rho = √2, phi = -135deg = -3π/4
+                np.roll(
+                    forward_displacement_polar * np.array([[1, 3]]),
+                    shift=1,
+                    axis=0,
+                ),
+                # Individual 1, rho = √2, phi = 135deg = 3π/4
             ],
         ),
         (
             "velocity",
             [
                 np.tile(
-                    [math.sqrt(2), math.atan(1)], (10, 1)
-                ),  # Individual O, rho, phi=45deg
+                    [math.sqrt(2), math.pi / 4], (10, 1)
+                ),  # Individual O, rho=√2, phi=45deg=π/4
                 np.tile(
-                    [math.sqrt(2), -math.atan(1)], (10, 1)
-                ),  # Individual 1, rho, phi=-45deg
+                    [math.sqrt(2), -math.pi / 4], (10, 1)
+                ),  # Individual 1, rho=√2, phi=-45deg=-π/4
             ],
         ),
         (

--- a/tests/test_unit/test_deprecations.py
+++ b/tests/test_unit/test_deprecations.py
@@ -1,0 +1,56 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+import movement.kinematics as kinematics
+
+
+@pytest.mark.parametrize(
+    "deprecated_function, mocked_inputs, check_in_message",
+    [
+        (
+            kinematics.compute_displacement,
+            {"data": MagicMock(dims=["time", "space"])},
+            ["compute_forward_displacement", "compute_backward_displacement"],
+        ),
+    ],
+)
+def test_deprecation(deprecated_function, mocked_inputs, check_in_message):
+    """Test that calling median_filter raises a DeprecationWarning.
+    And that it forwards to rolling_filter with statistic='median'.
+    """
+    with pytest.warns(DeprecationWarning) as record:
+        _ = deprecated_function(**mocked_inputs)
+
+    assert len(record) == 1
+    assert isinstance(record[0].message, DeprecationWarning)
+    assert f"{deprecated_function.__name__}` is deprecated" in str(
+        record[0].message
+    )
+
+    assert all(
+        message in str(record[0].message) for message in check_in_message
+    )
+
+
+# ---------------- Backwards compatibility tests ----------------
+
+
+@pytest.mark.parametrize(
+    "valid_dataset",
+    ["valid_poses_dataset", "valid_bboxes_dataset"],
+)
+def test_backwards_compatibility_displacement(valid_dataset, request):
+    """Test that compute_displacement produces the same output as
+    the negative of compute_backward_displacement.
+    """
+    position = request.getfixturevalue(valid_dataset).position
+
+    with pytest.warns(DeprecationWarning):
+        result = kinematics.compute_displacement(position)
+
+    expected_result = -kinematics.compute_backward_displacement(position)
+    assert result.equals(expected_result), (
+        "compute_displacement should produce the same output as "
+        "the negative of compute_backward_displacement"
+    )

--- a/tests/test_unit/test_kinematics/test_kinematics.py
+++ b/tests/test_unit/test_kinematics/test_kinematics.py
@@ -337,26 +337,3 @@ def test_path_length_nan_warn_threshold(
             position, nan_warn_threshold=nan_warn_threshold
         )
         assert result.name == "path_length"
-
-
-@pytest.mark.parametrize(
-    "valid_dataset", ["valid_poses_dataset", "valid_bboxes_dataset"]
-)
-def test_displacement_deprecation(valid_dataset, request):
-    """Test that calling median_filter raises a DeprecationWarning.
-    And that it forwards to rolling_filter with statistic='median'.
-    """
-    position = request.getfixturevalue(valid_dataset).position
-
-    with pytest.warns(
-        DeprecationWarning,
-        match="compute_displacement.*deprecated.*compute_forward_displacement.*compute_backward_displacement",
-    ):
-        result = kinematics.compute_displacement(position)
-
-    # Ensure that median_filter correctly forwards to rolling_filter
-    expected_result = -kinematics.compute_backward_displacement(position)
-    assert result.equals(expected_result), (
-        "compute_displacement should produce the same output as "
-        "the negative of compute_backward_displacement"
-    )

--- a/tests/test_unit/test_vector.py
+++ b/tests/test_unit/test_vector.py
@@ -20,7 +20,7 @@ class TestVector:
         time_coords = np.arange(len(x_vals))
         rho = np.sqrt(x_vals**2 + y_vals**2)
         phi = np.pi * np.array(
-            [-1.0, -0.75, -0.5, -0.25, 0.0, 0.25, 0.5, 0.75, 1.0]
+            [0, -0.75, -0.5, -0.25, 0.0, 0.25, 0.5, 0.75, 1.0]
         )
         cart = xr.DataArray(
             np.column_stack((x_vals, y_vals)),

--- a/tests/test_unit/test_vector.py
+++ b/tests/test_unit/test_vector.py
@@ -15,9 +15,12 @@ class TestVector:
     @pytest.fixture
     def cart_pol_dataset(self):
         """Return an xarray.Dataset with Cartesian and polar coordinates."""
+        # Cartesian coordinates with unsigned zeros
         x_vals = np.array([-0.0, -1.0, 0.0, 1.0, 1.0, 1.0, 0.0, -1.0, -10.0])
         y_vals = np.array([-0.0, -1.0, -1.0, -1.0, 0.0, 1.0, 1.0, 1.0, 0.0])
         time_coords = np.arange(len(x_vals))
+
+        # Expected corresponding polar coordinates
         rho = np.sqrt(x_vals**2 + y_vals**2)
         phi = np.pi * np.array(
             [0, -0.75, -0.5, -0.25, 0.0, 0.25, 0.5, 0.75, 1.0]


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Currently, `compute_displacement` computes backward displacement vectors that are not easy to interpret.

**What does this PR do?**
As a solution, I propose to add two twin functions: `compute_forward_displacement` and `compute_backward_displacement`, whose results are vectors whose origin point is always the position in the associated frame.
I also updated the docstrings, the example and the tests accordingly.

Additionally, I also added an example of use of `compute_path_length` function.

## References

#136

## How has this PR been tested?

I have tested it by running the `compute_kinematics` example and checking whether the resulting vectors follow the direction of points.
Finally, i made sure unit and integration tests were correctly adapted and passing.

## Is this a breaking change?

Yes, it deprecates `compute_displacement` in favour of `compute_forward_displacement` and `compute_backward_displacement`.
See an example below:

```python
# Instead of:
from movement.kinematics import compute_displacement
bwd_inverted_displacement = compute_displacement(ds.position)

# Use:
from movement.kinematics import compute_backward_displacement
bwd_inverted_displacement = -compute_backward_displacement(ds.position)
```


## Does this PR require an update to the documentation?

The documentation should be re-generated to reflect the changes in the doctrings

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
