### PR TITLE
Pin napari-video >= 0.2.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "sleap-io",
   "xarray[accel,io,viz]",
   "PyYAML",
-  "napari-video",
+  "napari-video>=0.2.13",
   "pyvideoreader>=0.5.3", # since switching to depend on openCV-headless
   "qt-niu",               # needed for collapsible widgets
   "loguru",


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Closes #660.

**What does this PR do?**

Pins the `napari-video` dependency to >= 0.2.13. This is the most recent release, available on both `conda-forge` and `PyPI`, which solves the [bug](https://github.com/janclemenslab/napari-video/issues/6).

## References
- https://github.com/neuroinformatics-unit/movement/issues/660
- https://github.com/janclemenslab/napari-video/issues/6

## How has this PR been tested?

I locally installed `movement` alongside `napari-video=0.2.13`, and videos load without problems.
I tried this with two versions of `napari`, 0.6.2 and 0.6.4 (before and after the breaking change), and it worked with both.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
