### PR TITLE
Restrict sphinx version to < 9

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ myst-parser
 nbsphinx
 pydata-sphinx-theme
 setuptools-scm
-sphinx
+sphinx<9
 sphinx-autodoc-typehints
 sphinx-design
 sphinx-gallery


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Closes #767, see issue for details.

**What does this PR do?**

Pins Sphinx to <9 in `docs/requirements.txt`. This is a temporary measure, until such time as `ablog` resolves its incompatibility with Sphinx v9. We can track the following `ablog` issue and PR:

- https://github.com/sunpy/ablog/issues/313
- https://github.com/sunpy/ablog/issues/314

## References

#767

## How has this PR been tested?

Local docs build +  "Build Sphinx Docs" action in CI.

> [!note]
> The test failure in this PR is due to #762, which is being resolved separately in #766.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- ~[ ] Tests have been added to cover all new functionality~
- ~[ ] The documentation has been updated to reflect any changes~
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
