### PR TITLE
Remove Numpy upper pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dynamic = ["version"]
 license = { text = "BSD-3-Clause" }
 
 dependencies = [
-  "numpy>=2.0.0,<2.3.0",  # Upper pin is because of numba incompatibility
+  "numpy>=2.0.0",
   "pandas",
   "h5py",
   "netCDF4<1.7.3",


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other: dependency updates

**Why is this PR needed?**

Closes #639.

**What does this PR do?**

Remove the <2.3 restriction from NumPy dependency.
The conflict with Numba should be now resolved.

## References

- Numba issue: https://github.com/numba/numba/issues/10105
- Numba Fix: https://github.com/numba/numba/pull/10147

## How has this PR been tested?

CI will tell us if this works across OSes.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [ ] ~The code has been tested locally~
- [ ] ~Tests have been added to cover all new functionality~
- [ ] ~The documentation has been updated to reflect any changes~
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
