### PR TITLE
Add Filter trajectories

### DIFF
--- a/movement/filtering.py
+++ b/movement/filtering.py
@@ -356,9 +356,7 @@ def filter_short_trajectories(
 
     if "individuals" not in data.dims:
         raise logger.error(
-            ValueError(
-                "Dataset must have an 'individuals' dimension."
-            )
+            ValueError("Dataset must have an 'individuals' dimension.")
         )
 
     position = data.position

--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -424,7 +424,8 @@ class TestFilterShortTrajectories:
         )
 
     @pytest.mark.parametrize(
-        "bad_value", [-1, 0, 10.5, "abc"],
+        "bad_value",
+        [-1, 0, 10.5, "abc"],
     )
     def test_invalid_min_valid_frames(
         self, poses_dataset_varied_lengths, bad_value
@@ -438,9 +439,11 @@ class TestFilterShortTrajectories:
     def test_no_individuals_dimension(self):
         """Dataset without individuals dimension should raise ValueError."""
         ds = xr.Dataset(
-            {"position": xr.DataArray(
-                np.random.rand(10, 2), dims=("time", "space")
-            )},
+            {
+                "position": xr.DataArray(
+                    np.random.rand(10, 2), dims=("time", "space")
+                )
+            },
         )
         with pytest.raises(ValueError, match="individuals"):
             filter_short_trajectories(ds, min_valid_frames=5)
@@ -466,11 +469,13 @@ class TestFilterShortTrajectories:
     def test_single_individual_dataset(self):
         """Dataset with only 1 individual should work correctly."""
         ds = xr.Dataset(
-            {"position": xr.DataArray(
-                np.random.rand(10, 2, 1),
-                dims=("time", "space", "individuals"),
-                coords={"individuals": ["solo"]},
-            )},
+            {
+                "position": xr.DataArray(
+                    np.random.rand(10, 2, 1),
+                    dims=("time", "space", "individuals"),
+                    coords={"individuals": ["solo"]},
+                )
+            },
         )
         result = filter_short_trajectories(ds, min_valid_frames=5)
         assert len(result.individuals) == 1
@@ -480,11 +485,13 @@ class TestFilterShortTrajectories:
         position = np.random.rand(10, 2, 2)
         position[:, :, 1] = np.nan
         ds = xr.Dataset(
-            {"position": xr.DataArray(
-                position,
-                dims=("time", "space", "individuals"),
-                coords={"individuals": ["valid", "empty"]},
-            )},
+            {
+                "position": xr.DataArray(
+                    position,
+                    dims=("time", "space", "individuals"),
+                    coords={"individuals": ["valid", "empty"]},
+                )
+            },
         )
         result = filter_short_trajectories(ds, min_valid_frames=1)
         assert len(result.individuals) == 1

--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -438,10 +438,11 @@ class TestFilterShortTrajectories:
 
     def test_no_individuals_dimension(self):
         """Dataset without individuals dimension should raise ValueError."""
+        rng = np.random.default_rng(42)
         ds = xr.Dataset(
             {
                 "position": xr.DataArray(
-                    np.random.rand(10, 2), dims=("time", "space")
+                    rng.random((10, 2)), dims=("time", "space")
                 )
             },
         )
@@ -468,10 +469,11 @@ class TestFilterShortTrajectories:
 
     def test_single_individual_dataset(self):
         """Dataset with only 1 individual should work correctly."""
+        rng = np.random.default_rng(42)
         ds = xr.Dataset(
             {
                 "position": xr.DataArray(
-                    np.random.rand(10, 2, 1),
+                    rng.random((10, 2, 1)),
                     dims=("time", "space", "individuals"),
                     coords={"individuals": ["solo"]},
                 )
@@ -482,7 +484,8 @@ class TestFilterShortTrajectories:
 
     def test_all_nan_individual(self):
         """Individual with all NaN frames should be filtered."""
-        position = np.random.rand(10, 2, 2)
+        rng = np.random.default_rng(42)
+        position = rng.random((10, 2, 2))
         position[:, :, 1] = np.nan
         ds = xr.Dataset(
             {


### PR DESCRIPTION
## Description

**What is this PR**
- [x] Addition of a new feature

**Why is this PR needed?**

Tracking data often contains spurious short trajectories that are likely tracking errors. Currently, users need to manually write complex xarray selection code to filter these out. This PR adds a convenient utility function to streamline this common preprocessing task.

**What does this PR do?**

Adds `filter_short_trajectories()` function to `movement.filtering` module that:
- Filters out individuals with fewer than a specified number of valid frames
- Works at the Dataset level (filtering across all data variables)
- Supports both poses and bounding boxes datasets
- Includes optional `print_report` parameter to show which individuals were filtered
- Follows existing filtering function patterns (consistent error handling with `logger.error`)

## References

Closes #791

## How has this PR been tested?

- Added comprehensive unit tests in `tests/test_unit/test_filtering.py` covering:
  - Basic filtering for both poses and bboxes datasets
  - Edge cases (no individuals removed, all individuals removed, exact threshold)
  - Input validation (negative, zero, float, invalid types)
  - Missing `individuals` dimension
  - Attribute and coordinate preservation
  - Print report functionality
- All existing tests pass
- Tested manually with sample datasets to verify expected behavior

## Is this a breaking change?

No. This is a new function with no changes to existing functionality.

## Does this PR require an update to the documentation?

The function includes a comprehensive docstring with examples. The function will automatically appear in the API reference documentation when built. No additional documentation updates needed at this time, though a usage example could be added to the user guide in a future PR if desired.

## Checklist:
- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)