### PR TITLE
Unpin sphinx and pin ablog>=0.11.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,12 +81,12 @@ dev = [
 ]
 docs = [
   "movement[napari]",
-  "ablog",
+  "ablog>=0.11.13",
   "linkify-it-py",
   "myst-parser",
   "nbsphinx",
   "pydata-sphinx-theme",
-  "sphinx<9",
+  "sphinx",
   "sphinx-autodoc-typehints",
   "sphinx-design",
   "sphinx-gallery",


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other: dependencies.

**Why is this PR needed?**

`ablog` is now compatible with Sphinx  v9, meaning we can update our pins in 'docs' dependencies.
See https://github.com/neuroinformatics-unit/neuroinformatics-unit.github.io/pull/226 and https://github.com/neuroinformatics-unit/neuroinformatics-unit.github.io/pull/244 for a full explanation.

**What does this PR do?**

Unpins sphinx and instead constrains `ablog` to versions equal or above v0.11.13.

## References

https://github.com/neuroinformatics-unit/neuroinformatics-unit.github.io/pull/226
https://github.com/neuroinformatics-unit/neuroinformatics-unit.github.io/pull/244

## How has this PR been tested?

Local documentation build in a fresh `uv venv`.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

N/A

## Checklist:

- [x] The code has been tested locally
- ~[ ] Tests have been added to cover all new functionality~
- ~[ ] The documentation has been updated to reflect any changes~
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
