### PR TITLE
Remove setup-miniconda action from test workflow

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -49,13 +49,6 @@ jobs:
             ~/.movement/*
           key: cached-test-data-${{ runner.os }}
           restore-keys: cached-test-data
-      - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v3
-        with:
-          python-version: ${{ matrix.python-version }}
-          auto-update-conda: true
-          channels: conda-forge,defaults
-          activate-environment: movement-env
       - uses: neuroinformatics-unit/actions/test@v2
         with:
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] CI cleanup

**Why is this PR needed?**

The `setup-miniconda` action was added to our test workflow back in #133, because it was needed for `tox-conda` to work properly.

As of #683 , we no longer use `tox-conda`, so there should be no more need for this action in `test_and_deploy.yml`.

Besides, we now run conda install steps in a separate workflow, see #701 and #703.

**What does this PR do?**

Remove the `setup-miniconda` actions from `test_and_deploy.yml`.

## References

#133
#683
#701
#703


## How has this PR been tested?

CI passes.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [ ] ~The code has been tested locally~
- [ ] ~Tests have been added to cover all new functionality~
- [ ] ~The documentation has been updated to reflect any changes~
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
