### PR TITLE
Hide _factorized properties from Points layer tooltips

### DIFF
--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -333,11 +333,17 @@ class DataLoader(QWidget):
             properties_df=self.properties,
         )
 
+        # Filter out columns ending in _factorized (used internally for
+        # Tracks/Shapes coloring but not needed in Points layer tooltips)
+        points_properties = self.properties.loc[
+            :, ~self.properties.columns.str.endswith("_factorized")
+        ]
+
         # Add data as a points layer with metadata
         # (max_frame_idx is used to set the frame slider range)
         self.points_layer = self.viewer.add_points(
             self.data[self.data_not_nan, 1:],
-            properties=self.properties.iloc[self.data_not_nan, :],
+            properties=points_properties.iloc[self.data_not_nan, :],
             metadata={"max_frame_idx": max(self.data[:, 1])},
             **points_style.as_kwargs(),
         )

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -853,6 +853,16 @@ def test_add_points_and_tracks_layer_style(
     if source_software == "VIA-tracks":
         bboxes_layer = viewer.layers[2]
 
+    # Check that _factorized columns are excluded from Points layer properties
+    # (these are internal and should not appear in tooltips)
+    points_props_cols = list(points_layer.properties.keys())
+    assert not any(col.endswith("_factorized") for col in points_props_cols)
+
+    # Check that _factorized column is present in Tracks layer properties
+    # (needed for coloring)
+    tracks_props_cols = list(tracks_layer.properties.keys())
+    assert any(col.endswith("_factorized") for col in tracks_props_cols)
+
     # Check the text follows the expected property
     assert points_layer.text.string.feature == expected_text_property
     if source_software == "VIA-tracks":


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other: UX improvement

**Why is this PR needed?**

When hovering over keypoints in a Points layer, properties like "individual_factorized" and "keypoint_factorized" appear in the tooltip.

This can be confusing for users, who probably have no idea what "factorized" even means in this context. Moreover, the information is superfluous, as the "individual" and "keypoint" properties are already shown.

These "factorized" properties are created by us during loading, because they are necessary for color assignment in Tracks and Shapes layers. They are not needed in the Points layer, and they were not shown in old versions of `movement`.

The current behaviour was likely inadvertently introduced while refactoring the loader widget to share properties across layer types.

**What does this PR do?**

Filters out columns ending in `_factorized` when passing properties to the Points layer specifically.

It also updates the link to the Aeon habitat (a failing linkcheck alerted me to this).

## References

N/A

## How has this PR been tested?

Existing tests have been updated to verify that the modification applies to Points but not Tracks layers.

I've also verified that the "factorized" properties no longer appear in `napari`.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No. The [GUI guide](https://movement.neuroinformatics.dev/latest/user_guide/gui.html) is correct, as it was created before the "bug" was introduced.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- ~[ ] The documentation has been updated to reflect any changes~
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
