### PR TITLE
Fix y-axis label in acceleration plot

### DIFF
--- a/examples/compute_kinematics.py
+++ b/examples/compute_kinematics.py
@@ -419,7 +419,7 @@ for mouse_name, ax in zip(accel.individuals.values, axes, strict=False):
     )
     ax.set_title(mouse_name)
     ax.set_xlabel("time (s)")
-    ax.set_ylabel("speed (px/s**2)")
+    ax.set_ylabel("accel (px/s**2)")
     ax.legend(loc="center right", bbox_to_anchor=(1.07, 1.07))
 fig.tight_layout()
 


### PR DESCRIPTION
Fixes the y-axis label in the acceleration components plot in the kinematics example (it incorrectly said "speed"). Units remain unchanged (px/s**2). Closes #848.