### PR TITLE
Fix `save_bboxes` import typos in docstring examples

### DIFF
--- a/movement/io/save_bboxes.py
+++ b/movement/io/save_bboxes.py
@@ -71,15 +71,15 @@ def to_via_tracks_file(
     names and assuming the image files are PNG files. The frame numbers in the
     image filenames are padded with at least one leading zero by default:
 
-    >>> from movement.io import save_boxes
-    >>> save_boxes.to_via_tracks_file(ds, "/path/to/output.csv")
+    >>> from movement.io import save_bboxes
+    >>> save_bboxes.to_via_tracks_file(ds, "/path/to/output.csv")
 
     Export a ``movement`` bounding boxes dataset as a VIA tracks .csv file,
     assigning the track IDs sequentially based on the alphabetically sorted
     list of individuals' names, and assuming the image files are PNG files:
 
-    >>> from movement.io import save_boxes
-    >>> save_boxes.to_via_tracks_file(
+    >>> from movement.io import save_bboxes
+    >>> save_bboxes.to_via_tracks_file(
     ...     ds,
     ...     "/path/to/output.csv",
     ...     track_ids_from_trailing_numbers=False,
@@ -89,8 +89,8 @@ def to_via_tracks_file(
     deriving the track IDs from the numbers at the end of the individuals'
     names, and assuming the image files are JPG files:
 
-    >>> from movement.io import save_boxes
-    >>> save_boxes.to_via_tracks_file(
+    >>> from movement.io import save_bboxes
+    >>> save_bboxes.to_via_tracks_file(
     ...     ds,
     ...     "/path/to/output.csv",
     ...     image_file_suffix=".jpg",
@@ -101,8 +101,8 @@ def to_via_tracks_file(
     names and with image filenames following the format
     ``frame-<frame_number>.jpg``:
 
-    >>> from movement.io import save_boxes
-    >>> save_boxes.to_via_tracks_file(
+    >>> from movement.io import save_bboxes
+    >>> save_bboxes.to_via_tracks_file(
     ...     ds,
     ...     "/path/to/output.csv",
     ...     image_file_prefix="frame-",
@@ -114,8 +114,8 @@ def to_via_tracks_file(
     names, and with frame numbers in the image filenames represented using 4
     digits (i.e., image filenames would be ``0000.png``, ``0001.png``, etc.):
 
-    >>> from movement.io import save_boxes
-    >>> save_boxes.to_via_tracks_file(
+    >>> from movement.io import save_bboxes
+    >>> save_bboxes.to_via_tracks_file(
     ...     ds,
     ...     "/path/to/output.csv",
     ...     frame_n_digits=4,


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

The docstring examples in the [to_via_tracks_file](cci:1://file:///d:/Agentic_AI/Gssoc_NLU/movement/movement/io/save_bboxes.py:16:0-155:20) function incorrectly use `save_boxes` instead of the correct module name `save_bboxes`. This causes confusion for users following the documentation examples.

**What does this PR do?**

Fixes 5 incorrect import statements in the docstring examples:
- `from movement.io import save_boxes` → `from movement.io import save_bboxes`
- `save_boxes.to_via_tracks_file(...)` → `save_bboxes.to_via_tracks_file(...)`

## References

Fixes #729

## How has this PR been tested?

- Verified that no occurrences of `save_boxes` remain in the file
- Pre-commit hooks passed (ruff, ruff format, mypy)
- This is a documentation-only change with no functional code modifications

## Is this a breaking change?

No. This PR only corrects typos in docstring examples.

## Does this PR require an update to the documentation?

No additional documentation updates required. This PR itself fixes the documentation.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)