### PR TITLE
Fix y-axis label in acceleration plot

### DIFF
--- a/examples/compute_kinematics.py
+++ b/examples/compute_kinematics.py
@@ -419,7 +419,7 @@ for mouse_name, ax in zip(accel.individuals.values, axes, strict=False):
     )
     ax.set_title(mouse_name)
     ax.set_xlabel("time (s)")
-    ax.set_ylabel("speed (px/s**2)")
+    ax.set_ylabel("accel (px/s**2)")
     ax.legend(loc="center right", bbox_to_anchor=(1.07, 1.07))
 fig.tight_layout()
 


### PR DESCRIPTION
## Description

Fixes the y-axis label in the acceleration components plot in the kinematics example.

The plot for the components of the acceleration vector incorrectly had `"speed (px/s**2)"` as the y-axis label. This changes it to `"acceleration (px/s**2)"` to correctly reflect what is being plotted.

Note: the units `(px/s**2)` were already correct for acceleration — only the word "speed" was wrong.

## Changes

- `examples/compute_kinematics.py` line 422: `"speed (px/s**2)"` → `"acceleration (px/s**2)"`

Closes #848