### PR TITLE
Mention typical timing of community calls on website and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To help you get started, we have prepared a detailed [contributing guide](https:
 
 - [Chat with the team on Zulip](https://neuroinformatics.zulipchat.com/#narrow/stream/406001-Movement).
 - [Open an issue](https://github.com/neuroinformatics-unit/movement/issues) to report a bug or request a new feature.
-- [Follow this Zulip topic](https://neuroinformatics.zulipchat.com/#narrow/channel/406001-Movement/topic/Community.20Calls) to receive updates about upcoming Community Calls. These typically run every other Friday from 11:00 to 11:45 (Europe/London time).
+- [Follow this Zulip topic](https://neuroinformatics.zulipchat.com/#narrow/channel/406001-Movement/topic/Community.20Calls) to receive updates about upcoming Community Calls. These typically run every other Friday from 11:00 to 11:45 (London, U.K. time).
 
 ## Citation
 

--- a/docs/source/snippets/get-in-touch.md
+++ b/docs/source/snippets/get-in-touch.md
@@ -1,5 +1,5 @@
 :::{admonition} Get in touch
 - [Chat with the team on Zulip](movement-zulip:).
 - [Open an issue](https://github.com/neuroinformatics-unit/movement/issues) to report a bug or request a new feature.
-- [Follow this Zulip topic](movement-community-calls:) to receive updates about upcoming Community Calls. These typically run every other Friday from 11:00 to 11:45 (Europe/London time).
+- [Follow this Zulip topic](movement-community-calls:) to receive updates about upcoming Community Calls. These typically run every other Friday from 11:00 to 11:45 (London, U.K. time).
 :::


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other: docs

**Why is this PR needed?**
We encourage people to receive updates about Community Calls via Zulip, but we don't mentioned the typical day/time on which they happen. Having that info public would help people in quickly deciding if it's a time that would work for them.

**What does this PR do?**

Mentions the "typical" call timing on the website and in the README. This timing is quite fixed, but sometime we skip meetings (hence the "typical").

## References

N/A

## How has this PR been tested?

Local docs build.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

N/A

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
