### PR TITLE
Add COCO keypoint annotation format support 

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -199,6 +199,7 @@ linkcheck_anchors_ignore_for_url = [
     "https://gin.g-node.org/G-Node/Info/wiki/",
     "https://neuroinformatics.zulipchat.com/",
     "https://github.com/talmolab/sleap/blob/v1.3.3/sleap/info/write_tracking_h5.py",
+    "https://cocodataset.org/",  # JS-generated anchors
 ]
 # A list of regular expressions that match URIs that should not be checked
 linkcheck_ignore = [

--- a/docs/source/user_guide/input_output.md
+++ b/docs/source/user_guide/input_output.md
@@ -200,7 +200,7 @@ ds = load_poses.from_coco_file(
 
 The COCO format stores keypoints as a flat list `[x1, y1, v1, x2, y2, v2, ...]` where `v` is a visibility flag:
 - `v=0`: not labeled (confidence = 0.0)
-- `v=1`: labeled but occluded (confidence = 0.5)  
+- `v=1`: labeled but occluded (confidence = 0.5)
 - `v=2`: labeled and visible (confidence = 1.0)
 
 Each image in the COCO file corresponds to a frame, and each annotation within an image represents an individual. Frames without annotations are filled with NaN values.

--- a/docs/source/user_guide/input_output.md
+++ b/docs/source/user_guide/input_output.md
@@ -31,6 +31,7 @@ and can be loaded from and saved to various third-party formats.
 | [Anipose](anipose:)                                                         |              | triangulation .csv file, or corresponding pandas DataFrame                                                                | Pose                 | Load                 |
 | [VGG Image Annotator](via:)                                                 | VIA          | .csv file for [tracks annotation](via:docs/face_track_annotation.html)                                                    | Bounding box         | Load & Save          |
 | [Neurodata Without Borders](https://nwb-overview.readthedocs.io/en/latest/) | NWB          | .nwb file or NWBFile object with the [ndx-pose extension](https://github.com/rly/ndx-pose)                                | Pose                 | Load & Save          |
+| [COCO](https://cocodataset.org/#format-data)                                | COCO         | COCO keypoints .json file                                                                                                 | Pose                 | Load                 |
 | Any                                                                         |              | Numpy arrays                                                                                                              | Pose or Bounding box | Load & Save\*        |
 
 \*Exporting any `movement` DataArray to a NumPy array is as simple as calling xarray's built-in {meth}`xarray.DataArray.to_numpy()` method, so no specialised "Export/Save As" function is needed, see [xarray's documentation](xarray:user-guide/duckarrays.html) for more details.
@@ -186,6 +187,23 @@ with pynwb.NWBHDF5IO("path/to/file.nwb", mode="r") as io:
         nwb_file, pose_estimation_key="PoseEstimation"
     )
 ```
+::::
+
+::::{tab-item} COCO
+To load COCO keypoints JSON files:
+```python
+ds = load_poses.from_coco_file(
+    "path/to/coco_keypoints.json",
+    fps=30,  # Optional; time coords will be in seconds if provided
+)
+```
+
+The COCO format stores keypoints as a flat list `[x1, y1, v1, x2, y2, v2, ...]` where `v` is a visibility flag:
+- `v=0`: not labeled (confidence = 0.0)
+- `v=1`: labeled but occluded (confidence = 0.5)  
+- `v=2`: labeled and visible (confidence = 1.0)
+
+Each image in the COCO file corresponds to a frame, and each annotation within an image represents an individual. Frames without annotations are filled with NaN values.
 ::::
 
 ::::{tab-item} From NumPy

--- a/movement/io/load.py
+++ b/movement/io/load.py
@@ -29,6 +29,7 @@ SourceSoftware: TypeAlias = Literal[
     "Anipose",
     "NWB",
     "VIA-tracks",
+    "COCO",
 ]
 
 

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -17,6 +17,7 @@ from movement.utils.logging import logger
 from movement.validators.datasets import ValidPosesInputs
 from movement.validators.files import (
     ValidAniposeCSV,
+    ValidCOCOJSON,
     ValidDeepLabCutCSV,
     ValidDeepLabCutH5,
     ValidFile,
@@ -944,3 +945,192 @@ def _ds_from_nwb_object(
     return xr.merge(
         single_keypoint_datasets, join="outer", compat="no_conflicts"
     )
+
+
+def _group_coco_annotations(
+    coco_data: dict,
+    image_id_to_idx: dict[int, int],
+) -> dict[int, list[dict]]:
+    """Group COCO annotations by image_id with validation.
+
+    Parameters
+    ----------
+    coco_data
+        Parsed COCO JSON data.
+    image_id_to_idx
+        Mapping from image IDs to frame indices.
+
+    Returns
+    -------
+    dict
+        Annotations grouped by image_id.
+
+    """
+    annotations_by_image: dict[int, list[dict]] = {}
+    for ann in coco_data["annotations"]:
+        if "keypoints" not in ann:
+            continue
+        image_id = ann["image_id"]
+        if image_id not in image_id_to_idx:
+            raise logger.error(
+                ValueError(
+                    f"COCO annotation references unknown image_id {image_id}."
+                )
+            )
+        if image_id not in annotations_by_image:
+            annotations_by_image[image_id] = []
+        annotations_by_image[image_id].append(ann)
+    return annotations_by_image
+
+
+@register_loader("COCO", file_validators=[ValidCOCOJSON])
+def from_coco_file(
+    file: str | Path,
+    fps: float | None = None,
+) -> xr.Dataset:
+    """Create a ``movement`` poses dataset from a COCO keypoints JSON file.
+
+    Parameters
+    ----------
+    file
+        Path to the COCO format JSON file containing pose annotations.
+    fps
+        The number of frames per second in the video. If None (default),
+        the ``time`` coordinates will be in frame numbers.
+
+    Returns
+    -------
+    xarray.Dataset
+        ``movement`` dataset containing the pose tracks, confidence scores,
+        and associated metadata.
+
+    Notes
+    -----
+    The COCO keypoints format stores keypoints as a flat list:
+    [x1, y1, v1, x2, y2, v2, ...] where v is the visibility flag:
+
+    - v=0: not labeled
+    - v=1: labeled but not visible (occluded)
+    - v=2: labeled and visible
+
+    The visibility flags are converted to confidence scores:
+
+    - v=0 → confidence=0.0
+    - v=1 → confidence=0.5
+    - v=2 → confidence=1.0
+
+    Each image in the COCO file corresponds to a frame, and each annotation
+    within an image represents an individual. If multiple annotations exist
+    per image, they are treated as multiple individuals in that frame.
+    Frames without annotations are filled with NaN values.
+
+    Currently, only the first category's keypoint names are used if multiple
+    categories exist in the file.
+
+    Examples
+    --------
+    >>> from movement.io import load_poses
+    >>> ds = load_poses.from_coco_file("path/to/coco_keypoints.json", fps=30)
+
+    """
+    valid_file = cast("ValidFile", file)
+    import json
+
+    with open(valid_file.file) as f:
+        coco_data = json.load(f)
+
+    # Extract keypoint names from the first category with keypoints
+    keypoint_names = None
+    for category in coco_data["categories"]:
+        if "keypoints" in category:
+            keypoint_names = category["keypoints"]
+            break
+
+    if keypoint_names is None:
+        raise logger.error(
+            ValueError(
+                "No keypoint names found in any category. "
+                "COCO keypoints format requires a 'keypoints' field "
+                "in at least one category."
+            )
+        )
+
+    n_keypoints = len(keypoint_names)
+
+    # Sort images by id for deterministic frame ordering
+    images = sorted(coco_data["images"], key=lambda x: x["id"])
+
+    # Create image_id to frame_idx mapping
+    image_id_to_idx = {img["id"]: idx for idx, img in enumerate(images)}
+    n_frames = len(images)
+
+    # Group annotations by image_id
+    annotations_by_image = _group_coco_annotations(coco_data, image_id_to_idx)
+
+    # Determine maximum number of individuals per frame
+    max_individuals = max(
+        (len(anns) for anns in annotations_by_image.values()),
+        default=1,
+    )
+
+    # Initialize arrays with NaNs
+    # position_array: (n_frames, n_space, n_keypoints, n_individuals)
+    position_array = np.full(
+        (n_frames, 2, n_keypoints, max_individuals),
+        np.nan,
+        dtype=np.float32,
+    )
+    # confidence_array: (n_frames, n_keypoints, n_individuals)
+    confidence_array = np.full(
+        (n_frames, n_keypoints, max_individuals),
+        np.nan,
+        dtype=np.float32,
+    )
+
+    # Parse annotations
+    for image_id, annotations in annotations_by_image.items():
+        frame_idx = image_id_to_idx[image_id]
+
+        for ind_idx, ann in enumerate(annotations):
+            raw_keypoints = ann["keypoints"]
+            if len(raw_keypoints) % 3 != 0:
+                raise logger.error(
+                    ValueError(
+                        f"Invalid number of keypoint values for "
+                        f"image_id {image_id}. "
+                        f"Expected multiple of 3, "
+                        f"got {len(raw_keypoints)}."
+                    )
+                )
+            keypoints = np.array(raw_keypoints).reshape(-1, 3)
+
+            # Extract x, y coordinates
+            position_array[frame_idx, 0, :, ind_idx] = keypoints[:, 0]  # x
+            position_array[frame_idx, 1, :, ind_idx] = keypoints[:, 1]  # y
+
+            # Convert visibility flags to confidence scores
+            # v=0 -> 0.0, v=1 -> 0.5, v=2 -> 1.0
+            visibility = keypoints[:, 2]
+            confidence = np.where(
+                visibility == 0,
+                0.0,
+                np.where(visibility == 1, 0.5, 1.0),
+            )
+            confidence_array[frame_idx, :, ind_idx] = confidence
+
+    # Generate individual names
+    individual_names = [f"individual_{i}" for i in range(max_individuals)]
+
+    ds = from_numpy(
+        position_array=position_array,
+        confidence_array=confidence_array,
+        individual_names=individual_names,
+        keypoint_names=keypoint_names,
+        fps=fps,
+        source_software="COCO",
+    )
+
+    # Add metadata
+    ds.attrs["source_file"] = valid_file.file.as_posix()
+    logger.info(f"Loaded pose tracks from {valid_file.file}:\n{ds}")
+    return ds

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -1040,20 +1040,11 @@ def from_coco_file(
         coco_data = json.load(f)
 
     # Extract keypoint names from the first category with keypoints
-    keypoint_names = None
+    keypoint_names: list[str] = []
     for category in coco_data["categories"]:
         if "keypoints" in category:
             keypoint_names = category["keypoints"]
             break
-
-    if keypoint_names is None:
-        raise logger.error(
-            ValueError(
-                "No keypoint names found in any category. "
-                "COCO keypoints format requires a 'keypoints' field "
-                "in at least one category."
-            )
-        )
 
     n_keypoints = len(keypoint_names)
 

--- a/tests/fixtures/files.py
+++ b/tests/fixtures/files.py
@@ -554,3 +554,107 @@ def invalid_dstype_netcdf_file(tmp_path_factory):
     ds.to_netcdf(invalid_path)
 
     yield str(invalid_path)
+
+
+# ---------------- COCO JSON file fixtures ----------------------------
+@pytest.fixture
+def valid_coco_json_file(tmp_path):
+    """Return a path to a valid COCO keypoints JSON file with
+    3 frames, 2 individuals, and 3 keypoints.
+    """
+    import json
+
+    coco_data = {
+        "images": [
+            {"id": 1, "file_name": "frame_001.jpg"},
+            {"id": 2, "file_name": "frame_002.jpg"},
+            {"id": 3, "file_name": "frame_003.jpg"},
+        ],
+        "annotations": [
+            {
+                "id": 1,
+                "image_id": 1,
+                "category_id": 1,
+                "keypoints": [10, 20, 2, 30, 40, 1, 50, 60, 0],
+            },
+            {
+                "id": 2,
+                "image_id": 1,
+                "category_id": 1,
+                "keypoints": [15, 25, 2, 35, 45, 2, 55, 65, 1],
+            },
+            {
+                "id": 3,
+                "image_id": 2,
+                "category_id": 1,
+                "keypoints": [11, 21, 1, 31, 41, 0, 51, 61, 2],
+            },
+        ],
+        "categories": [
+            {
+                "id": 1,
+                "name": "person",
+                "keypoints": ["nose", "left_eye", "right_eye"],
+            }
+        ],
+    }
+    file_path = tmp_path / "valid_coco.json"
+    with open(file_path, "w") as f:
+        json.dump(coco_data, f)
+    return file_path
+
+
+@pytest.fixture
+def coco_json_missing_categories(tmp_path):
+    """Return path to a COCO JSON file missing 'categories' key."""
+    import json
+
+    coco_data = {
+        "images": [{"id": 1, "file_name": "frame_001.jpg"}],
+        "annotations": [
+            {
+                "id": 1,
+                "image_id": 1,
+                "category_id": 1,
+                "keypoints": [10, 20, 2],
+            }
+        ],
+    }
+    file_path = tmp_path / "coco_missing_categories.json"
+    with open(file_path, "w") as f:
+        json.dump(coco_data, f)
+    return file_path
+
+
+@pytest.fixture
+def coco_json_missing_keypoints(tmp_path):
+    """Return path to a COCO JSON file with categories
+    but no keypoints field.
+    """
+    import json
+
+    coco_data = {
+        "images": [{"id": 1, "file_name": "frame_001.jpg"}],
+        "annotations": [
+            {
+                "id": 1,
+                "image_id": 1,
+                "category_id": 1,
+                "keypoints": [10, 20, 2],
+            }
+        ],
+        "categories": [{"id": 1, "name": "person"}],
+    }
+    file_path = tmp_path / "coco_missing_keypoints.json"
+    with open(file_path, "w") as f:
+        json.dump(coco_data, f)
+    return file_path
+
+
+@pytest.fixture
+def invalid_json_file(tmp_path):
+    """Return path to an invalid JSON file (not parseable)."""
+    file_path = tmp_path / "invalid.json"
+    with open(file_path, "w") as f:
+        f.write("{this is not valid JSON")
+    return file_path

--- a/tests/fixtures/files.py
+++ b/tests/fixtures/files.py
@@ -557,6 +557,10 @@ def invalid_dstype_netcdf_file(tmp_path_factory):
 
 
 # ---------------- COCO JSON file fixtures ----------------------------
+# Constants for COCO fixtures
+COCO_FRAME_001 = "frame_001.jpg"
+
+
 @pytest.fixture
 def valid_coco_json_file(tmp_path):
     """Return a path to a valid COCO keypoints JSON file with
@@ -566,7 +570,7 @@ def valid_coco_json_file(tmp_path):
 
     coco_data = {
         "images": [
-            {"id": 1, "file_name": "frame_001.jpg"},
+            {"id": 1, "file_name": COCO_FRAME_001},
             {"id": 2, "file_name": "frame_002.jpg"},
             {"id": 3, "file_name": "frame_003.jpg"},
         ],
@@ -610,7 +614,7 @@ def coco_json_missing_categories(tmp_path):
     import json
 
     coco_data = {
-        "images": [{"id": 1, "file_name": "frame_001.jpg"}],
+        "images": [{"id": 1, "file_name": COCO_FRAME_001}],
         "annotations": [
             {
                 "id": 1,
@@ -634,7 +638,7 @@ def coco_json_missing_keypoints(tmp_path):
     import json
 
     coco_data = {
-        "images": [{"id": 1, "file_name": "frame_001.jpg"}],
+        "images": [{"id": 1, "file_name": COCO_FRAME_001}],
         "annotations": [
             {
                 "id": 1,

--- a/tests/test_unit/test_io/test_load_poses.py
+++ b/tests/test_unit/test_io/test_load_poses.py
@@ -349,12 +349,11 @@ def test_coco_confidence_mapping(valid_coco_json_file):
     """Test that COCO visibility flags are correctly mapped to confidence."""
     ds = load_poses.from_coco_file(valid_coco_json_file)
 
-    # Frame 1, individual 0: keypoints with v=[2,1,0]
+    # Frame 1, individual 0: keypoints with visibility flags [2,1,0]
     # Should map to confidence [1.0, 0.5, 0.0]
     confidence_frame1_ind0 = ds.confidence.isel(time=0, individuals=0).values
-    assert confidence_frame1_ind0[0] == 1.0  # v=2
-    assert confidence_frame1_ind0[1] == 0.5  # v=1
-    assert confidence_frame1_ind0[2] == 0.0  # v=0
+    expected_confidence = np.array([1.0, 0.5, 0.0])
+    np.testing.assert_allclose(confidence_frame1_ind0, expected_confidence)
 
 
 def test_coco_position_values(valid_coco_json_file):


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/neuroinformatics-unit/.github/blob/main/CONTRIBUTING.md).

## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

This PR adds support for loading pose data in COCO keypoints format.  
Issue #182 requested extending the input capabilities of `movement` to support COCO-style datasets, allowing users to work directly with COCO-formatted keypoint annotations without needing external conversion.

Adding native support improves interoperability with common computer vision pipelines and datasets that rely on COCO specifications.

**What does this PR do?**

This PR introduces full support for COCO keypoints JSON files, including:

- A `ValidCOCOJSON` validator to ensure correct structure and required fields
- A new `from_coco_file()` loader function registered via the existing loader system
- Mapping of COCO visibility flags (`v=0,1,2`) to confidence scores
- Support for multiple annotations per image (multi-individual support)
- NaN handling for missing frames
- Clean and informative error messages for invalid inputs
- Integration into the `SourceSoftware` type alias

The implementation follows the existing repository architecture and does not modify unrelated functionality.

## References

Closes #182

## How has this PR been tested?

The following testing steps were performed:

- Added 4 dedicated COCO JSON test fixtures
- Added 6 unit tests covering:
  - Successful loading
  - Validation errors
  - Multiple annotations
  - Confidence mapping
  - Shape correctness
- Ran full test suite locally (`pytest`)
- Ran lint checks using `ruff`
- Ensured formatting consistency
- Built documentation with Sphinx to verify no COCO-related warnings or errors

All new functionality is covered by tests, and no existing tests were modified.  
Existing functionality remains unaffected.

## Is this a breaking change?

No.  
This PR only adds support for an additional input format and does not modify existing loaders or APIs.

## Does this PR require an update to the documentation?

Yes.  
The input/output documentation has been updated to:

- Include COCO in the supported formats table
- Describe the expected COCO keypoints structure
- Provide usage guidance

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
