### PR TITLE
feat(io): add MMPose I/O support (#175)

### DIFF
--- a/examples/load_mmpose.py
+++ b/examples/load_mmpose.py
@@ -1,0 +1,52 @@
+import json
+from pathlib import Path
+from movement.io.load_poses import from_mmpose_file
+
+# Create a sample MMPose file
+sample_data = [
+    {
+        "frame_id": 0,
+        "instances": [
+            {
+                "keypoints": [[100.0, 200.0], [150.0, 250.0]],
+                "keypoint_scores": [0.95, 0.88],
+                "bbox": [50, 50, 200, 300],
+                "bbox_score": 0.92,
+                "track_id": 1
+            }
+        ]
+    },
+    {
+        "frame_id": 1,
+        "instances": [
+            {
+                "keypoints": [[102.0, 205.0], [155.0, 255.0]],
+                "keypoint_scores": [0.94, 0.89],
+                "bbox": [52, 55, 205, 305],
+                "bbox_score": 0.91,
+                "track_id": 1
+            }
+        ]
+    }
+]
+
+file_path = Path("mmpose_example.json")
+with open(file_path, "w") as f:
+    json.dump(sample_data, f)
+
+print(f"Created sample MMPose file: {file_path}")
+
+# Load the data
+print("Loading MMPose file...")
+ds = from_mmpose_file(file_path, fps=30)
+
+# Display the dataset
+print("\nMovement Dataset Representation:")
+print(ds)
+
+print("\nPosition data (first two frames):")
+print(ds.position.values[:2])
+
+# Clean up
+file_path.unlink()
+print(f"\nCleaned up sample file: {file_path}")

--- a/movement/io/load.py
+++ b/movement/io/load.py
@@ -29,6 +29,7 @@ SourceSoftware: TypeAlias = Literal[
     "Anipose",
     "NWB",
     "VIA-tracks",
+    "MMPose",
 ]
 
 

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -897,103 +897,61 @@ def from_mmpose_file(file: str | Path, fps: float | None = None) -> xr.Dataset:
     ----------
     file
         Path to the JSON file containing MMPose predictions.
-        The file can contain a single frame dictionary or a list of
-        frame dictionaries.
     fps
-        The number of frames per second in the video. If None (default),
-        the ``time`` coordinates will be in frame numbers.
+        The number of frames per second in the video.
 
     Returns
     -------
     xarray.Dataset
-        ``movement`` dataset containing the pose tracks, confidence scores,
-        and associated metadata.
-
-    Examples
-    --------
-    >>> from movement.io import load_poses
-    >>> ds = load_poses.from_mmpose_file("path/to/file.json", fps=30)
+        ``movement`` dataset containing the pose tracks and metadata.
 
     """
     import json
 
     valid_file = cast("ValidFile", file)
-    file_path = valid_file.file
-    with open(file_path) as f:
+    with open(valid_file.file) as f:
         data = json.load(f)
 
-    # Ensure data is a list of frame dictionaries
     if isinstance(data, dict):
         data = [data]
-
-    # Sort frames by frame_id to ensure chronological order
     data.sort(key=lambda x: x["frame_id"])
 
-    # Extract unique keypoint names (assumed consistent across frames/instances)
-    # MMPose JSON doesn't explicitly store keypoint names.
-    # We will use default names "keypoint_0", "keypoint_1", etc.
-    # unless we can find a way to infer them.
-    # For now, let's determine the number of keypoints from the first instance.
-    n_keypoints = 0
-    if data and data[0]["instances"]:
-        n_keypoints = len(data[0]["instances"][0]["keypoints"])
-
-    # Determine individuals (instances)
-    # If track_id is present, use it. Otherwise use instance index.
-    track_ids = set()
-    for frame in data:
-        for inst in frame["instances"]:
-            track_ids.add(inst.get("track_id", None))
-
+    # Determine individual names
+    track_ids = {
+        inst.get("track_id") for frame in data for inst in frame["instances"]
+    }
     if None in track_ids:
-        # If any instance lacks a track_id, we fall back to using instance
-        # indices as identifiers, assuming the number of individuals is
-        # the maximum number of instances in any single frame.
-        max_instances = max(len(frame["instances"]) for frame in data)
-        individual_names = [f"id_{i}" for i in range(max_instances)]
+        n_ind = max(len(frame["instances"]) for frame in data)
+        individual_names = [f"id_{i}" for i in range(n_ind)]
     else:
-        # Use track_ids as individual names
         individual_names = [f"track_{tid}" for tid in sorted(list(track_ids))]
 
-    n_frames = len(data)
-    n_individuals = len(individual_names)
-    n_space = 2  # MMPose 2D keypoints
-
-    # Initialize arrays
-    position_array = np.full(
-        (n_frames, n_space, n_keypoints, n_individuals), np.nan
+    # Determine keypoints and initialize arrays
+    n_kpts = (
+        len(data[0]["instances"][0]["keypoints"])
+        if data and data[0]["instances"]
+        else 0
     )
-    confidence_array = np.full((n_frames, n_keypoints, n_individuals), np.nan)
+    n_frames, n_ind = len(data), len(individual_names)
 
-    frame_id_to_idx = {frame["frame_id"]: i for i, frame in enumerate(data)}
+    pos = np.full((n_frames, 2, n_kpts, n_ind), np.nan, dtype="float32")
+    conf = np.full((n_frames, n_kpts, n_ind), np.nan, dtype="float32")
 
     for i, frame in enumerate(data):
         for j, inst in enumerate(frame["instances"]):
-            # Determine individual index
-            if "track_id" in inst:
-                ind_idx = individual_names.index(f"track_{inst['track_id']}")
-            else:
-                ind_idx = j
+            tid = inst.get("track_id")
+            idx = (
+                individual_names.index(f"track_{tid}")
+                if tid is not None
+                else j
+            )
+            if idx < n_ind:
+                pos[i, ..., idx] = np.array(inst["keypoints"]).T
+                conf[i, ..., idx] = inst["keypoint_scores"]
 
-            if ind_idx < n_individuals:
-                # Extract keypoints (n_keypoints, 2)
-                kp = np.array(inst["keypoints"])
-                # Extract scores (n_keypoints,)
-                scores = np.array(inst["keypoint_scores"])
-
-                position_array[i, :, :, ind_idx] = kp.T
-                confidence_array[i, :, ind_idx] = scores
-
-    ds = from_numpy(
-        position_array=position_array.astype(np.float32),
-        confidence_array=confidence_array.astype(np.float32),
-        individual_names=individual_names,
-        keypoint_names=None,  # Will default to keypoint_0, keypoint_1, etc.
-        fps=fps,
-        source_software="MMPose",
-    )
-    ds.attrs["source_file"] = file_path.as_posix()
-    logger.info(f"Loaded pose tracks from {file_path}:\n{ds}")
+    ds = from_numpy(pos, conf, individual_names, None, fps, "MMPose")
+    ds.attrs["source_file"] = valid_file.file.as_posix()
+    logger.info(f"Loaded {n_frames} frames from {valid_file.file}")
     return ds
 
 

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -23,6 +23,7 @@ from movement.validators.files import (
     ValidNWBFile,
     ValidSleapAnalysis,
     ValidSleapLabels,
+    ValidMMPoseJSON,
 )
 
 
@@ -885,6 +886,114 @@ def from_nwb_file(
             processing_module_key,
             pose_estimation_key,
         )
+    return ds
+
+
+@register_loader("MMPose", file_validators=[ValidMMPoseJSON])
+def from_mmpose_file(file: str | Path, fps: float | None = None) -> xr.Dataset:
+    """Create a ``movement`` poses dataset from an MMPose JSON file.
+
+    Parameters
+    ----------
+    file
+        Path to the JSON file containing MMPose predictions.
+        The file can contain a single frame dictionary or a list of
+        frame dictionaries.
+    fps
+        The number of frames per second in the video. If None (default),
+        the ``time`` coordinates will be in frame numbers.
+
+    Returns
+    -------
+    xarray.Dataset
+        ``movement`` dataset containing the pose tracks, confidence scores,
+        and associated metadata.
+
+    Examples
+    --------
+    >>> from movement.io import load_poses
+    >>> ds = load_poses.from_mmpose_file("path/to/file.json", fps=30)
+
+    """
+    import json
+
+    valid_file = cast("ValidFile", file)
+    file_path = valid_file.file
+    with open(file_path) as f:
+        data = json.load(f)
+
+    # Ensure data is a list of frame dictionaries
+    if isinstance(data, dict):
+        data = [data]
+
+    # Sort frames by frame_id to ensure chronological order
+    data.sort(key=lambda x: x["frame_id"])
+
+    # Extract unique keypoint names (assumed consistent across frames/instances)
+    # MMPose JSON doesn't explicitly store keypoint names.
+    # We will use default names "keypoint_0", "keypoint_1", etc.
+    # unless we can find a way to infer them.
+    # For now, let's determine the number of keypoints from the first instance.
+    n_keypoints = 0
+    if data and data[0]["instances"]:
+        n_keypoints = len(data[0]["instances"][0]["keypoints"])
+
+    # Determine individuals (instances)
+    # If track_id is present, use it. Otherwise use instance index.
+    track_ids = set()
+    for frame in data:
+        for inst in frame["instances"]:
+            track_ids.add(inst.get("track_id", None))
+
+    if None in track_ids:
+        # If any instance lacks a track_id, we fall back to using instance
+        # indices as identifiers, assuming the number of individuals is
+        # the maximum number of instances in any single frame.
+        max_instances = max(len(frame["instances"]) for frame in data)
+        individual_names = [f"id_{i}" for i in range(max_instances)]
+    else:
+        # Use track_ids as individual names
+        individual_names = [f"track_{tid}" for tid in sorted(list(track_ids))]
+
+    n_frames = len(data)
+    n_individuals = len(individual_names)
+    n_space = 2  # MMPose 2D keypoints
+
+    # Initialize arrays
+    position_array = np.full(
+        (n_frames, n_space, n_keypoints, n_individuals), np.nan
+    )
+    confidence_array = np.full((n_frames, n_keypoints, n_individuals), np.nan)
+
+    frame_id_to_idx = {frame["frame_id"]: i for i, frame in enumerate(data)}
+
+    for i, frame in enumerate(data):
+        for j, inst in enumerate(frame["instances"]):
+            # Determine individual index
+            if "track_id" in inst:
+                ind_idx = individual_names.index(f"track_{inst['track_id']}")
+            else:
+                ind_idx = j
+
+            if ind_idx < n_individuals:
+                # Extract keypoints (n_keypoints, 2)
+                kp = np.array(inst["keypoints"])
+                # Extract scores (n_keypoints,)
+                scores = np.array(inst["keypoint_scores"])
+
+                position_array[i, :, :, ind_idx] = kp.T
+                confidence_array[i, :, ind_idx] = scores
+
+    ds = from_numpy(
+        position_array=position_array.astype(np.float32),
+        confidence_array=confidence_array.astype(np.float32),
+        individual_names=individual_names,
+        keypoint_names=None,  # Will default to keypoint_0, keypoint_1, etc.
+        fps=fps,
+        source_software="MMPose",
+    )
+    ds.attrs["source_file"] = file_path.as_posix()
+    logger.info(f"Loaded pose tracks from {file_path}:\n{ds}")
     return ds
 
 

--- a/movement/validators/_json_schemas.py
+++ b/movement/validators/_json_schemas.py
@@ -65,89 +65,50 @@ ROI_COLLECTION_SCHEMA: Mapping[str, Any] = {
 }
 
 # JSON schema for validating MMPose output JSON files.
+_MMPOSE_FRAME_SCHEMA: Mapping[str, Any] = {
+    "type": "object",
+    "required": ["frame_id", "instances"],
+    "properties": {
+        "frame_id": {"type": "integer"},
+        "instances": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["keypoints", "keypoint_scores"],
+                "properties": {
+                    "keypoints": {
+                        "type": "array",
+                        "items": {
+                            "type": "array",
+                            "items": {"type": "number"},
+                            "minItems": 2,
+                            "maxItems": 2,
+                        },
+                    },
+                    "keypoint_scores": {
+                        "type": "array",
+                        "items": {"type": "number"},
+                    },
+                    "bbox": {
+                        "type": "array",
+                        "items": {"type": "number"},
+                        "minItems": 4,
+                        "maxItems": 4,
+                    },
+                    "bbox_score": {"type": "number"},
+                    "track_id": {"type": "integer"},
+                },
+            },
+        },
+    },
+}
+
 MMPOSE_SCHEMA: Mapping[str, Any] = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "MMPose Output",
     "description": "Schema for validating MMPose output JSON files",
     "oneOf": [
-        # Single frame object
-        {
-            "type": "object",
-            "required": ["frame_id", "instances"],
-            "properties": {
-                "frame_id": {"type": "integer"},
-                "instances": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "required": ["keypoints", "keypoint_scores"],
-                        "properties": {
-                            "keypoints": {
-                                "type": "array",
-                                "items": {
-                                    "type": "array",
-                                    "items": {"type": "number"},
-                                    "minItems": 2,
-                                    "maxItems": 2,
-                                },
-                            },
-                            "keypoint_scores": {
-                                "type": "array",
-                                "items": {"type": "number"},
-                            },
-                            "bbox": {
-                                "type": "array",
-                                "items": {"type": "number"},
-                                "minItems": 4,
-                                "maxItems": 4,
-                            },
-                            "bbox_score": {"type": "number"},
-                            "track_id": {"type": "integer"},
-                        },
-                    },
-                },
-            },
-        },
-        # Array of frame objects
-        {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "required": ["frame_id", "instances"],
-                "properties": {
-                    "frame_id": {"type": "integer"},
-                    "instances": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "required": ["keypoints", "keypoint_scores"],
-                            "properties": {
-                                "keypoints": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "array",
-                                        "items": {"type": "number"},
-                                        "minItems": 2,
-                                        "maxItems": 2,
-                                    },
-                                },
-                                "keypoint_scores": {
-                                    "type": "array",
-                                    "items": {"type": "number"},
-                                },
-                                "bbox": {
-                                    "type": "array",
-                                    "items": {"type": "number"},
-                                    "minItems": 4,
-                                    "maxItems": 4,
-                                },
-                                "bbox_score": {"type": "number"},
-                                "track_id": {"type": "integer"},
-                            },
-                        },
-                    },
-                },
-            },
-        },
+        _MMPOSE_FRAME_SCHEMA,
+        {"type": "array", "items": _MMPOSE_FRAME_SCHEMA},
     ],
 }

--- a/movement/validators/_json_schemas.py
+++ b/movement/validators/_json_schemas.py
@@ -63,3 +63,91 @@ ROI_COLLECTION_SCHEMA: Mapping[str, Any] = {
         },
     },
 }
+
+# JSON schema for validating MMPose output JSON files.
+MMPOSE_SCHEMA: Mapping[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "MMPose Output",
+    "description": "Schema for validating MMPose output JSON files",
+    "oneOf": [
+        # Single frame object
+        {
+            "type": "object",
+            "required": ["frame_id", "instances"],
+            "properties": {
+                "frame_id": {"type": "integer"},
+                "instances": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["keypoints", "keypoint_scores"],
+                        "properties": {
+                            "keypoints": {
+                                "type": "array",
+                                "items": {
+                                    "type": "array",
+                                    "items": {"type": "number"},
+                                    "minItems": 2,
+                                    "maxItems": 2,
+                                },
+                            },
+                            "keypoint_scores": {
+                                "type": "array",
+                                "items": {"type": "number"},
+                            },
+                            "bbox": {
+                                "type": "array",
+                                "items": {"type": "number"},
+                                "minItems": 4,
+                                "maxItems": 4,
+                            },
+                            "bbox_score": {"type": "number"},
+                            "track_id": {"type": "integer"},
+                        },
+                    },
+                },
+            },
+        },
+        # Array of frame objects
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["frame_id", "instances"],
+                "properties": {
+                    "frame_id": {"type": "integer"},
+                    "instances": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["keypoints", "keypoint_scores"],
+                            "properties": {
+                                "keypoints": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "array",
+                                        "items": {"type": "number"},
+                                        "minItems": 2,
+                                        "maxItems": 2,
+                                    },
+                                },
+                                "keypoint_scores": {
+                                    "type": "array",
+                                    "items": {"type": "number"},
+                                },
+                                "bbox": {
+                                    "type": "array",
+                                    "items": {"type": "number"},
+                                    "minItems": 4,
+                                    "maxItems": 4,
+                                },
+                                "bbox_score": {"type": "number"},
+                                "track_id": {"type": "integer"},
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    ],
+}

--- a/movement/validators/files.py
+++ b/movement/validators/files.py
@@ -16,6 +16,7 @@ from pynwb import NWBFile
 
 from movement.utils.logging import logger
 from movement.validators._json_schemas import (
+    MMPOSE_SCHEMA,
     ROI_COLLECTION_SCHEMA,
     ROI_TYPE_TO_GEOMETRY,
 )
@@ -922,3 +923,17 @@ class ValidROICollectionGeoJSON:
         ),
     )
     data: dict = field(init=False, factory=dict)
+
+
+@define
+class ValidMMPoseJSON:
+    """Class for validating MMPose output JSON files."""
+
+    suffixes: ClassVar[set[str]] = {".json"}
+    file: Path = field(
+        converter=Path,
+        validator=validators.and_(
+            _file_validator(permission="r", suffixes=suffixes),
+            _json_validator(schema=MMPOSE_SCHEMA),
+        ),
+    )

--- a/tests/test_io/test_load_mmpose.py
+++ b/tests/test_io/test_load_mmpose.py
@@ -2,106 +2,73 @@ import json
 import pytest
 import numpy as np
 import xarray as xr
-from pathlib import Path
 from movement.io.load_poses import from_mmpose_file
 
-def test_load_mmpose_single_frame(tmp_path):
-    data = {
-        "frame_id": 0,
-        "instances": [
-            {
-                "keypoints": [[10.0, 20.0], [30.0, 40.0]],
-                "keypoint_scores": [0.9, 0.8],
-                "bbox": [5, 5, 50, 50],
-                "bbox_score": 0.95
-            }
-        ]
+def create_mmpose_json(filepath, frames_data):
+    """Helper to create an MMPose JSON file."""
+    with open(filepath, "w") as f:
+        json.dump(frames_data, f)
+
+def get_sample_instance(keypoints=None, scores=None, track_id=None):
+    """Helper to create a sample instance dictionary."""
+    return {
+        "keypoints": keypoints or [[10.0, 20.0], [30.0, 40.0]],
+        "keypoint_scores": scores or [0.9, 0.8],
+        "bbox": [5, 5, 50, 50],
+        "bbox_score": 0.95,
+        "track_id": track_id
     }
+
+def test_load_mmpose_single_frame(tmp_path):
     file_path = tmp_path / "mmpose_single.json"
-    with open(file_path, "w") as f:
-        json.dump(data, f)
+    data = {"frame_id": 0, "instances": [get_sample_instance()]}
+    create_mmpose_json(file_path, data)
     
     ds = from_mmpose_file(file_path)
     assert isinstance(ds, xr.Dataset)
-    assert ds.attrs["source_software"] == "MMPose"
-    assert ds.position.shape == (1, 2, 2, 1)  # (time, space, keypoints, individuals)
+    assert ds.position.shape == (1, 2, 2, 1)
     assert np.allclose(ds.position.values[0, :, 0, 0], [10.0, 20.0])
-    assert np.allclose(ds.confidence.values[0, 0, 0], 0.9)
 
 def test_load_mmpose_multi_frame(tmp_path):
-    data = [
-        {
-            "frame_id": 1,
-            "instances": [
-                {
-                    "keypoints": [[11.0, 21.0], [31.0, 41.0]],
-                    "keypoint_scores": [0.91, 0.81],
-                    "track_id": 1
-                }
-            ]
-        },
-        {
-            "frame_id": 0,
-            "instances": [
-                {
-                    "keypoints": [[10.0, 20.0], [30.0, 40.0]],
-                    "keypoint_scores": [0.9, 0.8],
-                    "track_id": 1
-                }
-            ]
-        }
-    ]
     file_path = tmp_path / "mmpose_multi.json"
-    with open(file_path, "w") as f:
-        json.dump(data, f)
+    data = [
+        {"frame_id": 1, "instances": [get_sample_instance(keypoints=[[11, 21], [31, 41]], track_id=1)]},
+        {"frame_id": 0, "instances": [get_sample_instance(track_id=1)]}
+    ]
+    create_mmpose_json(file_path, data)
     
     ds = from_mmpose_file(file_path)
     assert ds.position.shape == (2, 2, 2, 1)
-    # Check sorting by frame_id
     assert np.allclose(ds.position.values[0, :, 0, 0], [10.0, 20.0])
     assert np.allclose(ds.position.values[1, :, 0, 0], [11.0, 21.0])
-    assert "track_1" in ds.individuals.values
 
 def test_load_mmpose_multi_individual(tmp_path):
+    file_path = tmp_path / "mmpose_multi_ind.json"
     data = {
         "frame_id": 0,
         "instances": [
-            {
-                "keypoints": [[10.0, 20.0], [30.0, 40.0]],
-                "keypoint_scores": [0.9, 0.8],
-                "track_id": 1
-            },
-            {
-                "keypoints": [[100.0, 200.0], [300.0, 400.0]],
-                "keypoint_scores": [0.7, 0.6],
-                "track_id": 2
-            }
+            get_sample_instance(track_id=1),
+            get_sample_instance(keypoints=[[100, 200], [300, 400]], track_id=2)
         ]
     }
-    file_path = tmp_path / "mmpose_multi_ind.json"
-    with open(file_path, "w") as f:
-        json.dump(data, f)
+    create_mmpose_json(file_path, data)
     
     ds = from_mmpose_file(file_path)
     assert ds.position.shape == (1, 2, 2, 2)
     assert "track_1" in ds.individuals.values
     assert "track_2" in ds.individuals.values
-    assert np.allclose(ds.position.values[0, :, 0, 0], [10.0, 20.0])
-    assert np.allclose(ds.position.values[0, :, 0, 1], [100.0, 200.0])
 
-def test_load_mmpose_invalid_json(tmp_path):
-    file_path = tmp_path / "invalid.json"
+@pytest.mark.parametrize("invalid_content, match", [
+    ("invalid json", "is not valid JSON"),
+    ({"frame_id": 0}, "does not match schema")
+])
+def test_load_mmpose_errors(tmp_path, invalid_content, match):
+    file_path = tmp_path / "error.json"
     with open(file_path, "w") as f:
-        f.write("invalid json")
+        if isinstance(invalid_content, str):
+            f.write(invalid_content)
+        else:
+            json.dump(invalid_content, f)
     
-    with pytest.raises(ValueError, match="is not valid JSON"):
-        from_mmpose_file(file_path)
-
-def test_load_mmpose_schema_mismatch(tmp_path):
-    data = {"frame_id": 0}  # Missing instances
-    file_path = tmp_path / "mismatch.json"
-    with open(file_path, "w") as f:
-        json.dump(data, f)
-    
-    with pytest.raises(ValueError, match="does not match schema"):
+    with pytest.raises(ValueError, match=match):
         from_mmpose_file(file_path)

--- a/tests/test_io/test_load_mmpose.py
+++ b/tests/test_io/test_load_mmpose.py
@@ -1,0 +1,107 @@
+import json
+import pytest
+import numpy as np
+import xarray as xr
+from pathlib import Path
+from movement.io.load_poses import from_mmpose_file
+
+def test_load_mmpose_single_frame(tmp_path):
+    data = {
+        "frame_id": 0,
+        "instances": [
+            {
+                "keypoints": [[10.0, 20.0], [30.0, 40.0]],
+                "keypoint_scores": [0.9, 0.8],
+                "bbox": [5, 5, 50, 50],
+                "bbox_score": 0.95
+            }
+        ]
+    }
+    file_path = tmp_path / "mmpose_single.json"
+    with open(file_path, "w") as f:
+        json.dump(data, f)
+    
+    ds = from_mmpose_file(file_path)
+    assert isinstance(ds, xr.Dataset)
+    assert ds.attrs["source_software"] == "MMPose"
+    assert ds.position.shape == (1, 2, 2, 1)  # (time, space, keypoints, individuals)
+    assert np.allclose(ds.position.values[0, :, 0, 0], [10.0, 20.0])
+    assert np.allclose(ds.confidence.values[0, 0, 0], 0.9)
+
+def test_load_mmpose_multi_frame(tmp_path):
+    data = [
+        {
+            "frame_id": 1,
+            "instances": [
+                {
+                    "keypoints": [[11.0, 21.0], [31.0, 41.0]],
+                    "keypoint_scores": [0.91, 0.81],
+                    "track_id": 1
+                }
+            ]
+        },
+        {
+            "frame_id": 0,
+            "instances": [
+                {
+                    "keypoints": [[10.0, 20.0], [30.0, 40.0]],
+                    "keypoint_scores": [0.9, 0.8],
+                    "track_id": 1
+                }
+            ]
+        }
+    ]
+    file_path = tmp_path / "mmpose_multi.json"
+    with open(file_path, "w") as f:
+        json.dump(data, f)
+    
+    ds = from_mmpose_file(file_path)
+    assert ds.position.shape == (2, 2, 2, 1)
+    # Check sorting by frame_id
+    assert np.allclose(ds.position.values[0, :, 0, 0], [10.0, 20.0])
+    assert np.allclose(ds.position.values[1, :, 0, 0], [11.0, 21.0])
+    assert "track_1" in ds.individuals.values
+
+def test_load_mmpose_multi_individual(tmp_path):
+    data = {
+        "frame_id": 0,
+        "instances": [
+            {
+                "keypoints": [[10.0, 20.0], [30.0, 40.0]],
+                "keypoint_scores": [0.9, 0.8],
+                "track_id": 1
+            },
+            {
+                "keypoints": [[100.0, 200.0], [300.0, 400.0]],
+                "keypoint_scores": [0.7, 0.6],
+                "track_id": 2
+            }
+        ]
+    }
+    file_path = tmp_path / "mmpose_multi_ind.json"
+    with open(file_path, "w") as f:
+        json.dump(data, f)
+    
+    ds = from_mmpose_file(file_path)
+    assert ds.position.shape == (1, 2, 2, 2)
+    assert "track_1" in ds.individuals.values
+    assert "track_2" in ds.individuals.values
+    assert np.allclose(ds.position.values[0, :, 0, 0], [10.0, 20.0])
+    assert np.allclose(ds.position.values[0, :, 0, 1], [100.0, 200.0])
+
+def test_load_mmpose_invalid_json(tmp_path):
+    file_path = tmp_path / "invalid.json"
+    with open(file_path, "w") as f:
+        f.write("invalid json")
+    
+    with pytest.raises(ValueError, match="is not valid JSON"):
+        from_mmpose_file(file_path)
+
+def test_load_mmpose_schema_mismatch(tmp_path):
+    data = {"frame_id": 0}  # Missing instances
+    file_path = tmp_path / "mismatch.json"
+    with open(file_path, "w") as f:
+        json.dump(data, f)
+    
+    with pytest.raises(ValueError, match="does not match schema"):
+        from_mmpose_file(file_path)


### PR DESCRIPTION
This PR adds support for loading pose estimation outputs generated by MMPose.

Features:
- Implements from_mmpose_file loader
- Parses frame_id, keypoints, and keypoint_scores
- Supports single-frame and multi-frame JSON formats
- Handles missing tracking IDs
- Adds JSON schema validation for MMPose JSON files
- Includes tests and example script

Closes #175

I would appreciate feedback from the maintainers.