### PR TITLE
Upper pin SciPy < 1.17.0

### DIFF
--- a/movement/cli_entrypoint.py
+++ b/movement/cli_entrypoint.py
@@ -7,6 +7,7 @@ import sys
 
 import numpy as np
 import pandas as pd
+import scipy as sp
 import xarray as xr
 
 import movement
@@ -71,6 +72,7 @@ def info() -> None:
         f"     movement: {movement.__version__}\n"
         f"     Python: {platform.python_version()}\n"
         f"     NumPy: {np.__version__}\n"
+        f"     SciPy: {sp.__version__}\n"
         f"     xarray: {xr.__version__}\n"
         f"     pandas: {pd.__version__}\n"
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ license = { text = "BSD-3-Clause" }
 dependencies = [
   "numpy>=2.0.0",
   "pandas",
+  "scipy<1.17.0",
   "h5py",
   "netCDF4<1.7.3",
   "tables>=3.10.1",


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

See #752.

I've confirmed that the issue was caused by the recent SciPy 1.17 releases.

Concretely, `pytest ./tests/test_integration/test_filtering.py` passes with `scipy=1.16.3` but fails with `scipy=1.17.0`.

**What does this PR do?**

- Temporarily upper-pins SciPy to < 1.17.0 (to unblock our own v0.13.0 release)
- Adds the SciPy version to the `movement info` output, for easier debugging

I will leave the issue open as a reminder to deal with it properly, and eventually remove the upper-pin.

## References

Related to #752

## How has this PR been tested?

All tests now pass locally.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- ~[ ] Tests have been added to cover all new functionality~
- ~[ ] The documentation has been updated to reflect any changes~
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
