### PR TITLE
docs: clarify broadcasting example title, subtitle, and summary paragraph

### DIFF
--- a/examples/advanced/broadcasting_your_own_methods.py
+++ b/examples/advanced/broadcasting_your_own_methods.py
@@ -1,22 +1,29 @@
-"""Broadcast functions across multi-dimensional data
-=====================================================
+"""Apply custom functions across movement data dimensions
+=========================================================
 
-Use the @make_broadcastable decorator
-to efficiently apply functions across any data dimension.
+Use the ``@make_broadcastable`` decorator to run your own analysis functions
+across all individuals, keypoints, and time frames—without nested loops.
 """
 
 # %%
 # Summary
 # -------
-# :func:`@make_broadcastable()<movement.utils.broadcasting.\
-# make_broadcastable>` is particularly useful when you need to
-# apply the same operation to multiple individuals or time points
-# while avoiding the need to write complex loops.
+# When analysing movement data it is common to write a function that operates
+# on a single (x, y) position—for example, to check whether an animal is
+# inside a region of interest. Applying this function to an entire dataset
+# (across all time frames, keypoints, and individuals) usually requires writing
+# nested ``for`` loops, which are verbose, error-prone, and tightly coupled to
+# the shape of a particular dataset.
 #
-# The example walks through a practical case study of detecting when animals
-# enter a specific region of interest, showing how to convert a simple
-# point-in-rectangle check into a function that works on a data array
-# with many time-varying point trajectories.
+# The :func:`@make_broadcastable()<movement.utils.broadcasting.\
+# make_broadcastable>` decorator solves this problem. Decorate your function
+# once, and it will automatically accept an entire ``xarray.DataArray`` as
+# input, apply itself along the dimension you specify (e.g. ``"space"``), and
+# return a new ``DataArray`` with all remaining coordinates intact.
+#
+# This example walks through a practical case study—detecting when animals
+# enter a rectangular region of interest—to illustrate the step-by-step
+# transition from a simple per-point check to a fully broadcastable function.
 
 # %%
 # Imports


### PR DESCRIPTION
## Summary

Addresses the **first two checklist items** from issue #564:

> - [ ] Find a more appropriate title + subtitle, and write an informative short paragraph description at the top.
> - [ ] Update the contents to make them easier to follow *(separate follow-up PR)*

---

## What changed

### 1. Title (sphinx-gallery heading)

| Before | After |
|--------|-------|
| `Broadcast functions across multi-dimensional data` | `Apply custom functions across movement data dimensions` |

The old title used the technical term "broadcast" without context. The new title immediately conveys *what* you are doing (applying custom functions) and *where* (across a movement dataset), which is more informative for users browsing the example gallery.

### 2. Subtitle (second line of docstring)

| Before | After |
|--------|-------|
| `Use the @make_broadcastable decorator to efficiently apply functions across any data dimension.` | `Use the ``@make_broadcastable`` decorator to run your own analysis functions across all individuals, keypoints, and time frames—without nested loops.` |

The new subtitle names the concrete axes (`individuals`, `keypoints`, `time frames`) that users typically iterate over, and explicitly mentions the problem it solves (nested loops), giving readers an immediate reason to care.

### 3. Summary section (introductory paragraph)

The old summary jumped straight to describing the decorator, without first stating the problem.  The new paragraph follows the structure:

1. **Problem** — I have a function that works on a single (x, y) point; I want to apply it across the whole dataset.
2. **Naive solution** — nested `for` loops are verbose, error-prone, and tightly coupled to the dataset shape.
3. **Solution** — `@make_broadcastable` decorates your function once, so it accepts an entire `DataArray`, applies along the chosen dimension, and returns a new `DataArray` with coordinates intact.
4. **Preview** — this example uses a point-in-rectangle check as a case study.

---

## References

Closes the first checkbox of #564. The second checkbox (content improvements) will be addressed in a separate PR as suggested in the issue.

## Checklist

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality *(N/A — documentation only)*
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)