### PR TITLE
Expose `load_dataset` and `load_multiview_dataset` from top-level `movement` module (closes #361)

### DIFF
--- a/movement/__init__.py
+++ b/movement/__init__.py
@@ -1,5 +1,6 @@
 from importlib.metadata import PackageNotFoundError, version
 
+from movement.io.load import load_dataset, load_multiview_dataset
 from movement.utils.logging import logger
 
 try:
@@ -15,3 +16,8 @@ xr.set_options(keep_attrs=True, display_expand_data=False)
 
 # Configure logging to stderr and a file
 logger.configure()
+
+__all__ = [
+    "load_dataset",
+    "load_multiview_dataset",
+]

--- a/tests/test_unit/test_top_level_imports.py
+++ b/tests/test_unit/test_top_level_imports.py
@@ -1,0 +1,33 @@
+"""Tests for top-level imports from the movement package."""
+
+
+def test_load_dataset_importable_from_top_level():
+    """Test that load_dataset can be imported from movement directly."""
+    from movement import load_dataset
+
+    assert callable(load_dataset)
+
+
+def test_load_multiview_dataset_importable_from_top_level():
+    """Test that load_multiview_dataset can be imported from movement."""
+    from movement import load_multiview_dataset
+
+    assert callable(load_multiview_dataset)
+
+
+def test_top_level_load_dataset_is_same_as_io():
+    """Top-level load_dataset is the same object as movement.io.load's."""
+    from movement import load_dataset
+    from movement.io.load import load_dataset as io_load_dataset
+
+    assert load_dataset is io_load_dataset
+
+
+def test_top_level_load_multiview_dataset_is_same_as_io():
+    """Top-level load_multiview_dataset is the same as movement.io.load's."""
+    from movement import load_multiview_dataset
+    from movement.io.load import (
+        load_multiview_dataset as io_load_multiview_dataset,
+    )
+
+    assert load_multiview_dataset is io_load_multiview_dataset


### PR DESCRIPTION
# Expose `load_dataset` and `load_multiview_dataset` from top-level `movement` module

Closes #361

## Description

**What is this PR?**

- [x] Addition of a new feature

**Why is this PR needed?**

Previously, users had to import the core loading functions from the submodule path `movement.io.load`, which is an implementation detail rather than a stable public interface. Exposing these functions at the top level makes the API more discoverable and ergonomic, consistent with how users typically interact with a package:

```python
# Before: required knowledge of internal module structure
from movement.io.load import load_dataset
ds = load_dataset("file.h5", source_software="DeepLabCut", fps=30)

# After: clean top-level import
import movement as mvt
ds = mvt.load_dataset("file.h5", source_software="DeepLabCut", fps=30)
```

**What does this PR do?**

- Re-exports `load_dataset` and `load_multiview_dataset` in `movement/__init__.py` by importing them from `movement.io.load`
- Adds `__all__` to `movement/__init__.py` to formally document the public API surface
- Adds `tests/test_unit/test_top_level_imports.py` with 4 tests that verify:
  - `load_dataset` is importable directly from `movement`
  - `load_multiview_dataset` is importable directly from `movement`
  - The top-level `load_dataset` is the exact same object as `movement.io.load.load_dataset` (no wrapping or copying)
  - The top-level `load_multiview_dataset` is the exact same object as `movement.io.load.load_multiview_dataset`

## References

Closes #361

## How has this PR been tested?

A new test file `tests/test_unit/test_top_level_imports.py` was added. It tests both importability and object identity (i.e., the re-exported functions are the same objects as their source, not copies or wrappers), ensuring no indirection was introduced. No existing tests were modified, and no existing functionality was changed — this PR only adds re-exports.

## Is this a breaking change?

No. This PR is purely additive. The functions remain available at their original `movement.io.load` path; this PR only adds an additional, more convenient import path.

## Does this PR require an update to the documentation?

The `__all__` list in `movement/__init__.py` signals to documentation generators that `load_dataset` and `load_multiview_dataset` are part of the public API. If `movement`'s top-level module is listed in `docs/make_api.py` under `PACKAGE_MODULES`, these functions will appear automatically in the API reference. No manual documentation changes are required beyond verifying the API docs build correctly.

## Checklist

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
