### PR TITLE
Authenticate with GitHub token during linkcheck

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -46,6 +46,7 @@ jobs:
           fetch-tags: true
           use-artifactci: lazy
           use-requirements-txt: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   deploy_sphinx_docs:
     name: Deploy Sphinx Docs

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -215,6 +215,12 @@ linkcheck_ignore = [
     "https://zenodo.org/records/*",
     "https://doi.org/10.5281/zenodo.*",
 ]
+# Add request headers for specific domains (e.g. to avoid rate-limiting)
+linkcheck_request_headers = {
+    "https://github.com": {
+        "Authorization": f"Bearer {os.environ.get('GITHUB_TOKEN', '')}",
+    },
+}
 
 
 myst_url_schemes = {


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other: speed up CI

**Why is this PR needed?**

We have lots of links to GitHub, and we want to avoid being rate-limited during linkcheck runs in CI (which manifests as "rate limited - sleeping..." ins linkcheck jobs).

**What does this PR do?**
Passes a GitHub token to the build_sphinx_docs action (feature added in https://github.com/neuroinformatics-unit/actions/pull/138) and configures linkcheck to authenticate with GitHub.

## References

- Uses https://github.com/neuroinformatics-unit/actions/pull/138
- Tested in https://github.com/neuroinformatics-unit/neuroinformatics-unit.github.io/pull/242

## How has this PR been tested?

https://github.com/neuroinformatics-unit/neuroinformatics-unit.github.io/pull/242

## Is this a breaking change?

No. The only expected change is an occasional speedup of the `build_sphinx_docs` action.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)