### PR TITLE
feat(vector): add 3D support for coordinate transforms and vector ops

### DIFF
--- a/movement/utils/vector.py
+++ b/movement/utils/vector.py
@@ -42,7 +42,13 @@ def compute_norm(data: xr.DataArray) -> xr.DataArray:
 
     """
     if "space" in data.dims:
-        validate_dims_coords(data, {"space": ["x", "y"]})
+        # Allow both 2D and 3D 
+        if len(data.coords["space"]) == 2:
+            validate_dims_coords(data, {"space": ["x", "y"]})
+        elif len(data.coords["space"]) == 3:
+            validate_dims_coords(data, {"space": ["x", "y", "z"]})
+        else:
+            _raise_error_for_invalid_spatial_dim_length("space", 2, 3)
         return xr.apply_ufunc(
             np.linalg.norm,
             data,
@@ -50,7 +56,13 @@ def compute_norm(data: xr.DataArray) -> xr.DataArray:
             kwargs={"axis": -1},
         )
     elif "space_pol" in data.dims:
-        validate_dims_coords(data, {"space_pol": ["rho", "phi"]})
+        # Allow both 2D polar and 3D cylindrical
+        if len(data.coords["space_pol"]) == 2:
+            validate_dims_coords(data, {"space_pol": ["rho", "phi"]})
+        elif len(data.coords["space_pol"]) == 3:
+            validate_dims_coords(data, {"space_pol": ["rho", "phi", "z"]})
+        else:
+            _raise_error_for_invalid_spatial_dim_length("space_pol", 2, 3)
         return data.sel(space_pol="rho", drop=True)
     else:
         _raise_error_for_missing_spatial_dim()
@@ -81,10 +93,22 @@ def convert_to_unit(data: xr.DataArray) -> xr.DataArray:
 
     """
     if "space" in data.dims:
-        validate_dims_coords(data, {"space": ["x", "y"]})
+        # Allow both 2D and 3D
+        if len(data.coords["space"]) == 2:
+            validate_dims_coords(data, {"space": ["x", "y"]})
+        elif len(data.coords["space"]) == 3:
+            validate_dims_coords(data, {"space": ["x", "y", "z"]})
+        else:
+            _raise_error_for_invalid_spatial_dim_length("space", 2, 3)
         return data / compute_norm(data)
     elif "space_pol" in data.dims:
-        validate_dims_coords(data, {"space_pol": ["rho", "phi"]})
+        # Allow both 2D polar and 3D cylindrical
+        if len(data.coords["space_pol"]) == 2:
+            validate_dims_coords(data, {"space_pol": ["rho", "phi"]})
+        elif len(data.coords["space_pol"]) == 3:
+            validate_dims_coords(data, {"space_pol": ["rho", "phi", "z"]})
+        else:
+            _raise_error_for_invalid_spatial_dim_length("space_pol", 2, 3)
         # Set both rho and phi values to NaN at null vectors (where rho = 0)
         new_data = xr.where(data.sel(space_pol="rho") == 0, np.nan, data)
         # Set the rho values to 1 for non-null vectors (phi is preserved)
@@ -97,21 +121,26 @@ def convert_to_unit(data: xr.DataArray) -> xr.DataArray:
 
 
 def cart2pol(data: xr.DataArray) -> xr.DataArray:
-    """Transform Cartesian coordinates to polar.
+    """Transform Cartesian coordinates to polar (2D) or cylindrical (3D).
 
     Parameters
     ----------
     data
         The input data containing ``space`` as a dimension,
-        with ``x`` and ``y`` in the dimension coordinate.
+        with ``x`` and ``y`` (2D) or ``x``, ``y``, and ``z`` (3D)
+        in the dimension coordinate.
 
     Returns
     -------
     xarray.DataArray
-        An xarray DataArray containing the polar coordinates
-        stored in the ``space_pol`` dimension, with ``rho``
-        and ``phi`` in the dimension coordinate. The angles
-        ``phi`` returned are in radians, in the range ``[-pi, pi]``.
+        An xarray DataArray containing the polar/cylindrical coordinates
+        stored in the ``space_pol`` dimension:
+
+        - 2D: ``rho`` and ``phi``
+        - 3D: ``rho``, ``phi``, and ``z`` (cylindrical coordinates)
+
+        The angle ``phi`` is in radians, in the range ``[-pi, pi]``.
+        For 3D input, ``z`` is passed through unchanged.
 
     Notes
     -----
@@ -124,7 +153,7 @@ def cart2pol(data: xr.DataArray) -> xr.DataArray:
 
     References
     ----------
-    .. [1] ISO/IEC standard 9899:1999, “Programming language C.”
+    .. [1] ISO/IEC standard 9899:1999, "Programming language C."
     .. [2] https://en.wikipedia.org/wiki/Atan2
     .. [3] https://en.wikipedia.org/wiki/Signed_zero
 
@@ -133,61 +162,184 @@ def cart2pol(data: xr.DataArray) -> xr.DataArray:
     :obj:`numpy.arctan2`
 
     """
-    validate_dims_coords(data, {"space": ["x", "y"]})
-    rho = compute_norm(data)
-    phi = xr.apply_ufunc(
-        np.arctan2,
-        data.sel(space="y"),
-        data.sel(space="x"),
-    )
+    # Validate 2D or 3D input
+    is_3d = len(data.coords["space"]) == 3
+    if is_3d:
+        validate_dims_coords(data, {"space": ["x", "y", "z"]})
+    else:
+        validate_dims_coords(data, {"space": ["x", "y"]})
+
+    x = data.sel(space="x")
+    y = data.sel(space="y")
+    rho = np.sqrt(x**2 + y**2)
+    phi = xr.apply_ufunc(np.arctan2, y, x)
 
     # Make all zeros in phi positive zeros
     # - where rho == 0, set phi to 0
     # - where rho != 0, keep the phi value from atan2
     phi = xr.where(np.isclose(rho.values, 0.0, atol=1e-9), 0.0, phi)
 
+    # Build output components
+    components = [
+        rho.assign_coords({"space_pol": "rho"}),
+        phi.assign_coords({"space_pol": "phi"}),
+    ]
+
+    # For 3D, pass z through unchanged
+    if is_3d:
+        z = data.sel(space="z")
+        components.append(z.assign_coords({"space_pol": "z"}))
+
     # Replace space dim with space_pol
     dims = list(data.dims)
     dims[dims.index("space")] = "space_pol"
-    return xr.concat(
-        [
-            rho.assign_coords({"space_pol": "rho"}),
-            phi.assign_coords({"space_pol": "phi"}),
-        ],
-        dim="space_pol",
-    ).transpose(*dims)
+    return xr.concat(components, dim="space_pol").transpose(*dims)
 
 
 def pol2cart(data: xr.DataArray) -> xr.DataArray:
-    """Transform polar coordinates to Cartesian.
+    """Transform polar (2D) or cylindrical (3D) coordinates to Cartesian.
 
     Parameters
     ----------
     data
         The input data containing ``space_pol`` as a dimension,
-        with ``rho`` and ``phi`` in the dimension coordinate.
+        with ``rho`` and ``phi`` (2D) or ``rho``, ``phi``, and ``z`` (3D)
+        in the dimension coordinate.
 
     Returns
     -------
     xarray.DataArray
         An xarray DataArray containing the Cartesian coordinates
-        stored in the ``space`` dimension, with ``x`` and ``y``
-        in the dimension coordinate.
+        stored in the ``space`` dimension:
+
+        - 2D: ``x`` and ``y``
+        - 3D: ``x``, ``y``, and ``z``
 
     """
-    validate_dims_coords(data, {"space_pol": ["rho", "phi"]})
+    # Validate 2D or 3D input
+    is_3d = len(data.coords["space_pol"]) == 3
+    if is_3d:
+        validate_dims_coords(data, {"space_pol": ["rho", "phi", "z"]})
+    else:
+        validate_dims_coords(data, {"space_pol": ["rho", "phi"]})
+
     rho = data.sel(space_pol="rho")
     phi = data.sel(space_pol="phi")
     x = rho * np.cos(phi)
     y = rho * np.sin(phi)
 
+    # Build output components
+    components = [
+        x.assign_coords({"space": "x"}),
+        y.assign_coords({"space": "y"}),
+    ]
+
+    # For 3D, pass z through unchanged
+    if is_3d:
+        z = data.sel(space_pol="z")
+        components.append(z.assign_coords({"space": "z"}))
+
     # Replace space_pol dim with space
     dims = list(data.dims)
     dims[dims.index("space_pol")] = "space"
+    return xr.concat(components, dim="space").transpose(*dims)
+
+
+def cart2sph(data: xr.DataArray) -> xr.DataArray:
+    """Transform 3D Cartesian coordinates to spherical.
+
+    Parameters
+    ----------
+    data
+        The input data containing ``space`` as a dimension,
+        with ``x``, ``y``, and ``z`` in the dimension coordinate.
+
+    Returns
+    -------
+    xarray.DataArray
+        An xarray DataArray containing the spherical coordinates
+        stored in the ``space_sph`` dimension, with ``rho``,
+        ``azimuth``, and ``elevation`` in the dimension coordinate:
+
+        - ``rho``: radial distance (magnitude of the vector)
+        - ``azimuth``: angle in the x-y plane from the positive x-axis,
+          in radians, in the range ``[-pi, pi]``
+        - ``elevation``: angle from the x-y plane, in radians,
+          in the range ``[-pi/2, pi/2]``
+
+    See Also
+    --------
+    sph2cart : Inverse transformation from spherical to Cartesian.
+
+    """
+    validate_dims_coords(data, {"space": ["x", "y", "z"]})
+
+    x = data.sel(space="x")
+    y = data.sel(space="y")
+    z = data.sel(space="z")
+
+    rho = np.sqrt(x**2 + y**2 + z**2)
+    azimuth = xr.apply_ufunc(np.arctan2, y, x)
+    # Compute elevation, handling zero-magnitude vectors
+    elevation = xr.where(
+        rho > 0,
+        np.arcsin((z / rho).clip(-1, 1)),
+        0.0,
+    )
+
+    # Replace space dim with space_sph
+    dims = list(data.dims)
+    dims[dims.index("space")] = "space_sph"
+    return xr.concat(
+        [
+            rho.assign_coords({"space_sph": "rho"}),
+            azimuth.assign_coords({"space_sph": "azimuth"}),
+            elevation.assign_coords({"space_sph": "elevation"}),
+        ],
+        dim="space_sph",
+    ).transpose(*dims)
+
+
+def sph2cart(data: xr.DataArray) -> xr.DataArray:
+    """Transform spherical coordinates to 3D Cartesian.
+
+    Parameters
+    ----------
+    data
+        The input data containing ``space_sph`` as a dimension,
+        with ``rho``, ``azimuth``, and ``elevation`` in the
+        dimension coordinate.
+
+    Returns
+    -------
+    xarray.DataArray
+        An xarray DataArray containing the Cartesian coordinates
+        stored in the ``space`` dimension, with ``x``, ``y``, and ``z``
+        in the dimension coordinate.
+
+    See Also
+    --------
+    cart2sph : Inverse transformation from Cartesian to spherical.
+
+    """
+    validate_dims_coords(data, {"space_sph": ["rho", "azimuth", "elevation"]})
+
+    rho = data.sel(space_sph="rho")
+    azimuth = data.sel(space_sph="azimuth")
+    elevation = data.sel(space_sph="elevation")
+
+    x = rho * np.cos(elevation) * np.cos(azimuth)
+    y = rho * np.cos(elevation) * np.sin(azimuth)
+    z = rho * np.sin(elevation)
+
+    # Replace space_sph dim with space
+    dims = list(data.dims)
+    dims[dims.index("space_sph")] = "space"
     return xr.concat(
         [
             x.assign_coords({"space": "x"}),
             y.assign_coords({"space": "y"}),
+            z.assign_coords({"space": "z"}),
         ],
         dim="space",
     ).transpose(*dims)
@@ -312,5 +464,16 @@ def _raise_error_for_missing_spatial_dim() -> NoReturn:
         ValueError(
             "Input data array must contain either 'space' or 'space_pol' "
             "as dimensions."
+        )
+    )
+
+
+def _raise_error_for_invalid_spatial_dim_length(
+    dim_name: str, *valid_lengths: int
+) -> NoReturn:
+    lengths_str = " or ".join(str(n) for n in valid_lengths)
+    raise logger.error(
+        ValueError(
+            f"Dimension '{dim_name}' must have {lengths_str} coordinates."
         )
     )

--- a/movement/utils/vector.py
+++ b/movement/utils/vector.py
@@ -42,7 +42,7 @@ def compute_norm(data: xr.DataArray) -> xr.DataArray:
 
     """
     if "space" in data.dims:
-        # Allow both 2D and 3D 
+        # Allow both 2D and 3D
         if len(data.coords["space"]) == 2:
             validate_dims_coords(data, {"space": ["x", "y"]})
         elif len(data.coords["space"]) == 3:
@@ -162,6 +162,12 @@ def cart2pol(data: xr.DataArray) -> xr.DataArray:
     :obj:`numpy.arctan2`
 
     """
+    # Validate space dimension exists
+    if "space" not in data.dims:
+        raise logger.error(
+            ValueError("Input data must contain 'space' as a dimension.")
+        )
+
     # Validate 2D or 3D input
     is_3d = len(data.coords["space"]) == 3
     if is_3d:
@@ -169,9 +175,9 @@ def cart2pol(data: xr.DataArray) -> xr.DataArray:
     else:
         validate_dims_coords(data, {"space": ["x", "y"]})
 
-    x = data.sel(space="x")
-    y = data.sel(space="y")
-    rho = np.sqrt(x**2 + y**2)
+    x = data.sel(space="x", drop=True)
+    y = data.sel(space="y", drop=True)
+    rho = (x**2 + y**2) ** 0.5
     phi = xr.apply_ufunc(np.arctan2, y, x)
 
     # Make all zeros in phi positive zeros
@@ -187,7 +193,7 @@ def cart2pol(data: xr.DataArray) -> xr.DataArray:
 
     # For 3D, pass z through unchanged
     if is_3d:
-        z = data.sel(space="z")
+        z = data.sel(space="z", drop=True)
         components.append(z.assign_coords({"space_pol": "z"}))
 
     # Replace space dim with space_pol
@@ -216,6 +222,12 @@ def pol2cart(data: xr.DataArray) -> xr.DataArray:
         - 3D: ``x``, ``y``, and ``z``
 
     """
+    # Validate space_pol dimension exists
+    if "space_pol" not in data.dims:
+        raise logger.error(
+            ValueError("Input data must contain 'space_pol' as a dimension.")
+        )
+
     # Validate 2D or 3D input
     is_3d = len(data.coords["space_pol"]) == 3
     if is_3d:
@@ -223,8 +235,8 @@ def pol2cart(data: xr.DataArray) -> xr.DataArray:
     else:
         validate_dims_coords(data, {"space_pol": ["rho", "phi"]})
 
-    rho = data.sel(space_pol="rho")
-    phi = data.sel(space_pol="phi")
+    rho = data.sel(space_pol="rho", drop=True)
+    phi = data.sel(space_pol="phi", drop=True)
     x = rho * np.cos(phi)
     y = rho * np.sin(phi)
 
@@ -236,7 +248,7 @@ def pol2cart(data: xr.DataArray) -> xr.DataArray:
 
     # For 3D, pass z through unchanged
     if is_3d:
-        z = data.sel(space_pol="z")
+        z = data.sel(space_pol="z", drop=True)
         components.append(z.assign_coords({"space": "z"}))
 
     # Replace space_pol dim with space
@@ -274,11 +286,11 @@ def cart2sph(data: xr.DataArray) -> xr.DataArray:
     """
     validate_dims_coords(data, {"space": ["x", "y", "z"]})
 
-    x = data.sel(space="x")
-    y = data.sel(space="y")
-    z = data.sel(space="z")
+    x = data.sel(space="x", drop=True)
+    y = data.sel(space="y", drop=True)
+    z = data.sel(space="z", drop=True)
 
-    rho = np.sqrt(x**2 + y**2 + z**2)
+    rho = (x**2 + y**2 + z**2) ** 0.5
     azimuth = xr.apply_ufunc(np.arctan2, y, x)
     # Compute elevation, handling zero-magnitude vectors
     elevation = xr.where(
@@ -297,6 +309,7 @@ def cart2sph(data: xr.DataArray) -> xr.DataArray:
             elevation.assign_coords({"space_sph": "elevation"}),
         ],
         dim="space_sph",
+        coords="minimal",
     ).transpose(*dims)
 
 
@@ -324,9 +337,9 @@ def sph2cart(data: xr.DataArray) -> xr.DataArray:
     """
     validate_dims_coords(data, {"space_sph": ["rho", "azimuth", "elevation"]})
 
-    rho = data.sel(space_sph="rho")
-    azimuth = data.sel(space_sph="azimuth")
-    elevation = data.sel(space_sph="elevation")
+    rho = data.sel(space_sph="rho", drop=True)
+    azimuth = data.sel(space_sph="azimuth", drop=True)
+    elevation = data.sel(space_sph="elevation", drop=True)
 
     x = rho * np.cos(elevation) * np.cos(azimuth)
     y = rho * np.cos(elevation) * np.sin(azimuth)
@@ -342,6 +355,7 @@ def sph2cart(data: xr.DataArray) -> xr.DataArray:
             z.assign_coords({"space": "z"}),
         ],
         dim="space",
+        coords="minimal",
     ).transpose(*dims)
 
 

--- a/tests/test_unit/test_vector.py
+++ b/tests/test_unit/test_vector.py
@@ -89,6 +89,67 @@ class TestVector:
         cart_pol_dataset["space_pol"] = ["a", "b"]
         return cart_pol_dataset
 
+    @pytest.fixture
+    def cart_pol_dataset_3d(self):
+        """Return an xarray.Dataset with 3D Cartesian and cylindrical coords."""
+        # 3D Cartesian coordinates
+        x_vals = np.array([1.0, 0.0, -1.0, 1.0, 0.0])
+        y_vals = np.array([0.0, 1.0, 0.0, 1.0, 0.0])
+        z_vals = np.array([0.0, 0.0, 2.0, 3.0, -1.0])
+        time_coords = np.arange(len(x_vals))
+
+        # Expected cylindrical coordinates (rho in x-y plane, z passes through)
+        rho = np.sqrt(x_vals**2 + y_vals**2)
+        phi = np.arctan2(y_vals, x_vals)
+        # Handle null vectors in x-y plane
+        phi = np.where(np.isclose(rho, 0.0), 0.0, phi)
+
+        cart = xr.DataArray(
+            np.column_stack((x_vals, y_vals, z_vals)),
+            dims=["time", "space"],
+            coords={"time": time_coords, "space": ["x", "y", "z"]},
+        )
+        pol = xr.DataArray(
+            np.column_stack((rho, phi, z_vals)),
+            dims=["time", "space_pol"],
+            coords={"time": time_coords, "space_pol": ["rho", "phi", "z"]},
+        )
+        return xr.Dataset(data_vars={"cart": cart, "pol": pol})
+
+    @pytest.fixture
+    def cart_sph_dataset(self):
+        """Return an xarray.Dataset with 3D Cartesian and spherical coords."""
+        # 3D Cartesian coordinates (points on/around unit sphere)
+        cart_data = np.array([
+            [1.0, 0.0, 0.0],   # +x axis
+            [0.0, 1.0, 0.0],   # +y axis
+            [0.0, 0.0, 1.0],   # +z axis (north pole)
+            [0.0, 0.0, -1.0],  # -z axis (south pole)
+            [1.0, 1.0, 0.0],   # x-y plane, 45 deg
+        ])
+        time_coords = np.arange(len(cart_data))
+
+        # Expected spherical coordinates
+        x, y, z = cart_data[:, 0], cart_data[:, 1], cart_data[:, 2]
+        rho = np.sqrt(x**2 + y**2 + z**2)
+        azimuth = np.arctan2(y, x)
+        elevation = np.where(rho > 0, np.arcsin(z / rho), 0.0)
+
+        cart = xr.DataArray(
+            cart_data,
+            dims=["time", "space"],
+            coords={"time": time_coords, "space": ["x", "y", "z"]},
+        )
+        sph = xr.DataArray(
+            np.column_stack((rho, azimuth, elevation)),
+            dims=["time", "space_sph"],
+            coords={
+                "time": time_coords,
+                "space_sph": ["rho", "azimuth", "elevation"],
+            },
+        )
+        return xr.Dataset(data_vars={"cart": cart, "sph": sph})
+
     @pytest.mark.parametrize(
         "ds, expected_exception",
         [
@@ -196,6 +257,69 @@ class TestVector:
             expected_unit_pol.loc[{"space_pol": "rho"}] = 1
             expected_unit_pol = expected_unit_pol.where(~expected_nan_idxs)
             xr.testing.assert_allclose(unit_pol, expected_unit_pol)
+
+    def test_cart2pol_3d(self, cart_pol_dataset_3d):
+        """Test 3D Cartesian to cylindrical coordinates."""
+        result = vector.cart2pol(cart_pol_dataset_3d.cart)
+        xr.testing.assert_allclose(result, cart_pol_dataset_3d.pol)
+        # Verify z passes through unchanged
+        xr.testing.assert_equal(
+            result.sel(space_pol="z"),
+            cart_pol_dataset_3d.cart.sel(space="z"),
+        )
+
+    def test_pol2cart_3d(self, cart_pol_dataset_3d):
+        """Test 3D cylindrical to Cartesian coordinates."""
+        result = vector.pol2cart(cart_pol_dataset_3d.pol)
+        xr.testing.assert_allclose(result, cart_pol_dataset_3d.cart)
+
+    def test_compute_norm_3d(self, cart_pol_dataset_3d):
+        """Test norm computation on 3D Cartesian and cylindrical data."""
+        cart = cart_pol_dataset_3d.cart
+        pol = cart_pol_dataset_3d.pol
+
+        # 3D Cartesian norm: sqrt(x^2 + y^2 + z^2)
+        result_cart = vector.compute_norm(cart)
+        expected = np.sqrt(
+            cart.sel(space="x") ** 2
+            + cart.sel(space="y") ** 2
+            + cart.sel(space="z") ** 2
+        )
+        xr.testing.assert_allclose(result_cart, expected)
+
+        # Cylindrical norm should return rho (x-y plane magnitude)
+        result_pol = vector.compute_norm(pol)
+        xr.testing.assert_allclose(result_pol, pol.sel(space_pol="rho"))
+
+    def test_convert_to_unit_3d(self, cart_pol_dataset_3d):
+        """Test unit vector conversion on 3D Cartesian data."""
+        cart = cart_pol_dataset_3d.cart
+        unit_cart = vector.convert_to_unit(cart)
+
+        # Unit vectors should have norm = 1
+        norms = vector.compute_norm(unit_cart)
+        # Skip null vectors (where original norm was 0)
+        original_norms = vector.compute_norm(cart)
+        valid_mask = original_norms > 0
+        xr.testing.assert_allclose(
+            norms.where(valid_mask), xr.ones_like(norms).where(valid_mask)
+        )
+
+    def test_cart2sph(self, cart_sph_dataset):
+        """Test 3D Cartesian to spherical coordinates."""
+        result = vector.cart2sph(cart_sph_dataset.cart)
+        xr.testing.assert_allclose(result, cart_sph_dataset.sph)
+
+    def test_sph2cart(self, cart_sph_dataset):
+        """Test spherical to 3D Cartesian coordinates."""
+        result = vector.sph2cart(cart_sph_dataset.sph)
+        xr.testing.assert_allclose(result, cart_sph_dataset.cart)
+
+    def test_cart2sph_sph2cart_roundtrip(self, cart_sph_dataset):
+        """Test roundtrip conversion: cart -> sph -> cart."""
+        cart = cart_sph_dataset.cart
+        roundtrip = vector.sph2cart(vector.cart2sph(cart))
+        xr.testing.assert_allclose(roundtrip, cart)
 
 
 class TestComputeSignedAngle:

--- a/tests/test_unit/test_vector.py
+++ b/tests/test_unit/test_vector.py
@@ -91,7 +91,7 @@ class TestVector:
 
     @pytest.fixture
     def cart_pol_dataset_3d(self):
-        """Return an xarray.Dataset with 3D Cartesian and cylindrical coords."""
+        """Return xarray.Dataset with 3D Cartesian and cylindrical coords."""
         # 3D Cartesian coordinates
         x_vals = np.array([1.0, 0.0, -1.0, 1.0, 0.0])
         y_vals = np.array([0.0, 1.0, 0.0, 1.0, 0.0])
@@ -120,13 +120,15 @@ class TestVector:
     def cart_sph_dataset(self):
         """Return an xarray.Dataset with 3D Cartesian and spherical coords."""
         # 3D Cartesian coordinates (points on/around unit sphere)
-        cart_data = np.array([
-            [1.0, 0.0, 0.0],   # +x axis
-            [0.0, 1.0, 0.0],   # +y axis
-            [0.0, 0.0, 1.0],   # +z axis (north pole)
-            [0.0, 0.0, -1.0],  # -z axis (south pole)
-            [1.0, 1.0, 0.0],   # x-y plane, 45 deg
-        ])
+        cart_data = np.array(
+            [
+                [1.0, 0.0, 0.0],  # +x axis
+                [0.0, 1.0, 0.0],  # +y axis
+                [0.0, 0.0, 1.0],  # +z axis (north pole)
+                [0.0, 0.0, -1.0],  # -z axis (south pole)
+                [1.0, 1.0, 0.0],  # x-y plane, 45 deg
+            ]
+        )
         time_coords = np.arange(len(cart_data))
 
         # Expected spherical coordinates
@@ -264,8 +266,8 @@ class TestVector:
         xr.testing.assert_allclose(result, cart_pol_dataset_3d.pol)
         # Verify z passes through unchanged
         xr.testing.assert_equal(
-            result.sel(space_pol="z"),
-            cart_pol_dataset_3d.cart.sel(space="z"),
+            result.sel(space_pol="z", drop=True),
+            cart_pol_dataset_3d.cart.sel(space="z", drop=True),
         )
 
     def test_pol2cart_3d(self, cart_pol_dataset_3d):
@@ -281,15 +283,16 @@ class TestVector:
         # 3D Cartesian norm: sqrt(x^2 + y^2 + z^2)
         result_cart = vector.compute_norm(cart)
         expected = np.sqrt(
-            cart.sel(space="x") ** 2
-            + cart.sel(space="y") ** 2
-            + cart.sel(space="z") ** 2
+            cart.sel(space="x", drop=True) ** 2
+            + cart.sel(space="y", drop=True) ** 2
+            + cart.sel(space="z", drop=True) ** 2
         )
         xr.testing.assert_allclose(result_cart, expected)
 
         # Cylindrical norm should return rho (x-y plane magnitude)
         result_pol = vector.compute_norm(pol)
-        xr.testing.assert_allclose(result_pol, pol.sel(space_pol="rho"))
+        expected_pol = pol.sel(space_pol="rho", drop=True)
+        xr.testing.assert_allclose(result_pol, expected_pol)
 
     def test_convert_to_unit_3d(self, cart_pol_dataset_3d):
         """Test unit vector conversion on 3D Cartesian data."""


### PR DESCRIPTION
## Description

Adds 3D Support for Coordinate Transforms & Vector Operations

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

The `movement` library currently only supports 2D coordinate transforms and vector operations in `vector.py`. To enable 3D motion analysis, the vector utilities need to handle 3D Cartesian, cylindrical, and spherical coordinate systems. 

**What does this PR do?**

Extends existing functions and adds new functions in `movement/utils/vector.py`:

| Function | Change |
|----------|--------|
| `compute_norm` | Extended to handle 3D Cartesian `["x", "y", "z"]` and 3D cylindrical `["rho", "phi", "z"]` |
| `convert_to_unit` | Extended to handle 3D Cartesian and 3D cylindrical coordinates |
| `cart2pol` | Extended to handle 3D Cartesian → cylindrical (z passes through unchanged) |
| `pol2cart` | Extended to handle 3D cylindrical → Cartesian (z passes through unchanged) |
| `cart2sph` | **New:**  3D Cartesian → spherical `["rho", "azimuth", "elevation"]` |
| `sph2cart` | **New:**  Spherical → 3D Cartesian |
| `_raise_error_for_invalid_spatial_dim_length` | **New:** Helper for validation errors when spatial dimension has unexpected length |

**Implementation details:**
- Added dimension existence checks in `cart2pol`/`pol2cart` before accessing coords (raises `ValueError` with clear message)
- Uses `drop=True` on `.sel()` calls to avoid retaining scalar coordinates
- Uses `coords="minimal"` in `xr.concat` for `cart2sph`/`sph2cart` to handle coordinate alignment
- Helper function `_raise_error_for_invalid_spatial_dim_length` for consistent error messages

## References

- Spatial.coordinate.systems.pdf attachment in Issue #374 
- PR #875 

## How has this PR been tested?

Added 7 new test methods and 2 new fixtures in `tests/test_unit/test_vector.py`:

**New fixtures:**
- `cart_pol_dataset_3d` - 3D Cartesian + cylindrical test data (5 points including null vector edge case)
- `cart_sph_dataset` - 3D Cartesian + spherical test data (5 points including poles and axis-aligned vectors)

**New tests:**
| Test | What it verifies |
|------|------------------|
| `test_cart2pol_3d` | 3D Cartesian → cylindrical conversion, z passthrough |
| `test_pol2cart_3d` | 3D cylindrical → Cartesian conversion |
| `test_compute_norm_3d` | 3D norm: `sqrt(x²+y²+z²)` for Cartesian, `rho` for cylindrical |
| `test_convert_to_unit_3d` | 3D unit vectors have norm = 1 |
| `test_cart2sph` | 3D Cartesian → spherical conversion |
| `test_sph2cart` | Spherical → 3D Cartesian conversion |
| `test_cart2sph_sph2cart_roundtrip` | Roundtrip consistency |

Existing 2D tests continue to pass, ensuring no regression.

## Is this a breaking change?

No. All existing 2D functionality is preserved. The changes extend the existing functions to accept 3D data while maintaining full backward compatibility with 2D data.

## Does this PR require an update to the documentation?

No. API reference is auto-generated from docstrings. The following docstrings have been added/updated:

1. **`cart2pol` and `pol2cart`**: Updated to document both 2D and 3D modes, including:
   - Input coordinates (`["x", "y"]` or `["x", "y", "z"]`)
   - Output coordinates (`["rho", "phi"]` or `["rho", "phi", "z"]`)
   - Note that `z` passes through unchanged in 3D mode
2. **`compute_norm` and `convert_to_unit`**: Accept both 2D and 3D implicitly via existing `space`/`space_pol` dimension handling (no docstring changes needed)
3. **`cart2sph` and `sph2cart`** (new): 
   - Parameters and return types
   - Coordinate conventions (`rho`, `azimuth`, `elevation`)
   - Angle ranges and units (radians)
   - Cross-references via `See Also`

## Next Steps

A subsequent PR (once #875 is merged) can then extend `collective.py` to support 3D polarization by utilizing the new vector utilities.

**Current state of `collective.py`:**
```python
from movement.utils.vector import (
    compute_norm,
    compute_signed_angle_2d,  # 2D only
    convert_to_unit,
)
```
- Uses `return_angle: bool` and `in_degrees: bool` parameters
- Returns single `mean_angle` (2D only, uses `compute_signed_angle_2d`)
- Ignores `z` coordinate (line 55-56: "polarization is computed in the x/y plane")

**Planned changes**: 

1. **Update imports** - Add `cart2pol` and `cart2sph`:
   ```python
   from movement.utils.vector import (
       cart2pol,
       cart2sph,
       compute_norm,
       convert_to_unit,
   )
   ```

2. **Replace `return_angle`/`in_degrees` with `return_direction`**:
   - `False` (default): return only polarization
   - `"unit_vector"`: also return mean heading/orientation as unit vector
   - `"angle_radians"`: also return angle(s) in radians
   - `"angle_degrees"`: also return angle(s) in degrees

3. **Use `cart2pol`/`cart2sph` for angle conversion** (replaces `compute_signed_angle_2d`):
   ```python
   # 2D: use cart2pol → return (polarization, azimuth)
   angles_pol = cart2pol(mean_unit_vector)
   azimuth = angles_pol.sel(space_pol="phi")

   # 3D: use cart2sph → return (polarization, azimuth, elevation)
   angles_sph = cart2sph(mean_unit_vector)
   azimuth = angles_sph.sel(space_sph="azimuth")
   elevation = angles_sph.sel(space_sph="elevation")
   ```

**Example API after changes:**
```python
from movement.kinematics import compute_polarization

# Orientation polarization (body-axis mode) - default, no direction
pol = compute_polarization(data, body_axis_keypoints=("tail_base", "neck"))

# Heading polarization (displacement mode) - default, no direction
pol = compute_polarization(data.sel(keypoints="thorax"))
pol = compute_polarization(data.sel(keypoints="thorax"), displacement_frames=5)

# Return mean heading/orientation as unit vector (works for 2D and 3D)
pol, unit_vec = compute_polarization(
  data,
  body_axis_keypoints=("tail_base", "neck"),
  return_direction="unit_vector"
)

# 2D data: return (polarization, azimuth)
pol, azimuth = compute_polarization(
  data_2d,
  body_axis_keypoints=("tail_base", "neck"),
  return_direction="angle_degrees"
)

# 3D data: return (polarization, azimuth, elevation)
pol, azimuth, elevation = compute_polarization(
  data_3d,
  body_axis_keypoints=("tail_base", "neck"),
  return_direction="angle_degrees"
)
```

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
