### PR TITLE
Improve xarray compatibility in vector utilities (compute_signed_angle_2d and cart2pol) [fixes #901]

### DIFF
--- a/movement/utils/vector.py
+++ b/movement/utils/vector.py
@@ -144,7 +144,7 @@ def cart2pol(data: xr.DataArray) -> xr.DataArray:
     # Make all zeros in phi positive zeros
     # - where rho == 0, set phi to 0
     # - where rho != 0, keep the phi value from atan2
-    phi = xr.where(np.isclose(rho.values, 0.0, atol=1e-9), 0.0, phi)
+    phi = xr.where(np.isclose(rho, 0.0, atol=1e-9), 0.0, phi)
 
     # Replace space dim with space_pol
     dims = list(data.dims)
@@ -298,11 +298,12 @@ def compute_signed_angle_2d(
         cross *= -1.0
     dot = u_x * v_x + u_y * v_y
 
-    angles = np.arctan2(cross, dot)
-    assert isinstance(angles, xr.DataArray)
+    angles = xr.apply_ufunc(np.arctan2, cross, dot)
+
     # arctan2 returns values in [-pi, pi].
-    # We need to map -pi angles to pi, to stay in the (-pi, pi] range
-    angles.values[angles <= -np.pi] = np.pi
+    # Map -pi angles to pi to stay in the (-pi, pi] range
+    angles = xr.where(angles <= -np.pi, np.pi, angles)
+
     angles.name = "signed_angle"
     return angles
 


### PR DESCRIPTION
Closes #901

## Summary
While reviewing `movement/utils/vector.py`, I noticed a few places where NumPy operations were applied directly to xarray `DataArray` objects or where `.values` was accessed. These patterns can bypass xarray’s abstraction layer and may cause issues with lazy backends (e.g., dask) or metadata handling.

This PR improves compatibility with xarray best practices.

## Changes
- Replace `np.arctan2(cross, dot)` with `xr.apply_ufunc(np.arctan2, cross, dot)` in `compute_signed_angle_2d`
- Replace in-place mutation of `.values` with `xr.where`
- Avoid direct `.values` access in `cart2pol`

## Rationale
Using xarray-aware operations preserves metadata and ensures compatibility with lazy computation frameworks such as dask.

## Testing
All existing tests pass locally:

pytest --ignore=tests/test_unit/test_napari_plugin

Result:
1011 passed, 4 deselected, 2 xfailed

No functional behavior of the library was changed; the modifications only improve implementation safety and compatibility with xarray.