### PR TITLE
Update links to animovement

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Find out more on our [mission and scope](https://movement.neuroinformatics.dev/c
 
 > [!Tip]
 > If you prefer analysing your data in R, we recommend checking out the
-> [animovement](https://roald-arboel.com/animovement/) toolbox, which is similar in scope.
+> [animovement](https://animovement.dev/) toolbox, which is similar in scope.
 > We are working together with its developer
 > to gradually converge on common data standards and workflows.
 


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

The landing page for `animovement` changed to https://animovement.dev/, see [#Movement > animovement update](https://neuroinformatics.zulipchat.com/#narrow/channel/406001-Movement/topic/animovement.20update/with/545909973) on Zulip.

This caused linkcheck to error, because the earlier link is now broken.

**What does this PR do?**

Updates the link in the README. Note that the link in the docs is autogenerated from the one in the README, so the fix propagates to the docs as well.

## References

N/A

## How has this PR been tested?

Local docs build and CI docs buid.

> [!note]
> CI tests fail for an unrelated reason, and I'm tackling them separately in #685 

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
