### PR TITLE
Add "See Also" to `load_multiview_dataset` docstring

### DIFF
--- a/movement/io/load.py
+++ b/movement/io/load.py
@@ -259,7 +259,7 @@ def load_dataset(
         the NWB file.
     **kwargs
         Additional keyword arguments to pass to the software-specific
-        loading functions that are listed under "See Also".
+        loading functions in modules listed under "See Also".
 
     Returns
     -------
@@ -318,7 +318,7 @@ def load_multiview_dataset(
         the NWB file.
     **kwargs
         Additional keyword arguments to pass to the software-specific
-        loading functions that are listed under "See Also".
+        loading functions in modules listed under "See Also".
 
     Returns
     -------


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other: Doc fix

**Why is this PR needed?**

The `load_multiview_dataset` docstring mentions a "See Also" seciton, but no such section is present. This must have been overlooked in #722.


**What does this PR do?**

Adds the "See also" section (same as for `load_dataset`).

## References

Related to #722.

## How has this PR been tested?

Local docs build.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

It *is* an update of docs.

## Checklist:

- [x] The code has been tested locally
- ~[ ] Tests have been added to cover all new functionality~
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
