### PR TITLE
fix: raise errors correctly in vector.py instead of raise logger.error()

### DIFF
--- a/movement/utils/vector.py
+++ b/movement/utils/vector.py
@@ -278,8 +278,7 @@ def compute_signed_angle_2d(
         )
     elif not isinstance(v, xr.DataArray):
         error = TypeError(
-            "v must be an xarray.DataArray or np.ndarray, "
-            f"but got {type(v)}."
+            f"v must be an xarray.DataArray or np.ndarray, but got {type(v)}."
         )
         logger.error(error)
         raise error

--- a/movement/utils/vector.py
+++ b/movement/utils/vector.py
@@ -268,21 +268,21 @@ def compute_signed_angle_2d(
         elif v.ndim == 2:
             v_dims = ["time", "space"]
         else:
-            raise logger.error(
-                ValueError(f"v must be 1D or 2D, but got {v.ndim}D.")
-            )
+            error = ValueError(f"v must be 1D or 2D, but got {v.ndim}D.")
+            logger.error(error)
+            raise error
         v = xr.DataArray(
             v,
             dims=v_dims,
             coords={d: u.coords[d] for d in v_dims},
         )
     elif not isinstance(v, xr.DataArray):
-        raise logger.error(
-            TypeError(
-                "v must be an xarray.DataArray or np.ndarray, "
-                f"but got {type(v)}."
-            )
+        error = TypeError(
+            "v must be an xarray.DataArray or np.ndarray, "
+            f"but got {type(v)}."
         )
+        logger.error(error)
+        raise error
     validate_dims_coords(v, {"space": ["x", "y"]}, exact_coords=True)
 
     u = convert_to_unit(u)
@@ -308,9 +308,9 @@ def compute_signed_angle_2d(
 
 
 def _raise_error_for_missing_spatial_dim() -> NoReturn:
-    raise logger.error(
-        ValueError(
-            "Input data array must contain either 'space' or 'space_pol' "
-            "as dimensions."
-        )
+    error = ValueError(
+        "Input data array must contain either 'space' or 'space_pol' "
+        "as dimensions."
     )
+    logger.error(error)
+    raise error


### PR DESCRIPTION
Fixes #893

`logger.error()` returns `None`, so `raise logger.error(SomeError(...))` raises `TypeError` instead of the intended exception. Fixed all three occurrences in `vector.py` by separating the log call from the raise.