### PR TITLE
fix: remove deprecated `from_file` and `from_multiview_files` (#812)

### DIFF
--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -2,7 +2,6 @@
 
 import ast
 import re
-import warnings
 from collections.abc import Callable
 from pathlib import Path
 from typing import Literal, cast
@@ -148,102 +147,6 @@ def from_numpy(
         source_software=source_software,
     )
     return valid_bboxes_inputs.to_dataset()
-
-
-def from_file(
-    file: Path | str,
-    source_software: Literal["VIA-tracks"],
-    fps: float | None = None,
-    use_frame_numbers_from_file: bool = False,
-    frame_regexp: str = DEFAULT_FRAME_REGEXP,
-) -> xr.Dataset:
-    """Create a ``movement`` bounding boxes dataset from a supported file.
-
-    .. deprecated:: 0.14.0
-        This function is deprecated and will be removed in a future release.
-        Use :func:`movement.io.load_dataset<movement.io.load.load_dataset>`
-        instead.
-
-    At the moment, we only support VIA tracks .csv files.
-
-    Parameters
-    ----------
-    file
-        Path to the file containing the tracked bounding boxes. Currently
-        only VIA tracks .csv files are supported.
-    source_software
-        The source software of the file. Currently only files from the
-        VIA 2.0.12 annotator [1]_ ("VIA-tracks") are supported.
-        See .
-    fps
-        The video sampling rate. If None (default), the ``time`` coordinates
-        of the resulting ``movement`` dataset will be in frame numbers. If
-        ``fps`` is provided, the ``time`` coordinates  will be in seconds. If
-        the ``time`` coordinates are in seconds, they will indicate the
-        elapsed time from the capture of the first frame (assumed to be frame
-        0).
-    use_frame_numbers_from_file
-        If True, the frame numbers in the resulting dataset are
-        the same as the ones specified for each tracked bounding box in the
-        input file. This may be useful if the bounding boxes are tracked for a
-        subset of frames in a video, but you want to maintain the start of the
-        full video as the time origin. If False (default), the frame numbers
-        in the VIA tracks .csv file are instead mapped to a 0-based sequence of
-        consecutive integers.
-    frame_regexp
-        Regular expression pattern to extract the frame number from the frame
-        filename. By default, the frame number is expected to be encoded in
-        the filename as an integer number led by at least one zero, followed
-        by the file extension. Only used if ``use_frame_numbers_from_file`` is
-        True.
-
-
-    Returns
-    -------
-    xarray.Dataset
-        ``movement`` dataset containing the position, shape, and confidence
-        scores of the tracked bounding boxes, and any associated metadata.
-
-    See Also
-    --------
-    movement.io.load_bboxes.from_via_tracks_file
-
-    References
-    ----------
-    .. [1] https://www.robots.ox.ac.uk/~vgg/software/via/
-
-    Examples
-    --------
-    Create a dataset from the VIA tracks .csv file at "path/to/file.csv", with
-    the time coordinates in seconds, and assuming t = 0 seconds corresponds to
-    the first tracked frame in the file.
-
-    >>> from movement.io import load_bboxes
-    >>> ds = load_bboxes.from_file(
-    >>>     "path/to/file.csv",
-    >>>     source_software="VIA-tracks",
-    >>>     fps=30,
-    >>> )
-
-    """
-    warnings.warn(
-        "The function `movement.io.load_bboxes.from_file` is deprecated"
-        " and will be removed in a future release. "
-        "Please use `movement.io.load_dataset` instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    if source_software == "VIA-tracks":
-        return from_via_tracks_file(
-            file,
-            fps,
-            use_frame_numbers_from_file=use_frame_numbers_from_file,
-            frame_regexp=frame_regexp,
-        )
-    else:
-        raise logger.error(
-            ValueError(f"Unsupported source software: {source_software}")
-        )
 
 
 @register_loader("VIA-tracks", file_validators=[ValidVIATracksCSV])

--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -4,7 +4,7 @@ import ast
 import re
 from collections.abc import Callable
 from pathlib import Path
-from typing import Literal, cast
+from typing import cast
 
 import numpy as np
 import pandas as pd

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -1,6 +1,5 @@
 """Load pose tracking data from various frameworks into ``movement``."""
 
-import warnings
 from pathlib import Path
 from typing import Literal, cast
 
@@ -95,97 +94,6 @@ def from_numpy(
         source_software=source_software,
     )
     return valid_poses_inputs.to_dataset()
-
-
-def from_file(
-    file: Path | str,
-    source_software: Literal[
-        "DeepLabCut",
-        "SLEAP",
-        "LightningPose",
-        "Anipose",
-        "NWB",
-    ],
-    fps: float | None = None,
-    **kwargs,
-) -> xr.Dataset:
-    """Create a ``movement`` poses dataset from any supported file.
-
-    .. deprecated:: 0.14.0
-        This function is deprecated and will be removed in a future release.
-        Use :func:`movement.io.load_dataset<movement.io.load.load_dataset>`
-        instead.
-
-    Parameters
-    ----------
-    file
-        Path to the file containing predicted poses. The file format must
-        be among those supported by the ``from_dlc_file()``,
-        ``from_slp_file()`` or ``from_lp_file()`` functions. One of these
-        these functions will be called internally, based on
-        the value of ``source_software``.
-    source_software
-        The source software of the file.
-    fps
-        The number of frames per second in the video. If None (default),
-        the ``time`` coordinates will be in frame numbers.
-        This argument is ignored when ``source_software`` is "NWB", as the
-        frame rate will be directly read or estimated from metadata in
-        the NWB file.
-    **kwargs
-        Additional keyword arguments to pass to the software-specific
-        loading functions that are listed under "See Also".
-
-    Returns
-    -------
-    xarray.Dataset
-        ``movement`` dataset containing the pose tracks, confidence scores,
-        and associated metadata.
-
-
-    See Also
-    --------
-    movement.io.load_poses.from_dlc_file
-    movement.io.load_poses.from_sleap_file
-    movement.io.load_poses.from_lp_file
-    movement.io.load_poses.from_anipose_file
-    movement.io.load_poses.from_nwb_file
-
-    Examples
-    --------
-    >>> from movement.io import load_poses
-    >>> ds = load_poses.from_file(
-    ...     "path/to/file.h5", source_software="DeepLabCut", fps=30
-    ... )
-
-    """
-    warnings.warn(
-        "The function `movement.io.load_poses.from_file` is deprecated"
-        " and will be removed in a future release. "
-        "Please use `movement.io.load_dataset` instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    if source_software == "DeepLabCut":
-        return from_dlc_file(file, fps)
-    elif source_software == "SLEAP":
-        return from_sleap_file(file, fps)
-    elif source_software == "LightningPose":
-        return from_lp_file(file, fps)
-    elif source_software == "Anipose":
-        return from_anipose_file(file, fps, **kwargs)
-    elif source_software == "NWB":
-        if fps is not None:
-            logger.warning(
-                "The fps argument is ignored when loading from an NWB file. "
-                "The frame rate will be directly read or estimated from "
-                "metadata in the file."
-            )
-        return from_nwb_file(file, **kwargs)
-    else:
-        raise logger.error(
-            ValueError(f"Unsupported source software: {source_software}")
-        )
 
 
 def from_dlc_style_df(
@@ -425,51 +333,6 @@ def from_dlc_file(file: str | Path, fps: float | None = None) -> xr.Dataset:
         source_software="DeepLabCut",
         fps=fps,
     )
-
-
-def from_multiview_files(
-    file_dict: dict[str, Path | str],
-    source_software: Literal["DeepLabCut", "SLEAP", "LightningPose"],
-    fps: float | None = None,
-) -> xr.Dataset:
-    """Load and merge pose tracking data from multiple views (cameras).
-
-    .. deprecated:: 0.14.0
-        This function is deprecated and will be removed in a future release.
-        Use :func:`movement.io.load_multiview_dataset<movement.io.\
-        load.load_multiview_dataset>` instead.
-
-    Parameters
-    ----------
-    file_dict
-        A dict whose keys are the view names and values are the paths to load.
-    source_software
-        The source software of the file.
-    fps
-        The number of frames per second in the video. If None (default),
-        the ``time`` coordinates will be in frame numbers.
-
-    Returns
-    -------
-    xarray.Dataset
-        ``movement`` dataset containing the pose tracks, confidence scores,
-        and associated metadata, with an additional ``views`` dimension.
-
-    """
-    warnings.warn(
-        "The function `movement.io.load_poses.from_multiview_files` is "
-        "deprecated and will be removed in a future release. "
-        "Please use `movement.io.load_multiview_dataset` instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    views_list = list(file_dict.keys())
-    new_coord_views = xr.DataArray(views_list, dims="view")
-    dataset_list = [
-        from_file(f, source_software=source_software, fps=fps)
-        for f in file_dict.values()
-    ]
-    return xr.concat(dataset_list, dim=new_coord_views)
 
 
 def _ds_from_lp_or_dlc_file(

--- a/tests/test_unit/test_deprecations.py
+++ b/tests/test_unit/test_deprecations.py
@@ -1,11 +1,9 @@
 from contextlib import nullcontext
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
-import xarray as xr
 
 import movement.kinematics as kinematics
-from movement.io import load_bboxes, load_poses
 
 
 @pytest.mark.parametrize(
@@ -16,36 +14,6 @@ from movement.io import load_bboxes, load_poses
             {"data": MagicMock(dims=["time", "space"])},
             nullcontext(),
             ["compute_forward_displacement", "compute_backward_displacement"],
-        ),
-        (
-            load_poses.from_file,
-            {"file": "dummy_path", "source_software": "SLEAP"},
-            patch(
-                "movement.io.load_poses.from_sleap_file",
-                return_value=xr.Dataset(),
-            ),
-            ["load_dataset"],
-        ),
-        (
-            load_poses.from_multiview_files,
-            {
-                "file_dict": {"dummy_view": "dummy_path"},
-                "source_software": "SLEAP",
-            },
-            patch(
-                "movement.io.load_poses.from_sleap_file",
-                return_value=xr.Dataset(),
-            ),
-            ["load_multiview_dataset"],
-        ),
-        (
-            load_bboxes.from_file,
-            {"file": "dummy_path", "source_software": "VIA-tracks"},
-            patch(
-                "movement.io.load_bboxes.from_via_tracks_file",
-                return_value=xr.Dataset(),
-            ),
-            ["load_dataset"],
         ),
     ],
 )

--- a/tests/test_unit/test_io/test_load_bboxes.py
+++ b/tests/test_unit/test_io/test_load_bboxes.py
@@ -2,7 +2,6 @@
 
 import ast
 from pathlib import Path
-from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -225,46 +224,6 @@ def assert_time_coordinates(ds, fps, start_frame=None, frame_array=None):
     np.testing.assert_allclose(
         ds.coords["time"].data, np.array([f * scale for f in frame_array])
     )
-
-
-@pytest.mark.filterwarnings("ignore:.*is deprecated:DeprecationWarning")
-@pytest.mark.parametrize("source_software", ["Unknown", "VIA-tracks"])
-@pytest.mark.parametrize("fps", [None, 30, 60.0])
-@pytest.mark.parametrize("use_frame_numbers_from_file", [True, False])
-@pytest.mark.parametrize("frame_regexp", [None, r"frame_(\d+)"])
-def test_from_file(
-    source_software, fps, use_frame_numbers_from_file, frame_regexp
-):
-    """Test that the from_file() function delegates to the correct
-    loader function according to the source_software.
-    """
-    software_to_loader = {
-        "VIA-tracks": "movement.io.load_bboxes.from_via_tracks_file",
-    }
-    if source_software == "Unknown":
-        with pytest.raises(ValueError, match="Unsupported source"):
-            load_bboxes.from_file(
-                "some_file",
-                source_software,
-                fps,
-                use_frame_numbers_from_file=use_frame_numbers_from_file,
-                frame_regexp=frame_regexp,
-            )
-    else:
-        with patch(software_to_loader[source_software]) as mock_loader:
-            load_bboxes.from_file(
-                "some_file",
-                source_software,
-                fps,
-                use_frame_numbers_from_file=use_frame_numbers_from_file,
-                frame_regexp=frame_regexp,
-            )
-            mock_loader.assert_called_with(
-                "some_file",
-                fps,
-                use_frame_numbers_from_file=use_frame_numbers_from_file,
-                frame_regexp=frame_regexp,
-            )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_unit/test_io/test_load_poses.py
+++ b/tests/test_unit/test_io/test_load_poses.py
@@ -1,7 +1,5 @@
 """Test suite for the load_poses module."""
 
-from unittest.mock import patch
-
 import numpy as np
 import pytest
 import xarray as xr
@@ -270,54 +268,3 @@ def test_load_from_nwb_file(input_type, kwargs, request):
     if input_type == "nwb_file":
         expected_attrs["source_file"] = nwb_file
     assert ds_from_file_path.attrs == expected_attrs
-
-
-@pytest.mark.filterwarnings("ignore:.*is deprecated:DeprecationWarning")
-@pytest.mark.parametrize(
-    "source_software",
-    ["DeepLabCut", "SLEAP", "LightningPose", "Anipose", "NWB", "Unknown"],
-)
-@pytest.mark.parametrize("fps", [None, 30, 60.0])
-def test_from_file_delegates_correctly(source_software, fps, caplog):
-    """Test that the from_file() function delegates to the correct
-    loader function according to the source_software.
-    """
-    software_to_loader = {
-        "DeepLabCut": "movement.io.load_poses.from_dlc_file",
-        "SLEAP": "movement.io.load_poses.from_sleap_file",
-        "LightningPose": "movement.io.load_poses.from_lp_file",
-        "Anipose": "movement.io.load_poses.from_anipose_file",
-        "NWB": "movement.io.load_poses.from_nwb_file",
-    }
-    if source_software == "Unknown":
-        with pytest.raises(ValueError, match="Unsupported source"):
-            load_poses.from_file("some_file", source_software)
-    else:
-        with patch(software_to_loader[source_software]) as mock_loader:
-            load_poses.from_file("some_file", source_software, fps)
-            expected_call_args = (
-                ("some_file", fps)
-                if source_software != "NWB"
-                else ("some_file",)
-            )
-            mock_loader.assert_called_with(*expected_call_args)
-            if source_software == "NWB" and fps is not None:
-                assert "fps argument is ignored" in caplog.messages[0]
-
-
-@pytest.mark.filterwarnings("ignore:.*is deprecated:DeprecationWarning")
-def test_from_multiview_files():
-    """Test loading pose tracks from multiple files (representing
-    different views).
-    """
-    view_names = ["view_0", "view_1"]
-    file_path_dict = {
-        view: DATA_PATHS.get("DLC_single-wasp.predictions.h5")
-        for view in view_names
-    }
-    multi_view_ds = load_poses.from_multiview_files(
-        file_path_dict, source_software="DeepLabCut"
-    )
-    assert isinstance(multi_view_ds, xr.Dataset)
-    assert "view" in multi_view_ds.dims
-    assert multi_view_ds.view.values.tolist() == view_names


### PR DESCRIPTION
## Summary

Closes #812

Following the merging of PR #722, which introduced `load.load_dataset()` and `load.load_multiview_dataset()` as replacements and added deprecation warnings to the old dataset-specific functions, this PR removes those now-deprecated functions entirely.

### Changes

- **`movement/io/load_poses.py`**: Removed `from_file()` and `from_multiview_files()` functions, along with now-unused `import warnings`.
- **`movement/io/load_bboxes.py`**: Removed `from_file()` function, along with now-unused `import warnings`.
- **`tests/test_unit/test_io/test_load_poses.py`**: Removed `test_from_file_delegates_correctly()` and `test_from_multiview_files()` tests, along with now-unused `from unittest.mock import patch`.
- **`tests/test_unit/test_io/test_load_bboxes.py`**: Removed `test_from_file()` test, along with now-unused `from unittest.mock import patch`.
- **`tests/test_unit/test_deprecations.py`**: Removed the three parametrize entries for `load_poses.from_file`, `load_poses.from_multiview_files`, and `load_bboxes.from_file`; cleaned up now-unused imports (`xarray`, `load_bboxes`, `load_poses`, `patch`).

### Type of change

- [x] Bug fix / maintenance (removal of deprecated code)
