### PR TITLE
Log default name assignment at INFO instead of WARNING level

### DIFF
--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -402,7 +402,7 @@ def _ds_from_sleap_analysis_file(file: Path, fps: float | None) -> xr.Dataset:
         scores = np.full(tracks.shape[:1] + tracks.shape[2:], np.nan)
         individual_names = [n.decode() for n in f["track_names"][:]] or None
         if individual_names is None:
-            logger.warning(
+            logger.info(
                 f"Could not find SLEAP Track in {file}. "
                 "Assuming single-individual dataset and assigning "
                 "default individual name."
@@ -443,7 +443,7 @@ def _ds_from_sleap_labels_file(file: Path, fps: float | None) -> xr.Dataset:
     tracks_with_scores = _sleap_labels_to_numpy(labels)
     individual_names = [track.name for track in labels.tracks] or None
     if individual_names is None:
-        logger.warning(
+        logger.info(
             f"Could not find SLEAP Track in {file}. "
             "Assuming single-individual dataset and assigning "
             "default individual name."

--- a/movement/io/nwb.py
+++ b/movement/io/nwb.py
@@ -259,7 +259,7 @@ class NWBFileSaveConfig:
         def infer_entity_or_raise(cfg: dict) -> str:
             if len(cfg) == 1:
                 inferred = next(iter(cfg))
-                logger.warning(
+                logger.info(
                     f"No {entity_type} was provided. Assuming '{inferred}' "
                     f"since there is only one entry in {attr_name}."
                 )
@@ -279,7 +279,7 @@ class NWBFileSaveConfig:
                 entity = infer_entity_or_raise(cfg)
             base = dict(cfg.get(entity, {}))
             if not base:
-                logger.warning(
+                logger.info(
                     f"'{entity}' not found in {attr_name}; "
                     f"setting '{entity}' as {id_key}."
                 )
@@ -323,7 +323,7 @@ class NWBFileSaveConfig:
             prioritise_entity=prioritise_individual,
         )
         if "session_start_time" not in kwargs:
-            logger.warning(
+            logger.info(
                 "No session_start_time provided in nwbfile_kwargs; "
                 "using current UTC time as default."
             )


### PR DESCRIPTION
Closes #741

## Description

**What is this PR**
- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Default value assignments for parameters such as `individual_names` and `keypoint_names` were previously logged at `WARNING` level. This caused unnecessary noise during normal use and especially during CI test runs, since assigning a default is not a misconfiguration — it is expected behaviour.

**What does this PR do?**
Downgrades the relevant `logger.warning(...)` calls to `logger.info(...)` for messages that are purely about default value assignment. Genuine misconfiguration warnings (where the user needs to take action) are left unchanged at `WARNING` level. Tests that previously asserted `WARNING` level for these messages have been updated to assert `INFO` level accordingly.

## References
- Closes #741
- Originally raised in #705 (comment) by @niksirbi
- Related refactor: #706

## How has this PR been tested?
- Existing tests updated to reflect the new `INFO` log level for default-assignment messages
- Full test suite run locally with `pytest -q` — all tests pass
- Pre-commit hooks run with `pre-commit run --all-files` — all clean
- Ruff lint and format checks pass with zero errors
- Docs built locally with `make -C docs html` — zero Sphinx warnings
- Docs linkcheck run with `make -C docs linkcheck` — zero broken links

## Is this a breaking change?
No. This only changes the log level of specific informational messages from `WARNING` to `INFO`. No public API, data structures, or behaviour is affected. Users who have configured their logger to show only `WARNING` and above will simply no longer see these default-assignment messages, which is the intended outcome.

## Does this PR require an update to the documentation?
No documentation update is required. The change is internal to the logging behaviour and does not affect any public-facing API or user guide.

## Checklist:
- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
