### PR TITLE
Update binder config for multi-version docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -114,6 +114,8 @@ sphinx_gallery_conf = {
         "branch": "gh-pages",
         "binderhub_url": "https://mybinder.org",
         "dependencies": ["environment.yml"],
+        "filepath_prefix": doc_version,   # point to the versioned docs build folder inside the `gh-pages` branch
+        "notebooks_dir": "notebooks",     # default, but explicit is nice
     },
     "reference_url": {"movement": None},
     "default_thumb_file": "source/_static/data_icon.png",  # default thumbnail image


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Links to open examples in Binder are broken, across all docs versions. See <https://movement.neuroinformatics.dev/latest/index.html>.

I noticed this now because I usually check the binder link after each release.
They were working fine after the last release (which included multi-version docs) so I thought there wouldn't be any problems, but I had overlooked something.

Last time I checked, I hadn't yet cleaned the old contents in the `gh-pages` root, so Binder was happily finding notebooks where it expected them. Now that I've done the cleaning, there are no notebooks in the root, just under the versioned subfolders.

This is obvious in retrospect. The binder links for an example have the following form:

```
https://mybinder.org/v2/gh/neuroinformatics-unit/movement/gh-pages?filepath=notebooks/examples/load_and_explore_poses.ipynb
```

That `filepath` is relative to the `gh-pages` root. By checking our [current `gh-pages` branch](https://github.com/neuroinformatics-unit/movement/tree/gh-pages), I realised that is no longer correct.

**What does this PR do?**

Modifies the Binder config to insert the correct version release name as a `filepath_prefix`. Also sets the `notebooks_dir` parameter for good measure.

From the [relevant Sphinx-gallery docs](https://sphinx-gallery.github.io/stable/configuration.html#generate-binder-links-for-gallery-notebooks-experimental):

> filepath_prefix (type: string | None, default: None)
A prefix to append to the filepath in the Binder links. You should use this if you will store your built documentation in a sub-folder of a repository, instead of in the root.
>
> notebooks_dir (type: string, default: notebooks)
The name of a folder where the built Jupyter notebooks will be copied. This ensures that all the notebooks are in one place (though they retain their folder hierarchy) in case you’d like users to browse multiple notebook examples in one ses

A nice benefit of this approach is that now we should get examples appropriate for each release version!

## References

I'm relatively confident this was caused by #668, and sub-sequently not caught in #700. The bug only revealed itself after I'd cleaned up old contents of the `gh-pages` branch.

## How has this PR been tested?

I built the docs locally and checked the Binder links it the `build/html/examples` files. They now have the form:

```
https://mybinder.org/v2/gh/neuroinformatics-unit/movement/gh-pages?filepath=dev/notebooks/examples/load_and_explore_poses.ipynb
```

which would be correct relative to the `gh-pages` root (this link loads correctly).
Not sure how else to test it other than merging this PR and checking the `dev` version of the website.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- ~[ ] Tests have been added to cover all new functionality~
- ~[ ] The documentation has been updated to reflect any changes~
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
