### PR TITLE
Add example for annotating time with events of interest

### DIFF
--- a/examples/event_annotations.py
+++ b/examples/event_annotations.py
@@ -74,7 +74,7 @@ print(ds_bc.speed)
 
 def plot_speed(speed_da, threshold=None, active=None, title="Speed"):
     """Plot a speed DataArray over time."""
-    fig, ax = plt.subplots(figsize=(10, 3))
+    fig, ax = plt.subplots(figsize=(8, 3))
     time = speed_da.time.values
     speed_da.plot.line(x="time", ax=ax, linewidth=0.5, color="black")
 
@@ -141,7 +141,7 @@ plot_speed(
 # annotates an existing one with additional labels.
 
 ds_bc = ds_bc.assign_coords(active=("time", is_active))
-print(ds_bc.coords["active"])
+print(ds_bc.coords)
 
 # %%
 # With the ``active`` coordinate in place, we can select
@@ -172,6 +172,7 @@ print(f"Inactive frames: {ds_inactive.sizes['time']}")
 rng = np.random.default_rng(42)
 is_stimulus = rng.random(ds_bc.sizes["time"]) > 0.7
 ds_bc = ds_bc.assign_coords(stimulus=("time", is_stimulus))
+print(ds_bc.coords)
 
 # %%
 # While :meth:`xarray.Dataset.sel` works for selecting on a
@@ -201,7 +202,7 @@ print(f"Active + stimulus frames: {ds_active_stim.sizes['time']}")
 
 state_labels = np.where(is_active, "active", "inactive")
 ds_bc = ds_bc.assign_coords(state=("time", state_labels))
-print(ds_bc.coords["state"])
+print(ds_bc.coords)
 
 # %%
 # Selection works the same way with :meth:`xarray.Dataset.sel`.


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

`movement` users often need to combine tracking data with behavioural annotations (from manual scoring, classifiers, or derived metrics) and stimulus timings, but no existing example shows how. This fills that gap using native `xarray` features — no extra tooling required.

**What does this PR do?**

Adds a new example to the gallery, based on a 1-hour-long mouse home-cage monitoring sample dataset.

The example is named "Annotate time with events of interest" and shows how to:

1. compute speed and threshold it into active/inactive states
2. attach state labels as a non-dimension coordinate on `time`
3. select data subsets by state using `ds.sel()`
4. combines multiple boolean event annotations (via boolean indexing)
5. use string labels for states with more than two categories

This approach of using non-dimension coordinates to attach additional labels to an axis was directly inspired by [Callum Marshall's](https://github.com/CS-2425) code written for the [Keshavarzi lab](https://www.keshavarzilab.com).

Callum uses this idea much more broadly, and in more complex scenarios. I thought that event annotation was a simple and generally useful application for this idea.

## References

Somewhat related to out idea of condition arrays: https://github.com/neuroinformatics-unit/movement/issues/418
Though here the 'event annotation' arrays are attached as coordinates to the time dimension (as opposed to being data variables), and they are not limited to being boolean.

## How has this PR been tested?

Local documentation build and CI.

## Is this a breaking change?

No,

## Does this PR require an update to the documentation?

It *is* and update of docs.

## Checklist:

- [x] The code has been tested locally
- ~[ ] Tests have been added to cover all new functionality~
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
