### PR TITLE
Added link to FOSDEM 2026 talk

### DIFF
--- a/docs/source/community/resources.md
+++ b/docs/source/community/resources.md
@@ -82,6 +82,7 @@ A selection of talks, posters, and blogposts about `movement`.
 
 | Type | Venue | Date | Link |
 |-------|-------|------|------|
+| Talk  | [FOSDEM 2026](https://fosdem.org/2026/schedule/) | Jan 2026 | [Video on fosdem.org](https://fosdem.org/2026/schedule/event/9VLSXV-movement-tracks-python/) |
 | Talk  | [CBIAS 2025](https://www.crick.ac.uk/whats-on/crick-bioimage-analysis-symposium-2025) | Nov 2025 | [Slides](https://neuroinformatics.dev/slides-movement-cbias2025/) |
 | Blogpost  | [UCL-ARC Showcase](https://www.ucl.ac.uk/advanced-research-computing/arc-showcase) | May 2025 | [URL](https://www.ucl.ac.uk/advanced-research-computing/case-studies/2025/may/movement-python-package-simplifies-analysis-animals-motion) |
 | Poster  | [ASAB Spring 2025](https://asabspring2025.github.io) | Apr 2025 | [PDF on Zenodo](https://doi.org/10.5281/zenodo.17924159) |


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other: update docs

**Why is this PR needed?**

We now keep a track record of `movement` related resources, including talks.

**What does this PR do?**

Adds my recent talk at FOSDEM 2026 to Community Resources. I've chosen to link the relevant FOSDEM page, which contains an abstract, the video recording and a link to the slides. 

The slides themsleves are not much different compared to CBIAS2025, but I think it's useful to also have a recently recorded talk.

## References

N/A

## How has this PR been tested?

Local docs build.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

N/A

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
