### PR TITLE
fix: three issues (vector broadcasting, save log path, safe version)

### DIFF
--- a/movement/__init__.py
+++ b/movement/__init__.py
@@ -6,7 +6,7 @@ try:
     __version__ = version("movement")
 except PackageNotFoundError:
     # package is not installed
-    pass
+    __version__ = "0.0.0"
 
 # set xarray global options
 import xarray as xr

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -216,7 +216,7 @@ def to_dlc_file(
             filepath = f"{file.path.with_suffix('')}_{key}{file.path.suffix}"
             if isinstance(df, pd.DataFrame):
                 _save_dlc_df(Path(filepath), df)
-            logger.info(f"Saved poses for individual {key} to {file.path}.")
+            logger.info(f"Saved poses for individual {key} to {filepath}.")
     else:
         # convert the dataset to a single dataframe for all individuals
         df_all = to_dlc_style_df(ds, split_individuals=False)

--- a/movement/utils/vector.py
+++ b/movement/utils/vector.py
@@ -237,8 +237,20 @@ def compute_signed_angle_2d(
         v = v.squeeze()
         if v.ndim == 1:
             v_dims = ["space"]
+            v_coords = {"space": u.coords["space"]}
         elif v.ndim == 2:
-            v_dims = ["time", "space"]
+            # If a single time point is provided, treat as a 1D space vector
+            # so it can broadcast across the time dimension of ``u``
+            if v.shape[0] == 1:
+                v = v.squeeze(0)
+                v_dims = ["space"]
+                v_coords = {"space": u.coords["space"]}
+            else:
+                v_dims = ["time", "space"]
+                v_coords = {
+                    "time": u.coords["time"],
+                    "space": u.coords["space"],
+                }
         else:
             raise log_error(
                 ValueError,
@@ -247,7 +259,7 @@ def compute_signed_angle_2d(
         v = xr.DataArray(
             v,
             dims=v_dims,
-            coords={d: u.coords[d] for d in v_dims},
+            coords=v_coords,
         )
     elif not isinstance(v, xr.DataArray):
         raise log_error(


### PR DESCRIPTION
Vector: treat v shape (1,2) as space-only vector in compute_signed_angle_2d to broadcast over time correctly.
IO: fix save_poses.to_dlc_file log message to print the actual per-individual saved path.
Init: ensure __version__ has a safe default when package isn’t installed to avoid CLI info issues.