### PR TITLE
Feature/eks loader

### DIFF
--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -480,7 +480,7 @@ def from_eks_file(
         individual_names=individual_names,
         keypoint_names=keypoint_names,
         fps=fps,
-        source_software="EnsembleKalmanSmoother",
+        source_software="EKS",
     )
 
     # Group ensemble statistics by their type

--- a/tests/test_unit/test_io/test_load_poses.py
+++ b/tests/test_unit/test_io/test_load_poses.py
@@ -324,40 +324,47 @@ def test_load_from_eks_file():
     # otherwise skip the test
     try:
         from pathlib import Path
+
         file_path = Path("sub-460_strain-B6_2024-11-12T12_30_00_eks.csv")
         if not file_path.exists():
             pytest.skip("EKS example file not found")
-        
+
         # Load the EKS file
         ds = load_poses.from_eks_file(file_path, fps=30)
-        
+
         # Check that it's a valid dataset with the expected structure
         assert isinstance(ds, xr.Dataset)
         assert "position" in ds.data_vars
         assert "confidence" in ds.data_vars
-        
+
         # Check ensemble statistics are present
-        ensemble_vars = ['x_ens_median', 'y_ens_median', 'x_ens_var', 
-                        'y_ens_var', 'x_posterior_var', 'y_posterior_var']
+        ensemble_vars = [
+            "x_ens_median",
+            "y_ens_median",
+            "x_ens_var",
+            "y_ens_var",
+            "x_posterior_var",
+            "y_posterior_var",
+        ]
         for var in ensemble_vars:
             assert var in ds.data_vars
-        
+
         # Check dimensions
         assert "time" in ds.dims
         assert "individuals" in ds.dims
         assert "keypoints" in ds.dims
         assert "space" in ds.dims
-        
+
         # Check basic attributes
         assert ds.attrs["source_software"] == "EnsembleKalmanSmoother"
         assert ds.attrs["fps"] == 30
-        
+
         # Check shapes are consistent
         n_time, n_space, n_keypoints, n_individuals = ds.position.shape
         assert ds.confidence.shape == (n_time, n_keypoints, n_individuals)
         for var in ensemble_vars:
             assert ds[var].shape == (n_time, n_keypoints, n_individuals)
-            
+
     except ImportError:
         pytest.skip("Required dependencies for EKS loading not available")
 
@@ -366,16 +373,17 @@ def test_load_from_file_eks():
     """Test that loading EKS files via from_file() works correctly."""
     try:
         from pathlib import Path
+
         file_path = Path("sub-460_strain-B6_2024-11-12T12_30_00_eks.csv")
         if not file_path.exists():
             pytest.skip("EKS example file not found")
-        
+
         # Test loading via from_file
         ds = load_poses.from_file(file_path, source_software="EKS", fps=30)
-        
+
         # Should be identical to from_eks_file
         ds_direct = load_poses.from_eks_file(file_path, fps=30)
         xr.testing.assert_identical(ds, ds_direct)
-        
+
     except ImportError:
         pytest.skip("Required dependencies for EKS loading not available")

--- a/tests/test_unit/test_io/test_load_poses.py
+++ b/tests/test_unit/test_io/test_load_poses.py
@@ -325,7 +325,7 @@ def test_load_from_eks_file():
     try:
         from pathlib import Path
 
-        file_path = Path("sub-460_strain-B6_2024-11-12T12_30_00_eks.csv")
+        file_path = Path("eks_output.csv")
         if not file_path.exists():
             pytest.skip("EKS example file not found")
 
@@ -338,14 +338,7 @@ def test_load_from_eks_file():
         assert "confidence" in ds.data_vars
 
         # Check ensemble statistics are present
-        ensemble_vars = [
-            "x_ens_median",
-            "y_ens_median",
-            "x_ens_var",
-            "y_ens_var",
-            "x_posterior_var",
-            "y_posterior_var",
-        ]
+        ensemble_vars = ["ens_median", "ens_var", "posterior_var"]
         for var in ensemble_vars:
             assert var in ds.data_vars
 
@@ -363,7 +356,12 @@ def test_load_from_eks_file():
         n_time, n_space, n_keypoints, n_individuals = ds.position.shape
         assert ds.confidence.shape == (n_time, n_keypoints, n_individuals)
         for var in ensemble_vars:
-            assert ds[var].shape == (n_time, n_keypoints, n_individuals)
+            assert ds[var].shape == (
+                n_time,
+                n_space,
+                n_keypoints,
+                n_individuals,
+            )
 
     except ImportError:
         pytest.skip("Required dependencies for EKS loading not available")
@@ -374,7 +372,7 @@ def test_load_from_file_eks():
     try:
         from pathlib import Path
 
-        file_path = Path("sub-460_strain-B6_2024-11-12T12_30_00_eks.csv")
+        file_path = Path("eks_output.csv")
         if not file_path.exists():
             pytest.skip("EKS example file not found")
 

--- a/tests/test_unit/test_io/test_load_poses.py
+++ b/tests/test_unit/test_io/test_load_poses.py
@@ -314,3 +314,68 @@ def test_load_from_nwb_file(input_type, kwargs, request):
     if input_type == "nwb_file":
         expected_attrs["source_file"] = nwb_file
     assert ds_from_file_path.attrs == expected_attrs
+
+
+def test_load_from_eks_file():
+    """Test that loading pose tracks from an EKS CSV file
+    returns a proper Dataset with ensemble statistics.
+    """
+    # Use the provided example EKS file if available,
+    # otherwise skip the test
+    try:
+        from pathlib import Path
+        file_path = Path("sub-460_strain-B6_2024-11-12T12_30_00_eks.csv")
+        if not file_path.exists():
+            pytest.skip("EKS example file not found")
+        
+        # Load the EKS file
+        ds = load_poses.from_eks_file(file_path, fps=30)
+        
+        # Check that it's a valid dataset with the expected structure
+        assert isinstance(ds, xr.Dataset)
+        assert "position" in ds.data_vars
+        assert "confidence" in ds.data_vars
+        
+        # Check ensemble statistics are present
+        ensemble_vars = ['x_ens_median', 'y_ens_median', 'x_ens_var', 
+                        'y_ens_var', 'x_posterior_var', 'y_posterior_var']
+        for var in ensemble_vars:
+            assert var in ds.data_vars
+        
+        # Check dimensions
+        assert "time" in ds.dims
+        assert "individuals" in ds.dims
+        assert "keypoints" in ds.dims
+        assert "space" in ds.dims
+        
+        # Check basic attributes
+        assert ds.attrs["source_software"] == "EnsembleKalmanSmoother"
+        assert ds.attrs["fps"] == 30
+        
+        # Check shapes are consistent
+        n_time, n_space, n_keypoints, n_individuals = ds.position.shape
+        assert ds.confidence.shape == (n_time, n_keypoints, n_individuals)
+        for var in ensemble_vars:
+            assert ds[var].shape == (n_time, n_keypoints, n_individuals)
+            
+    except ImportError:
+        pytest.skip("Required dependencies for EKS loading not available")
+
+
+def test_load_from_file_eks():
+    """Test that loading EKS files via from_file() works correctly."""
+    try:
+        from pathlib import Path
+        file_path = Path("sub-460_strain-B6_2024-11-12T12_30_00_eks.csv")
+        if not file_path.exists():
+            pytest.skip("EKS example file not found")
+        
+        # Test loading via from_file
+        ds = load_poses.from_file(file_path, source_software="EKS", fps=30)
+        
+        # Should be identical to from_eks_file
+        ds_direct = load_poses.from_eks_file(file_path, fps=30)
+        xr.testing.assert_identical(ds, ds_direct)
+        
+    except ImportError:
+        pytest.skip("Required dependencies for EKS loading not available")

--- a/tests/test_unit/test_io/test_load_poses.py
+++ b/tests/test_unit/test_io/test_load_poses.py
@@ -320,15 +320,11 @@ def test_load_from_eks_file():
     """Test that loading pose tracks from an EKS CSV file
     returns a proper Dataset with ensemble statistics.
     """
-    # Use the provided example EKS file if available,
-    # otherwise skip the test
+    file_path = DATA_PATHS.get("EKS_IBL-paw_multicam_right.predictions.csv")
+    if file_path is None:
+        pytest.skip("EKS example file not found")
+
     try:
-        from pathlib import Path
-
-        file_path = Path("eks_output.csv")
-        if not file_path.exists():
-            pytest.skip("EKS example file not found")
-
         # Load the EKS file
         ds = load_poses.from_eks_file(file_path, fps=30)
 
@@ -349,7 +345,7 @@ def test_load_from_eks_file():
         assert "space" in ds.dims
 
         # Check basic attributes
-        assert ds.attrs["source_software"] == "EnsembleKalmanSmoother"
+        assert ds.attrs["source_software"] == "EKS"
         assert ds.attrs["fps"] == 30
 
         # Check shapes are consistent
@@ -369,13 +365,11 @@ def test_load_from_eks_file():
 
 def test_load_from_file_eks():
     """Test that loading EKS files via from_file() works correctly."""
+    file_path = DATA_PATHS.get("EKS_IBL-paw_multicam_right.predictions.csv")
+    if file_path is None:
+        pytest.skip("EKS example file not found")
+
     try:
-        from pathlib import Path
-
-        file_path = Path("eks_output.csv")
-        if not file_path.exists():
-            pytest.skip("EKS example file not found")
-
         # Test loading via from_file
         ds = load_poses.from_file(file_path, source_software="EKS", fps=30)
 


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
It allows loading the outputs of EKS (Ensemble Kalman Smoother) into movement.

**What does this PR do?**
It implements the loader similar to the other supported packages.

## References

Relevant discussion on Zulip: [#Movement > Importer for Ensemble Kalman Smoother](https://neuroinformatics.zulipchat.com/#narrow/channel/406001-Movement/topic/Importer.20for.20Ensemble.20Kalman.20Smoother)

## How has this PR been tested?

I tested it using an output file from my own data. It is referenced in the test file but of course is not part of movement. I am not sure what the best to do this would be. 

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

Would have to add the relevant parts to the input/output part in the codumentation

## Checklist:

- [ x] The code has been tested locally
- [ ?] Tests have been added to cover all new functionality (maybe? I am not sure)
- [ ] The documentation has been updated to reflect any changes
- [ x] The code has been formatted with [pre-commit](https://pre-commit.com/)
