### PR TITLE
Fix rolling_filter window=1 edge case by returning early and add test

### DIFF
--- a/movement/filtering.py
+++ b/movement/filtering.py
@@ -176,6 +176,8 @@ def rolling_filter(
     is sufficient to compute the result.
 
     """
+    if window == 1:
+        return data
     half_window = window // 2
     data_windows = data.pad(  # Pad the edges to avoid NaNs
         time=half_window, mode="reflect"

--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -1,6 +1,6 @@
 from contextlib import nullcontext as does_not_raise
-import numpy as np
 
+import numpy as np
 import pytest
 import xarray as xr
 
@@ -281,12 +281,11 @@ def test_filter_by_confidence_on_position(
     assert isinstance(position_filtered, xr.DataArray)
     assert n_nans == valid_input_dataset.sizes["space"] * n_low_confidence_kpts
 
+
 def test_rolling_filter_window_1():
     """window=1 should return data unchanged."""
     data = xr.DataArray(
-        np.random.rand(10),
-        dims=["time"],
-        coords={"time": np.arange(10)}
+        np.random.rand(10), dims=["time"], coords={"time": np.arange(10)}
     )
     result = rolling_filter(data, window=1)
     xr.testing.ass

--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -294,5 +294,3 @@ def test_rolling_filter_window_1():
 
     result = rolling_filter(data, window=1)
     xr.testing.assert_equal(result, data)
-
->>>>>>> f26cdbb (Fix SonarCloud warnings in rolling_filter window=1 test)

--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -281,6 +281,7 @@ def test_filter_by_confidence_on_position(
     assert isinstance(position_filtered, xr.DataArray)
     assert n_nans == valid_input_dataset.sizes["space"] * n_low_confidence_kpts
 
+
 def test_rolling_filter_window_1():
     """window=1 should return data unchanged."""
     rng = np.random.default_rng()
@@ -290,6 +291,7 @@ def test_rolling_filter_window_1():
         dims=["time"],
         coords={"time": np.arange(10)}
     )
+
     result = rolling_filter(data, window=1)
     xr.testing.assert_equal(result, data)
 

--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -287,9 +287,7 @@ def test_rolling_filter_window_1():
     rng = np.random.default_rng()
 
     data = xr.DataArray(
-        rng.random(10),
-        dims=["time"],
-        coords={"time": np.arange(10)}
+        rng.random(10), dims=["time"], coords={"time": np.arange(10)}
     )
 
     result = rolling_filter(data, window=1)

--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -292,5 +292,5 @@ def test_rolling_filter_window_1():
     )
     result = rolling_filter(data, window=1)
     xr.testing.assert_equal(result, data)
-    
+
 >>>>>>> f26cdbb (Fix SonarCloud warnings in rolling_filter window=1 test)

--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -289,5 +289,4 @@ def test_rolling_filter_window_1():
         coords={"time": np.arange(10)}
     )
     result = rolling_filter(data, window=1)
-    print(result, data)
-    xr.testing.assert_equal(result, data)
+    xr.testing.ass

--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -281,11 +281,16 @@ def test_filter_by_confidence_on_position(
     assert isinstance(position_filtered, xr.DataArray)
     assert n_nans == valid_input_dataset.sizes["space"] * n_low_confidence_kpts
 
-
 def test_rolling_filter_window_1():
     """window=1 should return data unchanged."""
+    rng = np.random.default_rng()
+
     data = xr.DataArray(
-        np.random.rand(10), dims=["time"], coords={"time": np.arange(10)}
+        rng.random(10),
+        dims=["time"],
+        coords={"time": np.arange(10)}
     )
     result = rolling_filter(data, window=1)
-    xr.testing.ass
+    xr.testing.assert_equal(result, data)
+    
+>>>>>>> f26cdbb (Fix SonarCloud warnings in rolling_filter window=1 test)

--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -1,4 +1,5 @@
 from contextlib import nullcontext as does_not_raise
+import numpy as np
 
 import pytest
 import xarray as xr
@@ -279,3 +280,14 @@ def test_filter_by_confidence_on_position(
     n_low_confidence_kpts = 5
     assert isinstance(position_filtered, xr.DataArray)
     assert n_nans == valid_input_dataset.sizes["space"] * n_low_confidence_kpts
+
+def test_rolling_filter_window_1():
+    """window=1 should return data unchanged."""
+    data = xr.DataArray(
+        np.random.rand(10),
+        dims=["time"],
+        coords={"time": np.arange(10)}
+    )
+    result = rolling_filter(data, window=1)
+    print(result, data)
+    xr.testing.assert_equal(result, data)


### PR DESCRIPTION
## Description

**What is this PR**

* [x] Bug fix
* [ ] Addition of a new feature
* [ ] Other

**Why is this PR needed?**

Calling `rolling_filter` with `window=1` currently returns an empty `DataArray`.
A window size of 1 is a valid no-op filter and should return the original data unchanged.

The issue occurs because when `window=1`, `half_window = window // 2 = 0`.
The trim step then calls `isel(time=slice(0, -0))`, which evaluates to `slice(0, 0)` and results in an empty array.

**What does this PR do?**

* Adds an early return in `rolling_filter` when `window == 1`
* Prevents unnecessary processing and avoids the trimming bug
* Adds a unit test to verify that the output equals the input when `window=1`

## References

Closes #887

## How has this PR been tested?

* Added a unit test `test_rolling_filter_window_1` that checks the output equals the input when `window=1`.
* Ran the full test suite with `pytest` to ensure existing tests pass and no regressions were introduced.

## Is this a breaking change?

No. This change only fixes an edge case and does not modify existing behavior for other window sizes.

## Does this PR require an update to the documentation?

No. This change fixes an internal bug and does not introduce any new functionality.
