### PR TITLE
FEAT: Handle NaN in kinetic energy and add warning threshold

### DIFF
--- a/movement/kinematics/kinetic_energy.py
+++ b/movement/kinematics/kinetic_energy.py
@@ -3,11 +3,13 @@
 import numpy as np
 import xarray as xr
 
-from movement.kinematics.kinematics import compute_velocity
+from movement.kinematics.kinematics import (
+    _warn_about_nan_proportion,
+    compute_velocity,
+)
 from movement.utils.logging import logger
 from movement.utils.vector import compute_norm
 from movement.validators.arrays import validate_dims_coords
-from movement.kinematics.kinematics import _warn_about_nan_proportion
 
 
 def compute_kinetic_energy(
@@ -15,7 +17,7 @@ def compute_kinetic_energy(
     keypoints: list | None = None,
     masses: dict | None = None,
     decompose: bool = False,
-    nan_warn_threshold: float = 0.1, # how much missing data is acceptable before a warning
+    nan_warn_threshold: float = 0.1,  # how much missing data is acceptable before a warning
 ) -> xr.DataArray:
     r"""Compute kinetic energy per individual.
 
@@ -41,7 +43,7 @@ def compute_kinetic_energy(
         decomposition. The default is False, meaning the total kinetic energy
         is returned.
     nan_warn_threshold: float, optional
-		If some keypoints are missing at some point in time, kinetic energy
+    If some keypoints are missing at some point in time, kinetic energy
         is computed only on the remaining valid points. If any point has at least
         threshold values missing, a warning will be emitted.
         By default 0.1.

--- a/tests/test_unit/test_kinematics/test_kinetic_energy.py
+++ b/tests/test_unit/test_kinematics/test_kinetic_energy.py
@@ -140,10 +140,11 @@ def test_insufficient_keypoints(
             decompose=True,
         )
 
+
 @pytest.fixture
 def position_array_with_nan():
-	data = np.ones((5, 1, 2, 2))
-	return xr.DataArray(
+    data = np.ones((5, 1, 2, 2))
+    return xr.DataArray(
         data,
         coords={
             "time": np.arange(5),
@@ -154,21 +155,24 @@ def position_array_with_nan():
         dims=["time", "individuals", "keypoints", "space"],
     )
 
+
 def test_kinetic_energy_partial_nan(position_array_with_nan):
-	data = position_array_with_nan.copy(deep=True)
-	data.loc[dict(time=2, keypoints="tail")] = np.nan
-	ke = compute_kinetic_energy(data)
-	assert np.isfinite(ke.sel(time=2, individuals="ind1"))
+    data = position_array_with_nan.copy(deep=True)
+    data.loc[dict(time=2, keypoints="tail")] = np.nan
+    ke = compute_kinetic_energy(data)
+    assert np.isfinite(ke.sel(time=2, individuals="ind1"))
+
 
 def test_kinetic_energy_full_nan(position_array_with_nan):
-	data = position_array_with_nan.copy(deep=True)
-	data.loc[dict(time=2)] = np.nan
-	ke = compute_kinetic_energy(data)
-	assert np.isnan(ke.sel(time=1, individuals="ind1"))
-	assert np.isnan(ke.sel(time=3, individuals="ind1"))
+    data = position_array_with_nan.copy(deep=True)
+    data.loc[dict(time=2)] = np.nan
+    ke = compute_kinetic_energy(data)
+    assert np.isnan(ke.sel(time=1, individuals="ind1"))
+    assert np.isnan(ke.sel(time=3, individuals="ind1"))
+
 
 def test_kinetic_energy_nan_warning(position_array_with_nan):
-	data = position_array_with_nan.copy(deep=True)
-	data.loc[dict(time=[1, 2], keypoints="head")] = np.nan
-	with pytest.warns(UserWarning, match="The result may be unreliable"):
-		compute_kinetic_energy(data, nan_warn_threshold=0.1)
+    data = position_array_with_nan.copy(deep=True)
+    data.loc[dict(time=[1, 2], keypoints="head")] = np.nan
+    with pytest.warns(UserWarning, match="The result may be unreliable"):
+        compute_kinetic_energy(data, nan_warn_threshold=0.1)


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/neuroinformatics-unit/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [x] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
This PR addresses inconsistent NaN handling in compute_kinetic_energy. Previously, missing keypoints were silently skipped during summation, potentially leading to underestimated kinetic energy values without alerting the user. 

**What does this PR do?**
This PR updates compute_kinetic_energy to use min_count=1 in xarray.sum(), ensuring that frames with only NaN values return NaN instead of 0.0. It also introduces the nan_warn_threshold parameter (default 0.2) and calls _warn_about_nan_proportion to alert users when data quality is low.


## References

Please reference any existing issues/PRs that relate to this PR.
Fixes #846
Fixes #406

## How has this PR been tested?

I added three new unit tests in tests/test_unit/test_kinematics/test_kinetic_energy.py:
test_kinetic_energy_partial_nan: Verifies that KE remains valid if at least one keypoint is present.
test_kinetic_energy_full_nan: Verifies that the result is NaN when all keypoints are missing.
test_kinetic_energy_nan_warning: Verifies that a UserWarning is emitted when the NaN proportion exceeds the threshold.

## Is this a breaking change?

No. The default behavior remains largely the same, but it is now improved for edge cases.

## Does this PR require an update to the documentation?

Yes. The docstring for compute_kinetic_energy has been updated to explain the new threshold parameter.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
