### PR TITLE
Update pandas URL in intersphinx config

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -214,7 +214,7 @@ linkcheck_ignore = [
     "https://zenodo.org/doi/*",
     "https://zenodo.org/records/*",
     "https://doi.org/10.5281/zenodo.*",
-    "https://abide.ics.ulisboa.pt/*"  # flaky
+    "https://abide.ics.ulisboa.pt/*",  # flaky
 ]
 # Add request headers for specific domains (e.g. to avoid rate-limiting)
 linkcheck_request_headers = {
@@ -256,7 +256,7 @@ myst_url_schemes = {
 intersphinx_mapping = {
     "xarray": ("https://docs.xarray.dev/en/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
-    "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
+    "pandas": ("https://pandas.pydata.org/docs/", None),
     "python": ("https://docs.python.org/3", None),
     "loguru": ("https://loguru.readthedocs.io/en/stable/", None),
     "pynwb": ("https://pynwb.readthedocs.io/en/stable/", None),


### PR DESCRIPTION
pandas 3.0 stable release URL has switched from https://pandas.pydata.org/pandas-docs/stable/ to https://pandas.pydata.org/docs/ so [intersphinx was unable to find pandas' objects.inv](https://github.com/neuroinformatics-unit/movement/actions/runs/23152830037/job/67259215206#step:3:977)

Requesting @sfmig 's review as this should unblock #769 