### PR TITLE
Use `tox-uv` in test action

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -43,7 +43,7 @@ jobs:
             ~/.movement/*
           key: cached-test-data-${{ runner.os }}
           restore-keys: cached-test-data
-      - uses: neuroinformatics-unit/actions/test@tox-uv
+      - uses: neuroinformatics-unit/actions/test@main
         with:
           python-version: ${{ matrix.python-version }}
           secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

In this PR I experimented with using `tox-uv` for the "test" action of our CI, to see if it circumvents #762.
For context #762 is currently blocking all of our CI jobs.

**What does this PR do?**

- I first tested using the `tox-uv` branch of our `actions`,  introduced in https://github.com/neuroinformatics-unit/actions/pull/136.
- After confirming that it worked, and merging https://github.com/neuroinformatics-unit/actions/pull/136, I updated this PR to use `actions@main` as the source for the "test"action.

## References

- Closes https://github.com/neuroinformatics-unit/movement/issues/762
- https://github.com/neuroinformatics-unit/actions/pull/136

## How has this PR been tested?

The tests pass in CI.

> [!note]
> The failing "Build Sphinx Docs" action is due to #767, which is being addressed in a separate PR #768 

## Is this a breaking change?

No. 

## Does this PR require an update to the documentation?

No.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
