### PR TITLE
Pin netcdf<1.7.3 to fix failing integration tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
   "pandas",
   "h5py",
   "netCDF4<1.7.3",
-  "tables",
   "attrs",
   "pooch",
   "tqdm",


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

`tests/test_integration/test_netcdf.py` raises in CI raises repeated errors of the form:

```
RuntimeError: NetCDF: HDF error
OSError: [Errno -101] NetCDF: HDF error: '/tmp/pytest-of-runner/pytest-0/test_ds_save_and_load_netcdf_hX/test_dataset.nc'
```

These are due to a failing `test_ds_save_and_load_netcdf` test, specifically when the `netcdf4` or the `h5netcdf` engines are used (`scipy` engine is fine). 

See example failing CI run [here](https://github.com/neuroinformatics-unit/movement/actions/runs/18655440060/job/53187744682?pr=684#step:5).

I'm unable to reproduce the test failures locally, and I suspect the CI is using a different xarray version than I have locally.

According to the [xarray release notes](https://docs.xarray.dev/en/stable/whats-new.html), they recently changed the default engine order in `v2025.09.01` and reverted it in [`v2025.10.1`](https://github.com/pydata/xarray/releases/tag/v2025.10.1), because it caused tons of issues. See references for some relevant issues/PRs.

**What does this PR do?**

Trying around various workarounds.

## References

- https://github.com/pydata/xarray/issues/10657
- https://github.com/pydata/xarray/pull/10817
- https://github.com/pydata/xarray/issues/10819

## How has this PR been tested?

CI and running `tox` locally.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
