### PR TITLE
Update links to SLEAP docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -211,6 +211,7 @@ myst_url_schemes = {
     "napari": "https://napari.org/dev/{{path}}",
     "setuptools-scm": "https://setuptools-scm.readthedocs.io/en/latest/{{path}}#{{fragment}}",
     "sleap": "https://sleap.ai/{{path}}#{{fragment}}",
+    "sleap-docs": "https://docs.sleap.ai/latest/{{path}}#{{fragment}}",
     "sphinx-doc": "https://www.sphinx-doc.org/en/master/usage/{{path}}#{{fragment}}",
     "sphinx-gallery": "https://sphinx-gallery.github.io/stable/{{path}}#{{fragment}}",
     "xarray": "https://docs.xarray.dev/en/stable/{{path}}#{{fragment}}",

--- a/docs/source/user_guide/input_output.md
+++ b/docs/source/user_guide/input_output.md
@@ -28,7 +28,7 @@ and can be loaded from and saved to various third-party formats.
 | Source Software                                                             | Abbreviation | Source Format                                                                              | Dataset Type         | Supported Operations |
 | --------------------------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------ | -------------------- | -------------------- |
 | [DeepLabCut](dlc:)                                                          | DLC          | DLC-style .h5 or .csv file, or corresponding pandas DataFrame                              | Pose                 | Load & Save          |
-| [SLEAP](sleap:)                                                             | SLEAP        | [analysis](sleap:tutorials/analysis) .h5 or .slp file                                      | Pose                 | Load & Save          |
+| [SLEAP](sleap:)                                                             | SLEAP        | [analysis](sleap-docs:learnings/export-analysis/) .h5 or .slp file                                      | Pose                 | Load & Save          |
 | [LightningPose](lp:)                                                        | LP           | DLC-style .csv file, or corresponding pandas DataFrame                                     | Pose                 | Load & Save          |
 | [Anipose](anipose:)                                                         |              | triangulation .csv file, or corresponding pandas DataFrame                                 | Pose                 | Load                 |
 | [VGG Image Annotator](via:)                                                 | VIA          | .csv file for [tracks annotation](via:docs/face_track_annotation.html)                     | Bounding box         | Load                 |
@@ -86,7 +86,7 @@ ds = load_poses.from_dlc_style_df(df, fps=30)
 :::
 
 :::{tab-item} SLEAP
-To load [SLEAP analysis files](sleap:tutorials/analysis) in .h5 format (recommended):
+To load [SLEAP analysis files](sleap-docs:learnings/export-analysis/) in .h5 format (recommended):
 
 ```python
 ds = load_poses.from_sleap_file("/path/to/file.analysis.h5", fps=30)
@@ -315,7 +315,7 @@ Other attributes and data variables
 (i.e., `instance_scores`, `tracking_scores`, `edge_names`, `edge_inds`, `video_path`,
 `video_ind`, and `provenance`) are not currently supported. To learn more about what
 each attribute and data variable represents, see the
-[SLEAP documentation](sleap:api/sleap.info.write_tracking_h5.html#module-sleap.info.write_tracking_h5).
+[SLEAP documentation](sleap-docs:api/info/write_tracking_h5/#sleap.info.write_tracking_h5).
 ::::
 
 ::::{tab-item} LightningPose

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -285,9 +285,9 @@ def from_sleap_file(
 
     References
     ----------
-    .. [1] https://sleap.ai/tutorials/analysis.html
+    .. [1] https://docs.sleap.ai/latest/learnings/export-analysis/
     .. [2] https://github.com/talmolab/sleap/blob/v1.3.3/sleap/info/write_tracking_h5.py#L59
-    .. [3] https://sleap.ai/guides/proofreading.html
+    .. [3] https://docs.sleap.ai/latest/how-to-guides/tracking-and-proofreading/
 
     Examples
     --------

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -291,7 +291,7 @@ def to_sleap_analysis_file(ds: xr.Dataset, file_path: str | Path) -> None:
 
     References
     ----------
-    .. [1] https://sleap.ai/api/sleap.info.write_tracking_h5.html
+    .. [1] https://docs.sleap.ai/latest/api/info/write_tracking_h5/#sleap.info.write_tracking_h5
 
     Examples
     --------


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

With [SLEAP v1.5](https://github.com/talmolab/sleap/releases/tag/v1.5.0) docs for older versions of SLEAP have migrated to http://legacy.sleap.ai/, while newer docs are at [docs.sleap.ai](https://docs.sleap.ai/). The [sleap.ai](https://sleap.ai/) URL is now a landing site for the whole project.

**What does this PR do?**

Updated the existing links to SLEAP and its docs. I search the repo for `sleap.ai` and `sleap:` to find the appropriate locations.

In the `myst_url_schemes` (in Sphinx's `conf.py`) we now have two SLEAP-related entries:
```python
    "sleap": "https://sleap.ai/{{path}}#{{fragment}}",
    "sleap-docs": "https://docs.sleap.ai/latest/{{path}}#{{fragment}}",
```

We can keep using the first one to point to the landing page (when referring to the whole SLEAP project), and the 2nd one for referring to specific places in the *new* SLEAP docs.

I've updated links to specific docs pages. In all cases I found an appropriate new docs page corresponding to an old one.
Therefore we don't need to link to any pages in the legacy docs (luckily).

## References

https://github.com/talmolab/sleap/releases/tag/v1.5.0

## How has this PR been tested?

Local docs build with linkcheck.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

N/A

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
