### PR TITLE
Change ylabel from 'speed' to 'accel'

### DIFF
--- a/examples/compute_kinematics.py
+++ b/examples/compute_kinematics.py
@@ -419,7 +419,7 @@ for mouse_name, ax in zip(accel.individuals.values, axes, strict=False):
     )
     ax.set_title(mouse_name)
     ax.set_xlabel("time (s)")
-    ax.set_ylabel("speed (px/s**2)")
+    ax.set_ylabel("accel (px/s**2)")
     ax.legend(loc="center right", bbox_to_anchor=(1.07, 1.07))
 fig.tight_layout()
 


### PR DESCRIPTION
Fix y-axis label in acceleration components plot

Before submitting a pull request (PR), please read the [contributing guide](https://github.com/neuroinformatics-unit/.github/blob/main/CONTRIBUTING.md).

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

The y-axis label on the acceleration plot was wrong—it said “speed (px/s**2)” even though the graph is showing acceleration. It should be labeled “accel (px/s**2)” to match what’s actually being plotted.

**What does this PR do?**

Changes the y-axis label in `examples/compute_kinematics.py` from `"speed (px/s**2)"` to `"accel (px/s**2)"` to match the label used in the acceleration norm plot.

## References

Fixes #848

## How has this PR been tested?

The change is a one-line label fix with no logic changes. Verified visually by inspecting the diff.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:
- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)