### PR TITLE
Fix docstring Raises formatting in LineOfInterest.normal

### DIFF
--- a/movement/roi/line.py
+++ b/movement/roi/line.py
@@ -121,7 +121,8 @@ class LineOfInterest(BaseRegionOfInterest[LineLike]):
 
         Raises
         ------
-        ValueError : When the normal is requested for a multi-segment geometry.
+        ValueError
+            When the normal is requested for a multi-segment geometry.
 
         """
         # A multi-segment geometry always has at least 3 coordinates.


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
- The ```Raises``` section in the ```LineOfInterest.normal``` docstring was incorrectly formatted.

**What does this PR do?**
- Fixes the formatting of the ```Raises``` section in the ```LineOfInterest.normal``` docstring.

## References
- Fixes #770 

## How has this PR been tested?
- This is a documentation-only change and was reviewed manually.

## Is this a breaking change?
- No.

## Does this PR require an update to the documentation?
- No additional documentation updates are required.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
