### PR TITLE
Fix links to SLEAP analysis h5 docs

### DIFF
--- a/docs/source/user_guide/input_output.md
+++ b/docs/source/user_guide/input_output.md
@@ -28,7 +28,7 @@ and can be loaded from and saved to various third-party formats.
 | Source Software                                                             | Abbreviation | Source Format                                                                              | Dataset Type         | Supported Operations |
 | --------------------------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------ | -------------------- | -------------------- |
 | [DeepLabCut](dlc:)                                                          | DLC          | DLC-style .h5 or .csv file, or corresponding pandas DataFrame                              | Pose                 | Load & Save          |
-| [SLEAP](sleap:)                                                             | SLEAP        | [analysis](sleap-docs:learnings/export-analysis/) .h5 or .slp file                                      | Pose                 | Load & Save          |
+| [SLEAP](sleap:)                                                             | SLEAP        | [analysis](sleap-docs:tutorial/exporting-the-results/#analysis-hdf5) .h5 or .slp file                                      | Pose                 | Load & Save          |
 | [LightningPose](lp:)                                                        | LP           | DLC-style .csv file, or corresponding pandas DataFrame                                     | Pose                 | Load & Save          |
 | [Anipose](anipose:)                                                         |              | triangulation .csv file, or corresponding pandas DataFrame                                 | Pose                 | Load                 |
 | [VGG Image Annotator](via:)                                                 | VIA          | .csv file for [tracks annotation](via:docs/face_track_annotation.html)                     | Bounding box         | Load                 |
@@ -90,7 +90,7 @@ In `movement`, pose data can only be loaded if all individuals have the same set
 
 
 :::{tab-item} SLEAP
-To load [SLEAP analysis files](sleap-docs:learnings/export-analysis/) in .h5 format (recommended):
+To load [SLEAP analysis files](sleap-docs:tutorial/exporting-the-results/#analysis-hdf5) in .h5 format (recommended):
 
 ```python
 ds = load_poses.from_sleap_file("/path/to/file.analysis.h5", fps=30)

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -302,7 +302,7 @@ def from_sleap_file(
 
     References
     ----------
-    .. [1] https://docs.sleap.ai/latest/learnings/export-analysis/
+    .. [1] https://docs.sleap.ai/latest/tutorial/exporting-the-results/#analysis-hdf5
     .. [2] https://github.com/talmolab/sleap/blob/v1.3.3/sleap/info/write_tracking_h5.py#L59
     .. [3] https://docs.sleap.ai/latest/guides/tracking-and-proofreading/
 


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

The links to the SLEAP docs about analysis h5 files are broken. This is due to a restructure of SLEAP docs by a recent release. See an example of a [failing CI job](https://github.com/neuroinformatics-unit/movement/actions/runs/21778608835/job/62839162556?pr=805).

**What does this PR do?**

Fixes 3 occurrences of the broken link, by pointing it to the new location in SLEAP docs.

## References

N/A

## How has this PR been tested?

Running linkcheck locally and in CI.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

N/A

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
