### PR TITLE
Update example to show usage of `to_via_tracks_file` from PR 580

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -190,6 +190,7 @@ linkcheck_ignore = [
     "https://pubs.acs.org/doi/*",  # Checking dois is forbidden here
     "https://opensource.org/license/bsd-3-clause/",  # to avoid odd 403 error
     "https://www.sainsburywellcome.org/",  # Occasional ConnectTimeoutError
+    "https://www.robots.ox.ac.uk/",  # occasional 404s
 ]
 
 

--- a/examples/load_and_upsample_bboxes.py
+++ b/examples/load_and_upsample_bboxes.py
@@ -20,7 +20,7 @@ from matplotlib import pyplot as plt
 
 from movement import sample_data
 from movement.filtering import interpolate_over_time
-from movement.io import load_bboxes
+from movement.io import load_bboxes, save_bboxes
 
 # %%
 # Load sample dataset
@@ -360,21 +360,25 @@ for frame_idx in range(6):
 fig.tight_layout()
 
 # %%
-# Export as .csv file
-# -------------------
+# Export as a VIA tracks .csv file
+# ---------------------------------
 # Let's assume the dataset with the forward filled values is the best suited
-# for our task - we can now export the computed values to a .csv file
-#
-# Note that currently we do not provide explicit methods to export a
-# ``movement`` bounding boxes dataset in a specific format. However, we can
-# save the bounding boxes’ trajectories to a .csv file using the
-# standard Python library :mod:`csv`.
+# for our task - we can now export the computed values to a VIA tracks .csv
+# file that is loadable in napari and the VIA annotation software.
+
+via_tracks_filepath = "tracking_output_via_tracks.csv"
+save_bboxes.to_via_tracks_file(ds_ff, via_tracks_filepath)
+
+# %%
+# Alternatively, we can save the bounding boxes’ trajectories to a
+# .csv file with a custom header using the standard Python library
+# :mod:`csv`.
 
 # define name for output csv file
-filepath = "tracking_output.csv"
+custom_csv_filepath = "tracking_output_custom.csv"
 
 # open the csv file in write mode
-with open(filepath, mode="w", newline="") as file:
+with open(custom_csv_filepath, mode="w", newline="") as file:
     writer = csv.writer(file)
 
     # write the header
@@ -392,6 +396,7 @@ with open(filepath, mode="w", newline="") as file:
 # %%
 # Clean-up
 # ----------------------
-# To remove the output file we have just created, we can run the following
+# To remove the output files we have just created, we can run the following
 # code.
-os.remove(filepath)
+os.remove(via_tracks_filepath)
+os.remove(custom_csv_filepath)

--- a/examples/load_and_upsample_bboxes.py
+++ b/examples/load_and_upsample_bboxes.py
@@ -363,8 +363,10 @@ fig.tight_layout()
 # Export as a VIA tracks .csv file
 # ---------------------------------
 # Let's assume the dataset with the forward filled values is the best suited
-# for our task - we can now export the computed values to a VIA tracks .csv
-# file that is loadable in napari and the VIA annotation software.
+# for our task. We can now export the computed values to a VIA tracks .csv
+# file that is loadable in the ``movement`` napari widget
+# and in the `VGG Image Annotator (VIA) <https://www.robots.ox.ac.uk/~vgg/software/via/>`_
+# software.
 
 via_tracks_filepath = "tracking_output_via_tracks.csv"
 save_bboxes.to_via_tracks_file(ds_ff, via_tracks_filepath)


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
The bounding boxes example mentions we do not have a function to export bounding boxes datasets, but after PR #580 we do.


**What does this PR do?**

It updates the bounding boxes example to use the `save_bboxes.to_via_tracks_file` function.

## References

#580 

## How has this PR been tested?

Tests pass locally and in CI

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

It is in itself.

## Checklist:

- [x] The code has been tested locally
- [ n/a ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
