### PR TITLE
Add workflow to check conda installation weekly

### DIFF
--- a/.github/workflows/conda_install_check.yml
+++ b/.github/workflows/conda_install_check.yml
@@ -24,7 +24,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: conda-incubator/setup-miniconda@v3
+      # pinning to a specific sha1 is recommended by this action's docs
+      - uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
         with:
           python-version: ${{ matrix.python-version }}
           auto-update-conda: true


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

We recommend conda-forge as one of our installation methods, but all of our CI infrastructure currently relies on installing `movement` via pip. 

This means that installing `movement` from conda-forge is never explicitly tested, except for when we make a new release. Sometimes months may pass between releases; if there is some problem with the conda installation (e.g. because of a dependency update), we won't hear it until a user reports it.

**What does this PR do?**

Adds a new GitHub workflow for checking conda installation, adapted from [`datashuttle`'s workflow](https://github.com/neuroinformatics-unit/datashuttle/blob/main/.github/workflows/conda_install_check.yml), which was added for similar reasons.

It has 3 deviations from the `datashuttle` workflow (other than adapting the OS + Python matrix):

- it can also be triggered manually (useful for diagnosing problems reported by users)
- it installs `movement` alongside `napari` and `pyqt`, as per our current [installation instructions](https://movement.neuroinformatics.dev/latest/user_guide/installation.html) for the GUI version of `movement`. 
- it pins the [setup-miniconda](https://github.com/conda-incubator/setup-miniconda/) action to a specific commit (corresponding to v3.2.0), as recommended by that action's docs. Apparently [dependabot can now deal with this](https://github.blog/changelog/2022-10-31-dependabot-now-updates-comments-in-github-actions-workflows-referencing-action-versions/), including updating the human-readable comment with the SemVer version.

## References

N/A

## How has this PR been tested?

Not sure how to test this other than manually triggering the workflow after merging this PR.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No,

## Checklist:

- [ ] ~The code has been tested locally~
- [ ] ~Tests have been added to cover all new functionality~
- [ ] ~The documentation has been updated to reflect any changes~
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
