### PR TITLE
fix bug: `from_dlc_style_df` can handle 3D DeepLabCut files

### DIFF
--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -206,8 +206,8 @@ def from_dlc_style_df(
     The "coords" level contains either:
     - the spatial coordinates "x", "y", "likelihood" (point-wise confidence scores)
     - the spatial coordinates "x", "y", "z",
-    The latter scenario applies when multiple DeepLabCut output files were 
-    triangulated to estimate 3D pose. 
+    The latter scenario applies when multiple DeepLabCut output files were
+    triangulated to estimate 3D pose.
     See further: https://deeplabcut.github.io/DeepLabCut/docs/Overviewof3D.html
     The row index corresponds to the frame number.
 
@@ -228,8 +228,6 @@ def from_dlc_style_df(
     )
     coord_names = df.columns.get_level_values("coords").unique().to_list()
 
-
-
     # Coords: ['x', 'y', 'z']
     if set(coord_names) == {"x", "y", "z"} and len(coord_names) == 3:
         tracks = (
@@ -244,7 +242,14 @@ def from_dlc_style_df(
     else:
         tracks_with_scores = (
             df.to_numpy()
-            .reshape((-1, len(individual_names), len(keypoint_names), len(coord_names)))
+            .reshape(
+                (
+                    -1,
+                    len(individual_names),
+                    len(keypoint_names),
+                    len(coord_names),
+                )
+            )
             .transpose(0, len(coord_names), 2, 1)
         )
         position_array = tracks_with_scores[:, :-1, :, :]


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/neuroinformatics-unit/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [x] Bug fix

**Why is this PR needed?**

The classic `.csv` and `.h5` DeepLabCut output files have the coords `x`, `y` and `likelihood` per keypoint/individual. One can triangulate two of these files into a 3D pose  `.csv` and `.h5` file. The structure is essentially the same, except that you have `x`, `y` and `z` (but no likelihood) per keypoint/individual combination. See further: https://deeplabcut.github.io/DeepLabCut/docs/Overviewof3D.html


<img width="1262" height="403" alt="image" src="https://github.com/user-attachments/assets/85fc631c-b54c-4963-bc97-86488b297c8e" />


**What does this PR do?**

I updated `movement.io.load_poses.from_dlc_style_df` to also handle DeepLabCut dataframes with  `x`, `y`, `z` coords. 

https://github.com/Akseli-Ilmanen/movement/blob/dadbf83a0af1996db44fdc767438a4817bb918da/movement/io/load_poses.py#L175-L260

## How has this PR been tested?


Download: 
[example_3d_DLC.csv](https://github.com/user-attachments/files/22119610/example_3d_DLC.csv)


```
from movement.io import load_poses

path = "example_3d_DLC.csv"

ds = load_poses.from_file(path, source_software="DeepLabCut", fps=200)
ds = load_poses.from_dlc_file(path)
ds

```

## Is this a breaking change?

It's a small change, therefore should not break any existing functionality.

## Does this PR require an update to the documentation?

Not really.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
