### PR TITLE
Changes for multi-version docs

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -56,7 +56,8 @@ jobs:
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
-      - uses: neuroinformatics-unit/actions/deploy_sphinx_docs@main
+      - uses: neuroinformatics-unit/actions/deploy_sphinx_docs_multiversion@main
         with:
           secret_input: ${{ secrets.GITHUB_TOKEN }}
           use-make: true
+          switcher_url: https://movement.neuroinformatics.dev/latest/_static/switcher.json

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -150,9 +150,14 @@ html_theme_options = {
             "type": "fontawesome",
         },
     ],
+    "switcher": {
+        "json_url": "https://movement.neuroinformatics.dev/latest/_static/switcher.json",
+        "version_match": release,
+    },
     "logo": {
         "text": f"{project} v{release}",
     },
+    "navbar_end": ["version-switcher", "navbar-icon-links"],
     "footer_start": ["footer_start"],
     "footer_end": ["footer_end"],
     "external_links": [],


### PR DESCRIPTION
## Description

**What is this PR**
- [x] Addition of a new feature

**Why is this PR needed?**
This PR is the implementation for https://github.com/neuroinformatics-unit/actions/issues/91.
At present, our build_sphinx_docs and deploy_sphinx_docs actions only deploy a single version of the documentation (either from main or the latest release) to GitHub Pages. In brief:

build_sphinx_docs builds the Sphinx docs and uploads an artefact
deploy_sphinx_docs downloads the artefact and copies it to the root of the gh-pages branch
This means users and contributors cannot view older versions of the docs, except by checking out an old commit and building locally. Having access to documentation for previous releases would be extremely useful.

**What does this PR do?**
The PR adds the [version switcher ](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/version-dropdown.html)to the docs along with changing the document deployment step to the newly created [multiversion deploy step](https://github.com/neuroinformatics-unit/actions/pull/93). 

## References
A similar implementation is used in the [NeuroBlueprint](https://github.com/neuroinformatics-unit/NeuroBlueprint) repository [here](https://github.com/neuroinformatics-unit/NeuroBlueprint/blob/main/.github/workflows/docs_build_and_deploy.yml).
Please reference any existing issues/PRs that relate to this PR.

## How has this PR been tested?

A test implementation exists by forking [this repository](https://github.com/neuroinformatics-unit/sphinx-deployment-test) and making [changes](https://github.com/neuroinformatics-unit/sphinx-deployment-test/compare/main...animeshsasan:sphinx-deployment-test:main) to enable the multi-version switcher. You can see it in action [here](https://animeshsasan.github.io/sphinx-deployment-test/latest/index.html).


## Is this a breaking change?

The document deploy step is changing but no actual features are changed.

## Does this PR require an update to the documentation?
It requires updating the movement repository to create the multi-version dropdown but no actual documentation has changed.

## Checklist:

- [x] The code has been tested locally
- [ ] ~~Tests have been added to cover all new functionality~~(I don't think there are any tests for the docs)
- [ ] ~~The documentation has been updated to reflect any changes~~
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
