### PR TITLE
Make hide_pooch_hash_logs internal by renaming to _hide_pooch_hash_logs

### DIFF
--- a/movement/sample_data.py
+++ b/movement/sample_data.py
@@ -35,7 +35,7 @@ METADATA_FILE = "metadata.yaml"
 
 
 @contextmanager
-def hide_pooch_hash_logs():
+def _hide_pooch_hash_logs():
     """Hide SHA256 hash printouts from ``pooch.retrieve``.
 
     This context manager temporarily suppresses SHA256 hash messages
@@ -82,7 +82,7 @@ def _download_metadata_file(file_name: str, data_dir: Path = DATA_DIR) -> Path:
         Path to the downloaded file.
 
     """
-    with hide_pooch_hash_logs():
+    with _hide_pooch_hash_logs():
         local_file_path = pooch.retrieve(
             url=f"{DATA_URL}/{file_name}",
             known_hash=None,

--- a/tests/test_unit/test_sample_data.py
+++ b/tests/test_unit/test_sample_data.py
@@ -13,9 +13,9 @@ from movement.sample_data import (
     SAMPLE_DATA,
     _fetch_and_unzip,
     _fetch_metadata,
+    _hide_pooch_hash_logs,
     fetch_dataset,
     fetch_dataset_paths,
-    hide_pooch_hash_logs,
     list_datasets,
 )
 
@@ -287,7 +287,7 @@ def test_fetch_and_unzip_exceptions(
 )
 def test_hide_pooch_hash_logs(message, should_block):
     """Test that ``HashFilter`` blocks only hash-related messages."""
-    with hide_pooch_hash_logs():
+    with _hide_pooch_hash_logs():
         logger = pooch.get_logger()
         hash_filter = logger.filters[-1]
 
@@ -324,11 +324,11 @@ def test_hash_filter_removed_after_context(raise_exception):
     initial_filter_count = len(logger.filters)
 
     if raise_exception:
-        with pytest.raises(ValueError), hide_pooch_hash_logs():
+        with pytest.raises(ValueError), _hide_pooch_hash_logs():
             assert len(logger.filters) == initial_filter_count + 1
             raise ValueError("Test exception")
     else:
-        with hide_pooch_hash_logs():
+        with _hide_pooch_hash_logs():
             assert len(logger.filters) == initial_filter_count + 1
 
     # Filter should be removed after context exits


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix  
- [ ] Addition of a new feature  
- [x] Other  

**Why is this PR needed?**

`hide_pooch_hash_logs` is only used internally and should not be exposed as part of the public API.

**What does this PR do?**

Renames `hide_pooch_hash_logs` to `_hide_pooch_hash_logs` and updates internal references and tests accordingly.

---

## References

Closes #841 

---

## How has this PR been tested?

Updated the existing unit tests to use the renamed function. Ran `pre-commit` locally to ensure formatting and linting checks pass.

---

## Is this a breaking change?

No.

---

## Does this PR require an update to the documentation?

No.

---

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with pre-commit