### PR TITLE
fix: preserve NaNs in displacement reindexing

### DIFF
--- a/movement/kinematics/kinematics.py
+++ b/movement/kinematics/kinematics.py
@@ -127,7 +127,7 @@ def _compute_forward_displacement(data: xr.DataArray) -> xr.DataArray:
     validate_dims_coords(data, {"time": [], "space": []})
     result = data.diff(dim="time", label="lower")
     result = result.reindex_like(data)
-    
+
     return result
 
 


### PR DESCRIPTION
I noticed that using fill_value=0 in reindex_like() was masking tracking gaps. This makes it impossible for the 'scale' nan_policy to work correctly because it can't tell the difference between a missing frame and a stationary one. Removed it to keep the NaNs intact.