### PR TITLE
Enforce strict time alignment in load_multiview_dataset

### DIFF
--- a/movement/io/load.py
+++ b/movement/io/load.py
@@ -462,11 +462,9 @@ def load_multiview_dataset(
     dataset specified in ``file_path_dict``. This is the default
     behaviour of :func:`xarray.concat` used under the hood.
 
-    This function assumes that all input views share identical ``time``
-    coordinates. If this is not the case,
-    :func:`xarray.concat` will follow its default alignment
-    behaviour, which may introduce missing values (NaNs). A warning is
-    raised when views have differing numbers of time points.
+    All input views must share identical ``time`` coordinates. If they
+    do not, :func:`xarray.concat` raises a :class:`ValueError` naming
+    the offending dimension. This is enforced via ``join="exact"``.
 
     See Also
     --------
@@ -480,17 +478,7 @@ def load_multiview_dataset(
         load_dataset(f, source_software=source_software, fps=fps, **kwargs)
         for f in file_dict.values()
     ]
-    time_lengths = [ds.sizes.get("time", None) for ds in dataset_list]
-    valid_lengths = [length for length in time_lengths if length is not None]
-    if len(set(valid_lengths)) > 1:
-        warnings.warn(
-            "Mismatched time coordinates detected across views. "
-            "The resulting dataset may contain NaN values due to "
-            "alignment issues.",
-            UserWarning,
-            stacklevel=2,
-        )
-    return xr.concat(dataset_list, dim=new_coord_views)
+    return xr.concat(dataset_list, dim=new_coord_views, join="exact")
 
 
 def rename_legacy_dimensions(ds: xr.Dataset) -> xr.Dataset:

--- a/movement/io/load.py
+++ b/movement/io/load.py
@@ -462,6 +462,12 @@ def load_multiview_dataset(
     dataset specified in ``file_path_dict``. This is the default
     behaviour of :func:`xarray.concat` used under the hood.
 
+    This function assumes that all input views share identical frame
+    indices. If this is not the case,
+    :func:`xarray.concat` will follow its default alignment
+    behaviour, which may introduce missing values (NaNs). A warning is
+    raised when mismatched frame counts are detected.
+
     See Also
     --------
     movement.io.load_poses
@@ -474,6 +480,16 @@ def load_multiview_dataset(
         load_dataset(f, source_software=source_software, fps=fps, **kwargs)
         for f in file_dict.values()
     ]
+    frame_length = [ds.sizes.get("frame", None) for ds in dataset_list]
+    valid_lengths = [length for length in frame_length if length is not None]
+    if len(set(valid_lengths)) > 1:
+        warnings.warn(
+            "Mismatched frame counts detected across views. "
+            "The resulting dataset may contain NaN values due to "
+            "alignment issues.",
+            UserWarning,
+            stacklevel=2,
+        )
     return xr.concat(dataset_list, dim=new_coord_views)
 
 

--- a/movement/io/load.py
+++ b/movement/io/load.py
@@ -462,11 +462,11 @@ def load_multiview_dataset(
     dataset specified in ``file_path_dict``. This is the default
     behaviour of :func:`xarray.concat` used under the hood.
 
-    This function assumes that all input views share identical frame
-    indices. If this is not the case,
+    This function assumes that all input views share identical ``time``
+    coordinates. If this is not the case,
     :func:`xarray.concat` will follow its default alignment
     behaviour, which may introduce missing values (NaNs). A warning is
-    raised when mismatched frame counts are detected.
+    raised when views have differing numbers of time points.
 
     See Also
     --------
@@ -480,11 +480,11 @@ def load_multiview_dataset(
         load_dataset(f, source_software=source_software, fps=fps, **kwargs)
         for f in file_dict.values()
     ]
-    frame_length = [ds.sizes.get("frame", None) for ds in dataset_list]
-    valid_lengths = [length for length in frame_length if length is not None]
+    time_lengths = [ds.sizes.get("time", None) for ds in dataset_list]
+    valid_lengths = [length for length in time_lengths if length is not None]
     if len(set(valid_lengths)) > 1:
         warnings.warn(
-            "Mismatched frame counts detected across views. "
+            "Mismatched time coordinates detected across views. "
             "The resulting dataset may contain NaN values due to "
             "alignment issues.",
             UserWarning,

--- a/tests/test_unit/test_io/test_load.py
+++ b/tests/test_unit/test_io/test_load.py
@@ -158,6 +158,22 @@ def test_load_multiview_dataset(dataset_name, source_software):
     assert multi_view_ds.view.values.tolist() == view_names
 
 
+def test_multiview_warning_on_mismatched_frames(mocker):
+    """Test that a warning is raised when frame counts differ across views."""
+    ds1 = xr.Dataset({"x": ("frame", [1, 2, 3])})
+    ds2 = xr.Dataset({"x": ("frame", [1, 2])})
+
+    mocker.patch(
+        "movement.io.load.load_dataset",
+        side_effect=[ds1, ds2],
+    )
+
+    file_dict = {"view1": "file1", "view2": "file2"}
+
+    with pytest.warns(UserWarning, match="Mismatched frame counts"):
+        load.load_multiview_dataset(file_dict, source_software="DeepLabCut")
+
+
 def test_get_validator_kwargs():
     """Test _get_validator_kwargs correctly extracts kwargs
     for file validators.

--- a/tests/test_unit/test_io/test_load.py
+++ b/tests/test_unit/test_io/test_load.py
@@ -160,8 +160,8 @@ def test_load_multiview_dataset(dataset_name, source_software):
 
 
 def test_multiview_warning_on_mismatched_frames(mocker):
-    ds1 = xr.Dataset({"x": ("frame", [1, 2, 3])})
-    ds2 = xr.Dataset({"x": ("frame", [1, 2])})
+    ds1 = xr.Dataset({"x": ("time", [1, 2, 3])})
+    ds2 = xr.Dataset({"x": ("time", [1, 2])})
 
     mocker.patch(
         "movement.io.load.load_dataset",
@@ -171,7 +171,7 @@ def test_multiview_warning_on_mismatched_frames(mocker):
     file_dict = {"view1": "file1", "view2": "file2"}
 
     with (
-        pytest.warns(UserWarning, match=r"Mismatched.*frame"),
+        pytest.warns(UserWarning, match=r"Mismatched.*time"),
         pytest.raises(AlignmentError),
     ):
         load.load_multiview_dataset(file_dict, source_software="DeepLabCut")

--- a/tests/test_unit/test_io/test_load.py
+++ b/tests/test_unit/test_io/test_load.py
@@ -7,7 +7,6 @@ import xarray as xr
 from attrs import define, field, validators
 from pytest import DATA_PATHS
 from requests_cache import Path
-from xarray.structure.alignment import AlignmentError
 
 from movement.io import load
 
@@ -159,21 +158,29 @@ def test_load_multiview_dataset(dataset_name, source_software):
     assert multi_view_ds.view.values.tolist() == view_names
 
 
-def test_multiview_warning_on_mismatched_frames(mocker):
-    ds1 = xr.Dataset({"x": ("time", [1, 2, 3])})
-    ds2 = xr.Dataset({"x": ("time", [1, 2])})
-
+@pytest.mark.parametrize(
+    "modify_second_view, should_raise",
+    [
+        (lambda ds: ds, False),
+        (lambda ds: ds.isel(time=slice(0, -1)), True),
+        (lambda ds: ds.assign_coords(time=ds["time"].values + 1.0), True),
+    ],
+    ids=["identical", "trimmed", "shifted"],
+)
+def test_load_multiview_dataset_strict_alignment(
+    modify_second_view, should_raise, dlc_h5_file, mocker
+):
+    """Mismatched ``time`` coordinates across views must raise via
+    xarray's ``join='exact'`` alignment.
+    """
+    real_ds = load.load_dataset(dlc_h5_file, source_software="DeepLabCut")
     mocker.patch(
         "movement.io.load.load_dataset",
-        side_effect=[ds1, ds2],
+        side_effect=[real_ds, modify_second_view(real_ds)],
     )
-
-    file_dict = {"view1": "file1", "view2": "file2"}
-
-    with (
-        pytest.warns(UserWarning, match=r"Mismatched.*time"),
-        pytest.raises(AlignmentError),
-    ):
+    file_dict = {"view_0": dlc_h5_file, "view_1": dlc_h5_file}
+    expected = pytest.raises(ValueError) if should_raise else does_not_raise()
+    with expected:
         load.load_multiview_dataset(file_dict, source_software="DeepLabCut")
 
 

--- a/tests/test_unit/test_io/test_load.py
+++ b/tests/test_unit/test_io/test_load.py
@@ -7,6 +7,7 @@ import xarray as xr
 from attrs import define, field, validators
 from pytest import DATA_PATHS
 from requests_cache import Path
+from xarray.structure.alignment import AlignmentError
 
 from movement.io import load
 
@@ -169,12 +170,11 @@ def test_multiview_warning_on_mismatched_frames(mocker):
 
     file_dict = {"view1": "file1", "view2": "file2"}
 
-    with pytest.warns(UserWarning, match="Mismatched frame"):
-        result = load.load_multiview_dataset(
-            file_dict, source_software="DeepLabCut"
-        )
-
-    assert isinstance(result, xr.Dataset)
+    with (
+        pytest.warns(UserWarning, match=r"Mismatched.*frame"),
+        pytest.raises(AlignmentError),
+    ):
+        load.load_multiview_dataset(file_dict, source_software="DeepLabCut")
 
 
 def test_get_validator_kwargs():

--- a/tests/test_unit/test_io/test_load.py
+++ b/tests/test_unit/test_io/test_load.py
@@ -159,7 +159,6 @@ def test_load_multiview_dataset(dataset_name, source_software):
 
 
 def test_multiview_warning_on_mismatched_frames(mocker):
-    """Test that a warning is raised when frame counts differ across views."""
     ds1 = xr.Dataset({"x": ("frame", [1, 2, 3])})
     ds2 = xr.Dataset({"x": ("frame", [1, 2])})
 
@@ -170,8 +169,12 @@ def test_multiview_warning_on_mismatched_frames(mocker):
 
     file_dict = {"view1": "file1", "view2": "file2"}
 
-    with pytest.warns(UserWarning, match="Mismatched frame counts"):
-        load.load_multiview_dataset(file_dict, source_software="DeepLabCut")
+    with pytest.warns(UserWarning, match="mismatched frame"):
+        result = load.load_multiview_dataset(
+            file_dict, source_software="DeepLabCut"
+        )
+
+    assert isinstance(result, xr.Dataset)
 
 
 def test_get_validator_kwargs():

--- a/tests/test_unit/test_io/test_load.py
+++ b/tests/test_unit/test_io/test_load.py
@@ -169,7 +169,7 @@ def test_multiview_warning_on_mismatched_frames(mocker):
 
     file_dict = {"view1": "file1", "view2": "file2"}
 
-    with pytest.warns(UserWarning, match="mismatched frame"):
+    with pytest.warns(UserWarning, match="Mismatched frame"):
         result = load.load_multiview_dataset(
             file_dict, source_software="DeepLabCut"
         )


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Currently, multi-view loading assumes that all input datasets have perfectly aligned frame counts. In practice, this is often not the case, which can lead to silent introduction of `NaNs` due to `xarray.concat` alignment. This behavior is not explicitly communicated to the user.

**What does this PR do?**
Adds a note in the docstring of load_multiview_dataset clarifying the assumption of aligned frames and introduces a runtime warning when mismatched frame counts are detected across views.

## References

Discussion with maintainers on Zulip regarding handling of mismatched frame alignment

## How has this PR been tested?

Tested locally by creating datasets with different frame lengths and confirming that a UserWarning is raised

## Is this a breaking change?

No. This PR only adds a warning and documentation; it does not modify existing behavior.

## Does this PR require an update to the documentation?

Yes. The docstring of `load_multiview_dataset` has been updated to explicitly mention the frame alignment assumption and the warning behavior.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
