### PR TITLE
fix(mypy): correct typing and None-handling in plots/trajectory

### DIFF
--- a/movement/plots/trajectory.py
+++ b/movement/plots/trajectory.py
@@ -1,6 +1,6 @@
 """Wrappers to plot movement data."""
 
-from typing import Optional, Tuple, Union, cast
+from typing import cast
 
 import xarray as xr
 from matplotlib import pyplot as plt


### PR DESCRIPTION
**What is this PR**
 Bug fix

**Why is this PR needed?**
Static type checkers (mypy / Pylance) reported several issues in
- movement.plots.trajectory, including:
- incorrect return type annotations (Figure vs Figure | SubFigure)
- unsafe access to optional attributes on matplotlib objects
- usage of type imports from matplotlib.pyplot that are not officially exported
These issues do not affect runtime behavior, but they cause CI failures and
make static analysis harder for contributors.

**What does this PR do?**
This PR fixes static typing issues in movement.plots.trajectory by:
- updating the function return type to correctly reflect Figure | SubFigure
- guarding access to optional colorbar attributes before calling .set(...)
- importing Figure and Axes from their canonical matplotlib modules
- keeping runtime behavior unchanged
The changes are intentionally scoped to a single file to keep the PR small and
reviewable. Other files affected by #723 will be addressed in follow-up PRs.

**References**
Partially addresses #723 (Uncaught mypy errors)

**How has this PR been tested?**
- Ran the existing unit tests for trajectory plotting:
       pytest tests/test_unit/test_plots/test_trajectory.py

- All tests pass locally
- Coverage for movement/plots/trajectory.py remains high (~95%)
- Verified that mypy movement/plots/trajectory.py --ignore-missing-imports
- reports no errors for this file

**Is this a breaking change?**
 No  
- This PR only affects type annotations and defensive checks.
- No public APIs or runtime behavior have changed.
     
**Does this PR require an update to the documentation?**
 No
- No user-facing behavior or APIs were modified.     

**Checklist**
-  The code has been tested locally