### PR TITLE
Add the get_transform functionality to the base ROI

### DIFF
--- a/movement/roi/line.py
+++ b/movement/roi/line.py
@@ -1,5 +1,7 @@
 """1-dimensional lines of interest."""
 
+from typing import Self
+
 import numpy as np
 import shapely
 import xarray as xr
@@ -179,3 +181,7 @@ class LineOfInterest(BaseRegionOfInterest[LineLike]):
             ),
             in_degrees=in_degrees,
         )
+
+    def get_transform(self, other: Self) -> np.ndarray:
+        """Throw error for transformation matrix for lines."""
+        raise NotImplementedError("Homography is undefined for LineOfInterest")

--- a/tests/test_unit/test_roi/test_transform.py
+++ b/tests/test_unit/test_roi/test_transform.py
@@ -1,0 +1,93 @@
+import numpy as np
+import pytest
+
+from movement.roi.line import LineOfInterest
+from movement.roi.polygon import PolygonOfInterest
+from movement.transforms import compute_homography_transform
+
+
+@pytest.mark.parametrize(
+    ["coords_a", "coords_b"],
+    [
+        pytest.param(
+            np.array([[1, 1], [5, 1], [5, 3], [1, 3]], dtype=np.float32),
+            np.array([[1, 1], [5, 1], [5, 3], [1, 3]], dtype=np.float32),
+            id="Identical rectangles (identity transform)",
+        ),
+        pytest.param(
+            np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=np.float32),
+            np.array(
+                [
+                    [3, -1],
+                    [4.73205081, 0],
+                    [3.98205081, 1.29903811],
+                    [2.25, 0.2990381],
+                ],
+                dtype=np.float32,
+            ),
+            id="Rotated and scaled square",
+        ),
+    ],
+)
+def test_get_transform_happy_path(
+    coords_a: np.ndarray,
+    coords_b: np.ndarray,
+) -> None:
+    roi_a = PolygonOfInterest(coords_a)
+    roi_b = PolygonOfInterest(coords_b)
+
+    expected_transform = compute_homography_transform(coords_a, coords_b)
+
+    computed_transform = roi_a.get_transform(roi_b)
+
+    assert computed_transform.shape == (3, 3)
+    assert np.allclose(computed_transform, expected_transform, atol=1e-6)
+
+
+@pytest.mark.parametrize(
+    ["coords_a", "coords_b"],
+    [
+        pytest.param(
+            np.array([[0, 0], [1, 0], [1, 1]], dtype=np.float32),
+            np.array(
+                [[0, 0], [1, 0], [2, 0.5], [1, 1], [0, 1]], dtype=np.float32
+            ),
+            id="Triangle vs Pentagon",
+        ),
+        pytest.param(
+            np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=np.float32),
+            np.array([[0, 0], [1, 0], [1, 1]], dtype=np.float32),
+            id="Quad vs triangle",
+        ),
+    ],
+)
+def test_get_transform_mismatched_points_raises(
+    coords_a: np.ndarray,
+    coords_b: np.ndarray,
+) -> None:
+    roi_a = PolygonOfInterest(coords_a)
+    roi_b = PolygonOfInterest(coords_b)
+
+    with pytest.raises(ValueError):
+        roi_a.get_transform(roi_b)
+
+
+@pytest.mark.parametrize(
+    ["coords_a", "coords_b"],
+    [
+        pytest.param(
+            np.array([[0, 0], [1, 1]], dtype=np.float32),
+            np.array([[0, 0], [1, 2]], dtype=np.float32),
+            id="2 lines",
+        )
+    ],
+)
+def test_line_of_interest_raises(
+    coords_a: np.ndarray,
+    coords_b: np.ndarray,
+):
+    line_1 = LineOfInterest(points=coords_a)
+    line_2 = LineOfInterest(points=coords_b)
+
+    with pytest.raises(NotImplementedError):
+        line_1.get_transform(line_2)


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
In multi-session or multi-video experiments of the same setup, small shifts in the camera or setup can cause coordinate systems to differ between sessions. This prevents direct comparison or aggregation of tracked positional data across sessions. Even minor changes in angle, distance, or tilt can introduce perspective distortions that make one-to-one point correspondence unreliable without geometric alignment.

**What does this PR do?**
This PR uses the functionality added in [PR-696](https://github.com/neuroinformatics-unit/movement/pull/696) to create transformations between the sessions for the RegionOfInterest (RoI) class.

## References
https://github.com/neuroinformatics-unit/movement/issues/565
https://github.com/neuroinformatics-unit/movement/pull/696

## How has this PR been tested?
This code was tested using multiple dummy problems in local. Some of the toy problems are also available in the unit tests.

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
Yes. Documentation for the functions have been added.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
