### PR TITLE
fix: replace .roll() with .shift() in compute_backward_displacement

### DIFF
--- a/movement/kinematics/kinematics.py
+++ b/movement/kinematics/kinematics.py
@@ -212,7 +212,7 @@ def compute_backward_displacement(data: xr.DataArray) -> xr.DataArray:
 
     """
     fwd_displacement = _compute_forward_displacement(data)
-    backward_displacement = -fwd_displacement.roll(time=1)
+    backward_displacement = -fwd_displacement.shift(time=1, fill_value=0)
     backward_displacement.name = "backward_displacement"
     return backward_displacement
 


### PR DESCRIPTION
Currently, compute_backward_displacement uses .roll(time=1). This causes the last frame's position to "wrap around" and affect the first frame's displacement calculation. In a real trajectory, the first frame shouldn't have a backward displacement from the last frame—it should be 0.