### PR TITLE
Move NWB test expectations to YAML

### DIFF
--- a/tests/data/nwb_expectations.yaml
+++ b/tests/data/nwb_expectations.yaml
@@ -1,0 +1,190 @@
+nwb_file_expectations_ind:
+  default_kwargs-single_ind:
+    nwbfile_kwargs:
+      - session_description: "not set"
+        identifier: "id_0"
+    processing_module_kwargs:
+      - description: "processed behavioral data"
+    subject_kwargs:
+      - subject_id: "id_0"
+    pose_estimation_kwargs:
+      - name: "PoseEstimation"
+        source_software: "test"
+    skeleton_kwargs:
+      - name: "skeleton_id_0"
+        nodes:
+          - centroid
+          - left
+          - right
+
+  default_kwargs-multi_ind:
+    nwbfile_kwargs:
+      - session_description: "not set"
+        identifier: "id_0"
+      - session_description: "not set"
+        identifier: "id_1"
+    processing_module_kwargs:
+      - description: "processed behavioral data"
+      - description: "processed behavioral data"
+    subject_kwargs:
+      - subject_id: "id_0"
+      - subject_id: "id_1"
+    pose_estimation_kwargs:
+      - name: "PoseEstimation"
+        source_software: "test"
+      - name: "PoseEstimation"
+        source_software: "test"
+    skeleton_kwargs:
+      - name: "skeleton_id_0"
+        nodes:
+          - centroid
+          - left
+          - right
+      - name: "skeleton_id_1"
+        nodes:
+          - centroid
+          - left
+          - right
+
+  shared_kwargs-single_ind:
+    nwbfile_kwargs:
+      - session_description: "test session"
+        identifier: "subj0"
+    processing_module_kwargs:
+      - description: "processed behav for test session"
+    subject_kwargs:
+      - age: "P90D"
+        subject_id: "subj0"
+    pose_estimation_kwargs:
+      - name: "subj0"
+        source_software: "other"
+    skeleton_kwargs:
+      - name: "skeleton0"
+        nodes:
+          - anchor
+          - left_ear
+          - right_ear
+
+  shared_kwargs-multi_ind:
+    nwbfile_kwargs:
+      - session_description: "test session"
+        identifier: "id_0"
+      - session_description: "test session"
+        identifier: "id_1"
+    processing_module_kwargs:
+      - description: "processed behav for test session"
+      - description: "processed behav for test session"
+    subject_kwargs:
+      - age: "P90D"
+        subject_id: "id_0"
+      - age: "P90D"
+        subject_id: "id_1"
+    pose_estimation_kwargs:
+      - name: "id_0"
+        source_software: "other"
+      - name: "id_1"
+        source_software: "other"
+    skeleton_kwargs:
+      - name: "id_0"
+        nodes:
+          - anchor
+          - left_ear
+          - right_ear
+      - name: "id_1"
+        nodes:
+          - anchor
+          - left_ear
+          - right_ear
+
+  custom_kwargs-single_ind:
+    nwbfile_kwargs:
+      - session_description: "session subj0"
+        identifier: "subj0"
+    processing_module_kwargs:
+      - description: "processed behav for subj0"
+    subject_kwargs:
+      - age: "P90D"
+        subject_id: "subj0"
+    pose_estimation_kwargs:
+      - name: "subj0"
+        source_software: "other0"
+    skeleton_kwargs:
+      - name: "skeleton_id_0"
+        nodes:
+          - node1
+          - node2
+          - node3
+
+  custom_kwargs-multi_ind:
+    nwbfile_kwargs:
+      - session_description: "session subj0"
+        identifier: "subj0"
+      - session_description: "session subj1"
+        identifier: "subj1"
+    processing_module_kwargs:
+      - description: "processed behav for subj0"
+      - description: "processed behav for subj1"
+    subject_kwargs:
+      - age: "P90D"
+        subject_id: "subj0"
+      - age: "P91D"
+        subject_id: "subj1"
+    pose_estimation_kwargs:
+      - name: "subj0"
+        source_software: "other0"
+      - name: "subj1"
+        source_software: "other1"
+    skeleton_kwargs:
+      - name: "skeleton_id_0"
+        nodes:
+          - node1
+          - node2
+          - node3
+      - name: "skeleton_id_1"
+        nodes:
+          - node4
+          - node5
+          - node6
+
+nwb_file_expectations_keypoint:
+  default_kwargs-single_keypoint:
+    pose_estimation_series_kwargs:
+      - reference_frame: "(0,0,0) corresponds to ..."
+        unit: "pixels"
+        name: "centroid"
+
+  default_kwargs-multi_keypoint:
+    pose_estimation_series_kwargs:
+      - reference_frame: "(0,0,0) corresponds to ..."
+        unit: "pixels"
+        name: "centroid"
+      - reference_frame: "(0,0,0) corresponds to ..."
+        unit: "pixels"
+        name: "left"
+      - reference_frame: "(0,0,0) corresponds to ..."
+        unit: "pixels"
+        name: "right"
+
+  shared_kwargs-single_keypoint:
+    pose_estimation_series_kwargs:
+      - reference_frame: "(0,0) is ..."
+        name: "anchor"
+
+  shared_kwargs-multi_keypoint:
+    pose_estimation_series_kwargs:
+      - reference_frame: "(0,0) is ..."
+        name: "centroid"
+      - reference_frame: "(0,0) is ..."
+        name: "left"
+      - reference_frame: "(0,0) is ..."
+        name: "right"
+
+  custom_kwargs-single_keypoint:
+    pose_estimation_series_kwargs:
+      - name: "anchor"
+
+  custom_kwargs-multi_keypoint:
+    pose_estimation_series_kwargs:
+      - name: "anchor"
+      - name: "left_ear"
+      - name: "right"

--- a/tests/test_unit/test_io/test_save_poses.py
+++ b/tests/test_unit/test_io/test_save_poses.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
+import yaml
 from pytest import DATA_PATHS
 
 from movement.io import load_poses, save_poses
@@ -305,119 +306,12 @@ def test_to_sleap_analysis_file_invalid_dataset(
         )
 
 
-nwb_file_expectations_ind = {
-    "default_kwargs-single_ind": {
-        "nwbfile_kwargs": [
-            {"session_description": "not set", "identifier": "id_0"}
-        ],
-        "processing_module_kwargs": [
-            {"description": "processed behavioral data"}
-        ],
-        "subject_kwargs": [{"subject_id": "id_0"}],
-        "pose_estimation_kwargs": [
-            {"name": "PoseEstimation", "source_software": "test"}
-        ],
-        "skeleton_kwargs": [
-            {"name": "skeleton_id_0", "nodes": ["centroid", "left", "right"]}
-        ],
-    },
-    "default_kwargs-multi_ind": {
-        "nwbfile_kwargs": [
-            {"session_description": "not set", "identifier": "id_0"},
-            {"session_description": "not set", "identifier": "id_1"},
-        ],
-        "processing_module_kwargs": [
-            {"description": "processed behavioral data"},
-            {"description": "processed behavioral data"},
-        ],
-        "subject_kwargs": [
-            {"subject_id": "id_0"},
-            {"subject_id": "id_1"},
-        ],
-        "pose_estimation_kwargs": [
-            {"name": "PoseEstimation", "source_software": "test"},
-            {"name": "PoseEstimation", "source_software": "test"},
-        ],
-        "skeleton_kwargs": [
-            {"name": "skeleton_id_0", "nodes": ["centroid", "left", "right"]},
-            {"name": "skeleton_id_1", "nodes": ["centroid", "left", "right"]},
-        ],
-    },
-    "shared_kwargs-single_ind": {
-        "nwbfile_kwargs": [
-            {"session_description": "test session", "identifier": "subj0"}
-        ],
-        "processing_module_kwargs": [
-            {"description": "processed behav for test session"}
-        ],
-        "subject_kwargs": [{"age": "P90D", "subject_id": "subj0"}],
-        "pose_estimation_kwargs": [
-            {"name": "subj0", "source_software": "other"}
-        ],
-        "skeleton_kwargs": [
-            {"name": "skeleton0", "nodes": ["anchor", "left_ear", "right_ear"]}
-        ],
-    },
-    "shared_kwargs-multi_ind": {
-        "nwbfile_kwargs": [
-            {"session_description": "test session", "identifier": "id_0"},
-            {"session_description": "test session", "identifier": "id_1"},
-        ],
-        "processing_module_kwargs": [
-            {"description": "processed behav for test session"},
-            {"description": "processed behav for test session"},
-        ],
-        "subject_kwargs": [
-            {"age": "P90D", "subject_id": "id_0"},
-            {"age": "P90D", "subject_id": "id_1"},
-        ],
-        "pose_estimation_kwargs": [
-            {"name": "id_0", "source_software": "other"},
-            {"name": "id_1", "source_software": "other"},
-        ],
-        "skeleton_kwargs": [
-            {"name": "id_0", "nodes": ["anchor", "left_ear", "right_ear"]},
-            {"name": "id_1", "nodes": ["anchor", "left_ear", "right_ear"]},
-        ],
-    },
-    "custom_kwargs-single_ind": {
-        "nwbfile_kwargs": [
-            {"session_description": "session subj0", "identifier": "subj0"}
-        ],
-        "processing_module_kwargs": [
-            {"description": "processed behav for subj0"}
-        ],
-        "subject_kwargs": [{"age": "P90D", "subject_id": "subj0"}],
-        "pose_estimation_kwargs": [
-            {"name": "subj0", "source_software": "other0"}
-        ],
-        "skeleton_kwargs": [
-            {"name": "skeleton_id_0", "nodes": ["node1", "node2", "node3"]}
-        ],
-    },
-    "custom_kwargs-multi_ind": {
-        "nwbfile_kwargs": [
-            {"session_description": "session subj0", "identifier": "subj0"},
-            {"session_description": "session subj1", "identifier": "subj1"},
-        ],
-        "processing_module_kwargs": [
-            {"description": "processed behav for subj0"},
-            {"description": "processed behav for subj1"},
-        ],
-        "subject_kwargs": [
-            {"age": "P90D", "subject_id": "subj0"},
-            {"age": "P91D", "subject_id": "subj1"},
-        ],
-        "pose_estimation_kwargs": [
-            {"name": "subj0", "source_software": "other0"},
-            {"name": "subj1", "source_software": "other1"},
-        ],
-        "skeleton_kwargs": [
-            {"name": "skeleton_id_0", "nodes": ["node1", "node2", "node3"]},
-            {"name": "skeleton_id_1", "nodes": ["node4", "node5", "node6"]},
-        ],
-    },
-}
+DATA_PATH = Path(__file__).parents[2] / "data" / "nwb_expectations.yaml"
+
+with DATA_PATH.open() as f:
+    data = yaml.safe_load(f)
+
+nwb_file_expectations_ind = data["nwb_file_expectations_ind"]
 
 
 @pytest.mark.parametrize(
@@ -509,58 +403,7 @@ def test_to_nwb_file_with_single_or_multi_ind_ds(
     assert actual_skeleton_kwargs == expected_skeleton_kwargs
 
 
-nwb_file_expectations_keypoint = {
-    "default_kwargs-single_keypoint": {
-        "pose_estimation_series_kwargs": [
-            {
-                "reference_frame": "(0,0,0) corresponds to ...",
-                "unit": "pixels",
-                "name": "centroid",
-            },
-        ],
-    },
-    "default_kwargs-multi_keypoint": {
-        "pose_estimation_series_kwargs": [
-            {
-                "reference_frame": "(0,0,0) corresponds to ...",
-                "unit": "pixels",
-                "name": "centroid",
-            },
-            {
-                "reference_frame": "(0,0,0) corresponds to ...",
-                "unit": "pixels",
-                "name": "left",
-            },
-            {
-                "reference_frame": "(0,0,0) corresponds to ...",
-                "unit": "pixels",
-                "name": "right",
-            },
-        ],
-    },
-    "shared_kwargs-single_keypoint": {
-        "pose_estimation_series_kwargs": [
-            {"reference_frame": "(0,0) is ...", "name": "anchor"}
-        ],
-    },
-    "shared_kwargs-multi_keypoint": {
-        "pose_estimation_series_kwargs": [
-            {"reference_frame": "(0,0) is ...", "name": "centroid"},
-            {"reference_frame": "(0,0) is ...", "name": "left"},
-            {"reference_frame": "(0,0) is ...", "name": "right"},
-        ],
-    },
-    "custom_kwargs-single_keypoint": {
-        "pose_estimation_series_kwargs": [{"name": "anchor"}],
-    },
-    "custom_kwargs-multi_keypoint": {
-        "pose_estimation_series_kwargs": [
-            {"name": "anchor"},
-            {"name": "left_ear"},
-            {"name": "right"},
-        ],
-    },
-}
+nwb_file_expectations_keypoint = data["nwb_file_expectations_keypoint"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**

Some NWB test expectation data was previously defined directly inside the test file (`test_save_poses.py`). Separating test data from test logic improves readability and maintainability, and makes it easier to modify or extend expectations without changing the test implementation.

**What does this PR do?**

Moves the NWB expectation dictionaries into a YAML file: `tests/data/nwb_expectations.yaml` and loads the test expectations in test_save_poses.py using `yaml.safe_load`

## References

Solves #602 

## How has this PR been tested?

All tests were executed locally using pytest.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No documentation updates are required, as this change only affects internal test organization.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
