### PR TITLE
Link to `stable` version of `napari` docs, instead of `dev`

### DIFF
--- a/docs/source/user_guide/installation.md
+++ b/docs/source/user_guide/installation.md
@@ -45,7 +45,7 @@ If you wish to use the GUI, which requires [napari](napari:), run instead:
 conda install -c conda-forge movement napari pyqt
 ```
 You may exchange `pyqt` for `pyside6` if you prefer a different Qt backend.
-See [napari's installation guide](napari:tutorials/fundamentals/installation_bundle_conda.html)
+See [napari's installation guide](napari:tutorials/fundamentals/installation.html)
 for more details on available backends.
 
 :::


### PR DESCRIPTION
## Description

### **What is this PR**
fixes : #751 

* [x] Bug fix
* [ ] Addition of a new feature
* [ ] Other

 
### **Why is this PR needed?**

 URL in the installation guide was outdated or broken, which could confuse users following the documentation and make setup harder than necessary.

 
### **What does this PR do?**

* Replaces broken/outdated URLs in `docs/source/user_guide/installation.md`
* Ensures all referenced links are valid and accessible

 

## References

* No related issues/PRs (documentation maintenance)

 
## How has this PR been tested?

* Manually verified that the updated links open correctly in the browser
* Confirmed no other documentation content or functionality was affected

 

## Is this a breaking change?

* No
  This PR only updates documentation links and does not affect any code or APIs.

 

## Does this PR require an update to the documentation?

* No additional updates required
  This PR itself is a documentation fix.

 

## Checklist:

* [x] The code has been tested locally
* [ ] Tests have been added to cover all new functionality (not applicable)
* [x] The documentation has been updated to reflect any changes
* [x] The code has been formatted with pre-commit (not applicable for docs-only changes)

BEFORE :
<img width="1919" height="867" alt="Screenshot 2026-01-13 120238" src="https://github.com/user-attachments/assets/f34d1f3c-978b-4128-b817-355300002952" />

AFTER : 
<img width="1917" height="969" alt="image" src="https://github.com/user-attachments/assets/8654bbb2-53c4-4bad-8893-e61f2918757e" />


 