### PR TITLE
fix: correct loader param name, path assignment, and spelling in docs

### DIFF
--- a/docs/source/user_guide/input_output.md
+++ b/docs/source/user_guide/input_output.md
@@ -84,7 +84,7 @@ Or to load bounding box tracks from a VIA tracks .csv file while retaining the o
 ds = load_dataset(
     "/path/to/file.csv",
     source_software="VIA-tracks",
-    use_frame_numbers_load_dataset=True,
+    use_frame_numbers_from_file=True,
 )
 ```
 

--- a/examples/load_and_upsample_bboxes.py
+++ b/examples/load_and_upsample_bboxes.py
@@ -143,7 +143,7 @@ for i, frame_idx in enumerate(list_frames):
 
     # set title and labels
     ax.set_title(f"Frame {frame_idx}")
-    ax.set_xlabel("x (pixles)")
+    ax.set_xlabel("x (pixels)")
     ax.set_ylabel("y (pixels)")
     ax.set_xlabel("")
     if frame_idx == 1:

--- a/movement/sample_data.py
+++ b/movement/sample_data.py
@@ -313,8 +313,8 @@ def fetch_dataset(
     >>> ds = fetch_dataset(
         "DLC_single-mouse_EPM.predictions.h5", with_video=True
     )
-    >>> frame_path = ds.video_path
-    >>> video_path = ds.frame_path
+    >>> frame_path = ds.frame_path
+    >>> video_path = ds.video_path
 
     See Also
     --------


### PR DESCRIPTION
## Fix: Documentation & Example Corrections

### Changes
- Fix incorrect kwarg name in VIA-tracks loader examples
- Fix swapped frame/video path assignments in docstring
- Fix spelling error in bbox example

### Files Changed
- `docs/source/user_guide/input_output.md`
- `movement/sample_data.py`
- `examples/load_and_upsample_bboxes.py`

### Type of Change
- [ ] Bug fix (non-breaking)
- [x] Documentation/Examples improvement

### Testing
Ruff linting: ✅ passed
Changes are documentation/examples only (no runtime logic affected).

Fixes copy-paste errors for new users learning the loader API.