### PR TITLE
Enable overwrite‑by‑default file saves with optional `overwrite=False`

### DIFF
--- a/movement/io/save_bboxes.py
+++ b/movement/io/save_bboxes.py
@@ -25,6 +25,7 @@ def to_via_tracks_file(
     frame_n_digits: int | None = None,
     image_file_prefix: str | None = None,
     image_file_suffix: str = ".png",
+    overwrite: bool = False,
 ) -> Path:
     """Save a ``movement`` bounding boxes dataset to a VIA tracks .csv file.
 
@@ -51,6 +52,9 @@ def to_via_tracks_file(
     image_file_suffix : str, optional
         Suffix to add to every image filename holding the file extension.
         Strings with or without the dot are accepted. Default is '.png'.
+    overwrite : bool, optional
+        If True, overwrite the file if it already exists.
+        If False (default), raise ``FileExistsError``.
 
     Returns
     -------
@@ -127,7 +131,9 @@ def to_via_tracks_file(
 
     """
     # Validate file path and dataset
-    file = _validate_file_path(file_path, expected_suffix=[".csv"])
+    file = _validate_file_path(
+        file_path, expected_suffix=[".csv"], overwrite=overwrite
+    )
     ValidBboxesInputs.validate(ds)
 
     # Check the number of digits required to represent the frame numbers

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -165,6 +165,7 @@ def to_dlc_file(
     ds: xr.Dataset,
     file_path: str | Path,
     split_individuals: bool | Literal["auto"] = "auto",
+    overwrite: bool = False,
 ) -> None:
     """Save a ``movement`` dataset to DeepLabCut file(s).
 
@@ -179,6 +180,9 @@ def to_dlc_file(
     split_individuals : bool or "auto", optional
         Whether to save individuals to separate files or to the same file
         (see Notes). Defaults to "auto".
+    overwrite : bool, optional
+        If True, overwrite the file if it already exists.
+        If False (default), raise ``FileExistsError``.
 
     Notes
     -----
@@ -203,7 +207,9 @@ def to_dlc_file(
     >>> save_poses.to_dlc_file(ds, "/path/to/file_dlc.h5")
 
     """  # noqa: D301
-    file = _validate_file_path(file_path, expected_suffix=[".csv", ".h5"])
+    file = _validate_file_path(
+        file_path, expected_suffix=[".csv", ".h5"], overwrite=overwrite
+    )
 
     # Sets default behaviour for the function
     if split_individuals == "auto":
@@ -238,6 +244,7 @@ def to_dlc_file(
 def to_lp_file(
     ds: xr.Dataset,
     file_path: str | Path,
+    overwrite: bool = False,
 ) -> None:
     """Save a ``movement`` dataset to a LightningPose file.
 
@@ -248,6 +255,9 @@ def to_lp_file(
         and associated metadata.
     file_path : pathlib.Path or str
         Path to the file to save the poses to. File extension must be .csv.
+    overwrite : bool, optional
+        If True, overwrite the file if it already exists.
+        If False (default), raise ``FileExistsError``.
 
     Notes
     -----
@@ -264,12 +274,16 @@ def to_lp_file(
     to_dlc_file : Save dataset to a DeepLabCut-style .h5 or .csv file.
 
     """
-    file = _validate_file_path(file_path=file_path, expected_suffix=[".csv"])
+    file = _validate_file_path(
+        file_path=file_path, expected_suffix=[".csv"], overwrite=overwrite
+    )
     ValidPosesInputs.validate(ds)
-    to_dlc_file(ds, file.path, split_individuals=True)
+    to_dlc_file(ds, file.path, split_individuals=True, overwrite=overwrite)
 
 
-def to_sleap_analysis_file(ds: xr.Dataset, file_path: str | Path) -> None:
+def to_sleap_analysis_file(
+    ds: xr.Dataset, file_path: str | Path, overwrite: bool = False
+) -> None:
     """Save a ``movement`` dataset to a SLEAP analysis file.
 
     Parameters
@@ -279,6 +293,9 @@ def to_sleap_analysis_file(ds: xr.Dataset, file_path: str | Path) -> None:
         and associated metadata.
     file_path : pathlib.Path or str
         Path to the file to save the poses to. File extension must be .h5.
+    overwrite : bool, optional
+        If True, overwrite the file if it already exists.
+        If False (default), raise ``FileExistsError``.
 
     Notes
     -----
@@ -308,7 +325,9 @@ def to_sleap_analysis_file(ds: xr.Dataset, file_path: str | Path) -> None:
     ... )
 
     """
-    file = _validate_file_path(file_path=file_path, expected_suffix=[".h5"])
+    file = _validate_file_path(
+        file_path=file_path, expected_suffix=[".h5"], overwrite=overwrite
+    )
     ValidPosesInputs.validate(ds)
 
     ds = _remove_unoccupied_tracks(ds)

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -235,9 +235,7 @@ def to_dlc_file(
             # Validate derived per-individual path for existence
             if filepath.exists() and not overwrite:
                 raise logger.error(
-                    FileExistsError(
-                        f"File {filepath} already exists."
-                    )
+                    FileExistsError(f"File {filepath} already exists.")
                 )
             if isinstance(df, pd.DataFrame):
                 _save_dlc_df(filepath, df)

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -229,10 +229,19 @@ def to_dlc_file(
 
         for key, df in df_dict.items():
             # the key is the individual's name
-            filepath = f"{file.path.with_suffix('')}_{key}{file.path.suffix}"
+            filepath = Path(
+                f"{file.path.with_suffix('')}_{key}{file.path.suffix}"
+            )
+            # Validate derived per-individual path for existence
+            if filepath.exists() and not overwrite:
+                raise logger.error(
+                    FileExistsError(
+                        f"File {filepath} already exists."
+                    )
+                )
             if isinstance(df, pd.DataFrame):
-                _save_dlc_df(Path(filepath), df)
-            logger.info(f"Saved poses for individual {key} to {file.path}.")
+                _save_dlc_df(filepath, df)
+            logger.info(f"Saved poses for individual {key} to {filepath}.")
     else:
         # convert the dataset to a single dataframe for all individuals
         df_all = to_dlc_style_df(ds, split_individuals=False)

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -91,6 +91,17 @@ class ValidFile:
                 raise logger.error(
                     FileExistsError(f"File {value} already exists.")
                 )
+            if (
+                value.exists()
+                and self.overwrite
+                and not os.access(value, os.W_OK)
+            ):
+                raise logger.error(
+                    PermissionError(
+                        f"File {value} already exists but is not "
+                        "writable. Check file permissions."
+                    )
+                )
 
     @path.validator
     def _file_has_access_permissions(self, attribute, value):

--- a/tests/test_unit/test_io/test_save_bboxes.py
+++ b/tests/test_unit/test_io/test_save_bboxes.py
@@ -743,3 +743,23 @@ def test_to_via_tracks_file_is_recoverable(via_file_path, tmp_path):
 
     # Compare the original and recovered datasets
     xr.testing.assert_equal(original_ds, recovered_ds)
+
+
+def test_to_via_tracks_file_overwrite(valid_bboxes_dataset, tmp_path):
+    """Test that overwrite=True allows re-saving to an existing file."""
+    output_path = tmp_path / "test_overwrite.csv"
+
+    # First save should succeed
+    save_bboxes.to_via_tracks_file(valid_bboxes_dataset, output_path)
+    assert output_path.is_file()
+
+    # Default (overwrite=False) should raise FileExistsError
+    with pytest.raises(FileExistsError):
+        save_bboxes.to_via_tracks_file(valid_bboxes_dataset, output_path)
+
+    # overwrite=True should succeed
+    save_bboxes.to_via_tracks_file(
+        valid_bboxes_dataset, output_path, overwrite=True
+    )
+    assert output_path.is_file()
+

--- a/tests/test_unit/test_io/test_save_bboxes.py
+++ b/tests/test_unit/test_io/test_save_bboxes.py
@@ -762,4 +762,3 @@ def test_to_via_tracks_file_overwrite(valid_bboxes_dataset, tmp_path):
         valid_bboxes_dataset, output_path, overwrite=True
     )
     assert output_path.is_file()
-

--- a/tests/test_unit/test_io/test_save_poses.py
+++ b/tests/test_unit/test_io/test_save_poses.py
@@ -647,4 +647,3 @@ def test_to_sleap_analysis_file_overwrite(valid_poses_dataset, tmp_path):
         valid_poses_dataset, file_path, overwrite=True
     )
     assert file_path.is_file()
-

--- a/tests/test_unit/test_io/test_save_poses.py
+++ b/tests/test_unit/test_io/test_save_poses.py
@@ -647,3 +647,55 @@ def test_to_sleap_analysis_file_overwrite(valid_poses_dataset, tmp_path):
         valid_poses_dataset, file_path, overwrite=True
     )
     assert file_path.is_file()
+
+
+def test_to_lp_file_overwrite(valid_poses_dataset, tmp_path):
+    """Test that overwrite=True allows re-saving a LightningPose file."""
+    file_path = tmp_path / "test_lp.csv"
+
+    # First save should succeed
+    save_poses.to_lp_file(valid_poses_dataset, file_path)
+
+    # Default should raise (derived individual files already exist)
+    with pytest.raises(FileExistsError):
+        save_poses.to_lp_file(valid_poses_dataset, file_path)
+
+    # overwrite=True should succeed
+    save_poses.to_lp_file(valid_poses_dataset, file_path, overwrite=True)
+
+
+def test_to_dlc_file_split_individuals_overwrite(
+    valid_poses_dataset, tmp_path
+):
+    """Test overwrite behavior with split_individuals=True.
+
+    When split_individuals=True, derived per-individual paths must also
+    be protected by the overwrite flag.
+    """
+    file_path = tmp_path / "test_dlc.h5"
+
+    # First save creates per-individual files
+    save_poses.to_dlc_file(
+        valid_poses_dataset, file_path, split_individuals=True
+    )
+
+    # Derived files should exist
+    individuals = valid_poses_dataset.coords["individuals"].values
+    for ind in individuals:
+        derived = tmp_path / f"test_dlc_{ind}.h5"
+        assert derived.is_file()
+
+    # Default should raise because derived files exist
+    with pytest.raises(FileExistsError):
+        save_poses.to_dlc_file(
+            valid_poses_dataset, file_path, split_individuals=True
+        )
+
+    # overwrite=True should succeed
+    save_poses.to_dlc_file(
+        valid_poses_dataset,
+        file_path,
+        split_individuals=True,
+        overwrite=True,
+    )
+

--- a/tests/test_unit/test_io/test_save_poses.py
+++ b/tests/test_unit/test_io/test_save_poses.py
@@ -613,3 +613,38 @@ def test_remove_unoccupied_tracks(valid_poses_dataset):
     ds = valid_poses_dataset.reindex(individuals=new_individuals)
     ds = save_poses._remove_unoccupied_tracks(ds)
     xr.testing.assert_equal(ds, valid_poses_dataset)
+
+
+def test_to_dlc_file_overwrite(valid_poses_dataset, new_h5_file):
+    """Test that overwrite=True allows re-saving to an existing file."""
+    # First save should succeed (file doesn't exist yet)
+    save_poses.to_dlc_file(valid_poses_dataset, new_h5_file)
+    assert new_h5_file.is_file()
+
+    # Default (overwrite=False) should raise FileExistsError
+    with pytest.raises(FileExistsError):
+        save_poses.to_dlc_file(valid_poses_dataset, new_h5_file)
+
+    # overwrite=True should succeed
+    save_poses.to_dlc_file(valid_poses_dataset, new_h5_file, overwrite=True)
+    assert new_h5_file.is_file()
+
+
+def test_to_sleap_analysis_file_overwrite(valid_poses_dataset, tmp_path):
+    """Test that overwrite=True allows re-saving to an existing SLEAP file."""
+    file_path = tmp_path / "test_sleap.h5"
+
+    # First save should succeed
+    save_poses.to_sleap_analysis_file(valid_poses_dataset, file_path)
+    assert file_path.is_file()
+
+    # Default should raise
+    with pytest.raises(FileExistsError):
+        save_poses.to_sleap_analysis_file(valid_poses_dataset, file_path)
+
+    # overwrite=True should succeed
+    save_poses.to_sleap_analysis_file(
+        valid_poses_dataset, file_path, overwrite=True
+    )
+    assert file_path.is_file()
+

--- a/tests/test_unit/test_io/test_save_poses.py
+++ b/tests/test_unit/test_io/test_save_poses.py
@@ -698,4 +698,3 @@ def test_to_dlc_file_split_individuals_overwrite(
         split_individuals=True,
         overwrite=True,
     )
-

--- a/tests/test_unit/test_validators/test_files_validators.py
+++ b/tests/test_unit/test_validators/test_files_validators.py
@@ -94,6 +94,22 @@ def test_validate_file_path_file_exists(sample_file_path, tmp_path, suffix):
         _validate_file_path(file_path, [suffix])
 
 
+@pytest.mark.parametrize("suffix", [".txt", ".csv"])
+def test_validate_file_path_overwrite(sample_file_path, tmp_path, suffix):
+    """Test that overwrite=True allows saving to an existing file."""
+    file_path = sample_file_path(tmp_path, suffix)
+    file_path.touch()
+
+    # Default (overwrite=False) should still raise
+    with pytest.raises(OSError):
+        _validate_file_path(file_path, [suffix])
+
+    # overwrite=True should succeed
+    validated_file = _validate_file_path(file_path, [suffix], overwrite=True)
+    assert isinstance(validated_file, ValidFile)
+    assert validated_file.path == file_path
+
+
 @pytest.mark.parametrize("invalid_suffix", [".foo", "", None])
 def test_validate_file_path_invalid_suffix(
     sample_file_path, tmp_path, invalid_suffix


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Currently, all save functions raise a `FileExistsError` if the target file already exists. While this ensures safety, it can interrupt common workflows where users intentionally re-run the same export operation and expect the file to be updated.

This PR introduces an explicit `overwrite` parameter that allows users to opt into overwriting existing files, while fully preserving the existing default behavior.

**What does this PR do?**

This PR adds `overwrite: bool = False` support across the file validation and save layers.

Specifically:

- Added `overwrite` parameter to the `ValidFile` validator.
- Updated `_file_exists_when_expected` to allow overwriting when explicitly enabled.
- Extended `_validate_file_path` to accept and forward the `overwrite` flag.
- Updated the following save functions to support and propagate `overwrite`:
  - `to_dlc_file`
  - `to_lp_file`
  - `to_sleap_analysis_file`
  - `to_via_tracks_file`

Special care was taken to correctly thread the `overwrite` parameter through the `to_lp_file → to_dlc_file` call chain to avoid duplicate validation conflicts.

Default behavior remains unchanged:
- If `overwrite=False` (default), `FileExistsError` is still raised.
- If `overwrite=True`, the file is safely overwritten.

Only the necessary files were modified. No unrelated scripts, tests, or auxiliary files are included in this PR.

---

## References

Closes #813

---

## How has this PR been tested?

- Added new unit tests to validate:
  - Overwrite allowed when `overwrite=True`
  - `FileExistsError` still raised when `overwrite=False`
- Verified save functions behave correctly under both scenarios.
- Ran targeted test suites:
  - `test_files_validators.py`
  - `test_save_poses.py`
- Executed the full repository test suite to confirm no regressions.
- Verified that existing napari-related failures are pre-existing on the `main` branch and unrelated to this change.
- Ran `ruff` lint checks to ensure formatting and style compliance.

---

## Is this a breaking change?

No.

The default behavior remains unchanged. Existing code that does not pass `overwrite=True` will continue to raise `FileExistsError` when the file already exists.

This change is fully backward-compatible.

---

## Does this PR require an update to the documentation?

No major documentation updates were required, as this is an additive feature that preserves default behavior.

The new parameter is self-contained and does not alter existing APIs.

---

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes (where applicable)
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
