### PR TITLE
Add missing contributors

### DIFF
--- a/docs/source/community/people.md
+++ b/docs/source/community/people.md
@@ -183,7 +183,7 @@ This section contains other manually added contributors (on GitHub) who have not
 contributed to the movement repository, but have contributed in other ways (e.g. by
 providing sample data, or by actively participating in discussions).
 =============================================================================== -->
-<!-- readme: Sepidak,sannatitus,lkatsouri,athenaakrami,dimokaramanlis,shailajaAkella,mehulrastogi,NeuroDuan,roaldarbol,Mahi7828,ShigrafS,albiangela -start -->
+<!-- readme: Sepidak,sannatitus,lkatsouri,athenaakrami,dimokaramanlis,shailajaAkella,mehulrastogi,NeuroDuan,roaldarbol,Mahi7828,ShigrafS,albiangela,edeno,luiztauffer -start -->
 <table>
 	<tbody>
 		<tr>
@@ -276,7 +276,7 @@ providing sample data, or by actively participating in discussions).
 		</tr>
 	<tbody>
 </table>
-<!-- readme: Sepidak,sannatitus,lkatsouri,athenaakrami,dimokaramanlis,shailajaAkella,mehulrastogi,NeuroDuan,roaldarbol,Mahi7828,ShigrafS,albiangela -end -->
+<!-- readme: Sepidak,sannatitus,lkatsouri,athenaakrami,dimokaramanlis,shailajaAkella,mehulrastogi,NeuroDuan,roaldarbol,Mahi7828,ShigrafS,albiangela,edeno,luiztauffer -end -->
 
 <!-- =================== MANUAL: OTHER NON-GITHUB CONTRIBUTORS ===================
 This section contains other manually added contributors (not on GitHub) who have not


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Two contributors, Eric Denovellis and Luiz Tauffer were missing from our [people page](https://movement.neuroinformatics.dev/community/people.html).
I think this omission snuck in because they were co-authors of the [NWB PR](https://github.com/neuroinformatics-unit/movement/pull/360), which our bots may have solely credited to me.

**What does this PR do?**

Adds them via the [manual route for GitHub users](https://movement.neuroinformatics.dev/community/contributing.html#updating-the-contributors-list).

## References

https://github.com/neuroinformatics-unit/movement/pull/360

## How has this PR been tested?

NaN.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

It is in itself an update to docs.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
