### PR TITLE
feat: support dynamic kwargs in loader widget

### DIFF
--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -154,6 +154,7 @@ def from_file(
     fps: float | None = None,
     use_frame_numbers_from_file: bool = False,
     frame_regexp: str = DEFAULT_FRAME_REGEXP,
+    **kwargs,
 ) -> xr.Dataset:
     """Create a ``movement`` bounding boxes dataset from a supported file.
 
@@ -189,6 +190,9 @@ def from_file(
         the filename as an integer number led by at least one zero, followed
         by the file extension. Only used if ``use_frame_numbers_from_file`` is
         True.
+    **kwargs : dict, optional
+        Additional keyword arguments to pass to the software-specific
+        loading functions (e.g. ``from_via_tracks_file``).
 
 
     Returns
@@ -225,6 +229,7 @@ def from_file(
             fps,
             use_frame_numbers_from_file=use_frame_numbers_from_file,
             frame_regexp=frame_regexp,
+            **kwargs,
         )
     else:
         raise logger.error(


### PR DESCRIPTION
## Description

### What is this PR
- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

### Why is this PR needed?
Previously, the napari loader widget was static and only exposed `file_path`, `source_software`, and `fps`. This prevented users from providing necessary extra arguments for specific file formats (e.g., `individual_name` for Anipose, or specific keys for NWB files). Additionally, the FPS input was active for NWB files, even though NWB files handle timing internally, which could lead to confusion.

### What does this PR do?
This PR upgrades the DataLoader widget to be dynamic and context-aware:

- **Dynamic UI**: The widget now listens to changes in the `source_software` dropdown.
  - **Anipose**: Shows an optional `individual_name` input field.
  - **NWB**: Shows optional `processing_module_key` and `pose_estimation_key` fields, and disables the FPS input (as per requirements).
  - **VIA-tracks**: Shows a checkbox for `use_frame_numbers` and a regex input field.
- **Backend Updates**: Updated `load_bboxes.from_file` to accept `**kwargs` and propagate them to the underlying loader functions, preventing crashes when these new UI arguments are passed.
- **Logic**: Implemented a visibility toggle mechanism (`_create_extra_input_widgets` and `_on_source_software_changed`) to ensure only relevant fields are shown to the user.

## References
Resolves #600

## How has this PR been tested?
I have tested the changes locally by running `movement launch` and verifying the UI behavior for different file types.

## Is this a breaking change?
No. The changes are additive. The default behavior for existing loaders is preserved, and the new arguments are optional.

## Does this PR require an update to the documentation?
I have updated the docstrings in `movement/io/load_bboxes.py` to document the new `**kwargs` parameter.

## Checklist:
- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes (Docstrings updated)
- [x] The code has been formatted with pre-commit