### PR TITLE
Add missing typed dependencies to mypy pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,11 @@ repos:
                 - types-attrs
                 - types-PyYAML
                 - types-requests
+                - numpy>=2.0.0
+                - xarray
+                - h5py
+                - types-tqdm
+                - shapely
     - repo: https://github.com/mgedmin/check-manifest
       rev: "0.51"
       hooks:


### PR DESCRIPTION
Fixes #723 by adding missing typed dependencies to the mypy pre-commit hook configuration.

## Problem
Currently, mypy passes in CI when run via `pre-commit run mypy -a`, but shows errors when run locally with `mypy .`. This inconsistency occurs because pre-commit runs mypy in an isolated virtualenv without the project's dependencies installed.

## Solution
Added the following typed dependencies to `additional_dependencies` in `.pre-commit-config.yaml`:
- `numpy>=2.0.0` - has built-in type stubs
- `xarray` - has built-in type stubs
- `h5py` - has type stubs
- `types-tqdm` - type stubs for tqdm
- `shapely` - has built-in type stubs

## Testing
This ensures mypy has access to type information for all typed dependencies used in the codebase, making local and CI mypy checks consistent.

## Checklist
- [x] Updated `.pre-commit-config.yaml` with missing dependencies
- [x] Verified changes align with project dependencies in `pyproject.toml`