### PR TITLE
improve: add supported options to deprecated loader errors

### DIFF
--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -241,8 +241,12 @@ def from_file(
             frame_regexp=frame_regexp,
         )
     else:
+        valid_options = ["VIA-tracks"]
         raise logger.error(
-            ValueError(f"Unsupported source software: {source_software}")
+            ValueError(
+                f"Unsupported source software: '{source_software}'. "
+                f"Supported options are: {', '.join(valid_options)}"
+            )
         )
 
 

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -184,8 +184,18 @@ def from_file(
             )
         return from_nwb_file(file, **kwargs)
     else:
+        valid_options = [
+            "Anipose",
+            "DeepLabCut",
+            "LightningPose",
+            "NWB",
+            "SLEAP",
+        ]
         raise logger.error(
-            ValueError(f"Unsupported source software: {source_software}")
+            ValueError(
+                f"Unsupported source software: '{source_software}'. "
+                f"Supported options are: {', '.join(valid_options)}"
+            )
         )
 
 

--- a/tests/test_unit/test_io/test_load_bboxes.py
+++ b/tests/test_unit/test_io/test_load_bboxes.py
@@ -242,7 +242,7 @@ def test_from_file(
         "VIA-tracks": "movement.io.load_bboxes.from_via_tracks_file",
     }
     if source_software == "Unknown":
-        with pytest.raises(ValueError, match="Unsupported source"):
+        with pytest.raises(ValueError, match="Unsupported source software"):
             load_bboxes.from_file(
                 "some_file",
                 source_software,
@@ -250,6 +250,17 @@ def test_from_file(
                 use_frame_numbers_from_file=use_frame_numbers_from_file,
                 frame_regexp=frame_regexp,
             )
+        try:
+            load_bboxes.from_file(
+                "some_file",
+                source_software,
+                fps,
+                use_frame_numbers_from_file=use_frame_numbers_from_file,
+                frame_regexp=frame_regexp,
+            )
+        except ValueError as e:
+            assert "Supported options are:" in str(e)
+            assert "VIA-tracks" in str(e)
     else:
         with patch(software_to_loader[source_software]) as mock_loader:
             load_bboxes.from_file(

--- a/tests/test_unit/test_io/test_load_poses.py
+++ b/tests/test_unit/test_io/test_load_poses.py
@@ -290,8 +290,22 @@ def test_from_file_delegates_correctly(source_software, fps, caplog):
         "NWB": "movement.io.load_poses.from_nwb_file",
     }
     if source_software == "Unknown":
-        with pytest.raises(ValueError, match="Unsupported source"):
+        with pytest.raises(ValueError, match="Unsupported source software"):
             load_poses.from_file("some_file", source_software)
+        try:
+            load_poses.from_file("some_file", source_software)
+        except ValueError as e:
+            assert "Supported options are:" in str(e)
+            assert any(
+                src in str(e)
+                for src in [
+                    "DeepLabCut",
+                    "SLEAP",
+                    "LightningPose",
+                    "Anipose",
+                    "NWB",
+                ]
+            )
     else:
         with patch(software_to_loader[source_software]) as mock_loader:
             load_poses.from_file("some_file", source_software, fps)


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [x] Other (error-message UX improvement for deprecated loaders)

**Why is this PR needed?**

Deprecated loader wrappers (`load_poses.from_file` and `load_bboxes.from_file`) raised generic unsupported-source errors that did not tell users which values are valid. This made troubleshooting harder, especially when migrating to the unified loading API.

**What does this PR do?**

- Improves unsupported `source_software` errors in:
  - `movement.io.load_poses.from_file`
  - `movement.io.load_bboxes.from_file`
- New error text now includes:
  - the invalid value (quoted)
  - a `"Supported options are: ..."` list of valid values
- Updates unit tests to verify:
  - `"Unsupported source software"` appears
  - `"Supported options are:"` appears
  - expected valid source names are included in the message

## References

No linked issue for this PR.

## How has this PR been tested?

- Ran lint checks on modified files:
  - `ruff check movement/io/load_poses.py movement/io/load_bboxes.py tests/test_unit/test_io/test_load_poses.py tests/test_unit/test_io/test_load_bboxes.py`
  - Result: passed
- Ran direct runtime checks for both updated error paths and confirmed expected message content.
- Note: targeted `pytest` invocation is currently blocked in this environment by external sample-data download timeouts from GIN during `tests/conftest.py` session startup.

## Is this a breaking change?

No.  
This change only improves error messages and test assertions for deprecated wrapper functions. No functional behavior or API contract is changed.

## Does this PR require an update to the documentation?

No.  
No public API behavior changed beyond clearer error messaging.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)