### PR TITLE
improve: add helpful source_software options to load_dataset errors

### DIFF
--- a/movement/io/load.py
+++ b/movement/io/load.py
@@ -282,8 +282,12 @@ def load_dataset(
 
     """
     if source_software not in _LOADER_REGISTRY:
+        valid_options = ", ".join(sorted(_LOADER_REGISTRY.keys()))
         raise logger.error(
-            ValueError(f"Unsupported source software: {source_software}")
+            ValueError(
+                f"Unsupported source software: '{source_software}'. "
+                f"Supported options are: {valid_options}"
+            )
         )
     if source_software == "NWB":
         if fps is not None:

--- a/tests/test_unit/test_io/test_load.py
+++ b/tests/test_unit/test_io/test_load.py
@@ -61,8 +61,18 @@ def test_load_dataset_delegates_correctly(
     according to the source_software.
     """
     if source_software == "Unknown":
-        with pytest.raises(ValueError, match="Unsupported source"):
+        with pytest.raises(ValueError, match="Unsupported source software"):
             load.load_dataset("some_file", source_software)
+        # Verify error message lists valid options
+        try:
+            load.load_dataset("some_file", source_software)
+        except ValueError as e:
+            assert "Supported options are:" in str(e)
+            # Check that at least one valid source is mentioned
+            assert any(
+                src in str(e)
+                for src in ["DeepLabCut", "SLEAP", "LightningPose", "Anipose"]
+            )
     else:
         mock_loader = mocker.patch(loader_fn)
         mocker.patch.dict(


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [x] Other (error-message UX improvement + test enhancement)

**Why is this PR needed?**

When an unsupported `source_software` is passed to `load_dataset`, the previous error did not clearly guide users to valid values. This made debugging harder, especially for new users.

**What does this PR do?**

- Improves the `ValueError` message in `load_dataset` to include:
  - the invalid `source_software` value
  - a sorted list of supported options from the loader registry
- Updates unit tests to verify:
  - the refined error text (`Unsupported source software`)
  - presence of `Supported options are:`
  - presence of known valid loader names in the message

## References

No linked issue for this PR.

## How has this PR been tested?

- Ran lint checks on changed files with:
  - `ruff check movement/io/load.py tests/test_unit/test_io/test_load.py`
- Verified behavior locally by triggering `load_dataset` with an unknown `source_software` and confirming the new message includes supported options.
- Updated existing unit test coverage in `tests/test_unit/test_io/test_load.py` for the new error-message behavior.

## Is this a breaking change?

No.  
This change is backward-compatible and only improves error messaging and related test assertions.

## Does this PR require an update to the documentation?

No.  
There is no API or usage change; only error clarity is improved.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)