### PR TITLE
Fix docstring examples to use save_bboxes instead of save_boxes

### DIFF
--- a/movement/io/save_bboxes.py
+++ b/movement/io/save_bboxes.py
@@ -71,15 +71,15 @@ def to_via_tracks_file(
     names and assuming the image files are PNG files. The frame numbers in the
     image filenames are padded with at least one leading zero by default:
 
-    >>> from movement.io import save_boxes
-    >>> save_boxes.to_via_tracks_file(ds, "/path/to/output.csv")
+    >>> from movement.io import save_bboxes
+    >>> save_bboxes.to_via_tracks_file(ds, "/path/to/output.csv")
 
     Export a ``movement`` bounding boxes dataset as a VIA tracks .csv file,
     assigning the track IDs sequentially based on the alphabetically sorted
     list of individuals' names, and assuming the image files are PNG files:
 
-    >>> from movement.io import save_boxes
-    >>> save_boxes.to_via_tracks_file(
+    >>> from movement.io import save_bboxes
+    >>> save_bboxes.to_via_tracks_file(
     ...     ds,
     ...     "/path/to/output.csv",
     ...     track_ids_from_trailing_numbers=False,
@@ -89,8 +89,8 @@ def to_via_tracks_file(
     deriving the track IDs from the numbers at the end of the individuals'
     names, and assuming the image files are JPG files:
 
-    >>> from movement.io import save_boxes
-    >>> save_boxes.to_via_tracks_file(
+    >>> from movement.io import save_bboxes
+    >>> save_bboxes.to_via_tracks_file(
     ...     ds,
     ...     "/path/to/output.csv",
     ...     image_file_suffix=".jpg",
@@ -101,8 +101,8 @@ def to_via_tracks_file(
     names and with image filenames following the format
     ``frame-<frame_number>.jpg``:
 
-    >>> from movement.io import save_boxes
-    >>> save_boxes.to_via_tracks_file(
+    >>> from movement.io import save_bboxes
+    >>> save_bboxes.to_via_tracks_file(
     ...     ds,
     ...     "/path/to/output.csv",
     ...     image_file_prefix="frame-",
@@ -114,8 +114,8 @@ def to_via_tracks_file(
     names, and with frame numbers in the image filenames represented using 4
     digits (i.e., image filenames would be ``0000.png``, ``0001.png``, etc.):
 
-    >>> from movement.io import save_boxes
-    >>> save_boxes.to_via_tracks_file(
+    >>> from movement.io import save_bboxes
+    >>> save_bboxes.to_via_tracks_file(
     ...     ds,
     ...     "/path/to/output.csv",
     ...     frame_n_digits=4,


### PR DESCRIPTION
## Description
Related to issue 

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
The docstring examples for to_via_tracks_file referenced save_boxes, which is not the correct public API.
The actual module is save_bboxes, so users following the documentation would run into confusion or import errors.
This PR fixes that inconsistency so the examples match the current API.

**What does this PR do?**

It updates the docstring examples in movement/io/save_bboxes.py to use save_bboxes instead of save_boxes.
There are no changes to the implementation or behavior — this is a documentation-only fix.

## References
Related issue: the documentation inconsistency reported for to_via_tracks_file using save_boxes instead of save_bboxes. #729 

## Is this a breaking change?
No.
This PR does not change any code paths or functionality. It only corrects documentation examples.

## Does this PR require an update to the documentation?
No additional documentation updates are required.
This PR is the documentation fix.


