### PR TITLE
Fix broken 404 page

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -270,8 +270,6 @@ notfound_context = {
 """,
 }
 
-# needed for GH pages (vs readthedocs),
-# because we have no '/<language>/<version>/' in the URL
-# and GH Pages only supports a single root-level 404.html.
-# We therefore serve the 404 page from the latest (stable) docs version
+# Static files live in /<version>/_static/, but GH pages expects a single
+# 404.html at root, so use latest version for all static asset URLs in 404 page
 notfound_urls_prefix = "/latest/"


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
- Versioned documentation URLs were not resolving to the custom 404 page, resulting in broken 404 behavior.

**What does this PR do?**
- Fixes the ```notfound-page``` configuration by setting ```notfound_urls_prefix``` to the correct value for gh-pages.

## References
- Fixes #784 

## How has this PR been tested?
- Built the docs locally using ```make html``` and verified that the custom ```404.html``` page is generated.

## Is this a breaking change?
- No.

## Does this PR require an update to the documentation?
- No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
