### PR TITLE
Migrate `dev` and `docs` from optional dependencies to PEP 735 dependency groups

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -39,7 +39,7 @@ jobs:
             ~/.movement/*
           key: cached-test-data-${{ runner.os }}
           restore-keys: cached-test-data
-      - uses: neuroinformatics-unit/actions/build_sphinx_docs@main
+      - uses: neuroinformatics-unit/actions/build_sphinx_docs@build-docs-group-dep
         with:
           python-version: 3.13
           use-make: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ source .venv/bin/activate  # On macOS and Linux
 .venv\Scripts\activate     # On Windows PowerShell
 
 # Install in editable mode with dev dependencies
-uv pip install -e ".[dev]"
+uv pip install -e . --group dev
 
 # Install pre-commit hooks
 pre-commit install
@@ -61,7 +61,7 @@ mypy movement
 ### Documentation
 ```bash
 # Install documentation dependencies
-pip install -e ".[docs]"
+uv pip install -e . --group docs
 
 # Build documentation (from docs/ directory)
 cd docs

--- a/docs/source/community/contributing.md
+++ b/docs/source/community/contributing.md
@@ -76,7 +76,7 @@ Now that you have the repository locally, you need to set up a Python environmen
     Then, install the package in editable mode with development dependencies:
 
     ```sh
-    pip install -e ".[dev]"
+    pip install -e . --group dev
     ```
     :::
 
@@ -93,12 +93,18 @@ Now that you have the repository locally, you need to set up a Python environmen
     Then, install the package in editable mode with development dependencies:
 
     ```sh
-    uv pip install -e ".[dev]"
+    uv pip install -e . --group dev
     ```
     :::
 
     ::::
-    If you also want to edit the documentation and preview the changes locally, you will additionally need the `docs` extra dependencies. See [Editing the documentation](#editing-the-documentation) for more details.
+    If you also want to [edit the documentation](#editing-the-documentation) and preview the changes locally, you will additionally need the `docs` dependencies.
+    To install both `dev` and `docs` dependencies at once, use `--all-groups`:
+
+    ```sh
+    pip install -e . --all-groups      # conda env
+    uv pip install -e . --all-groups   # uv env
+    ```
 
 2. Finally, initialise the [pre-commit hooks](#formatting-and-pre-commit-hooks):
 
@@ -615,10 +621,10 @@ This keeps the documentation aligned with releases, while allowing manual redepl
 ### Editing the documentation
 To edit the documentation, ensure you have already set up a [development environment](#creating-a-development-environment).
 
-To build the documentation locally, install the extra dependencies by running the following command from the repository root:
+To build the documentation locally, install the `docs` dependencies by running the following command from the repository root:
 ```sh
-pip install -e ".[docs]"      # conda env
-uv pip install -e ".[docs]"   # uv env
+pip install -e . --group docs      # conda env
+uv pip install -e . --group docs   # uv env
 ```
 
 Now create a new branch, edit the documentation source files (`.md` or `.rst` in the `docs` folder),

--- a/docs/source/community/contributing.md
+++ b/docs/source/community/contributing.md
@@ -76,7 +76,7 @@ Now that you have the repository locally, you need to set up a Python environmen
     Then, install the package in editable mode with development dependencies:
 
     ```sh
-    pip install -e ".[dev]"
+    pip install -e . --group dev
     ```
     :::
 
@@ -93,12 +93,18 @@ Now that you have the repository locally, you need to set up a Python environmen
     Then, install the package in editable mode with development dependencies:
 
     ```sh
-    uv pip install -e ".[dev]"
+    uv pip install -e . --group dev
     ```
     :::
 
     ::::
-    If you also want to edit the documentation and preview the changes locally, you will additionally need the `docs` extra dependencies. See [Editing the documentation](#editing-the-documentation) for more details.
+    If you also want to [edit the documentation](#editing-the-documentation) and preview the changes locally, you will additionally need the `docs` dependencies.
+    To install both `dev` and `docs` dependencies at once, use the `all` group:
+
+    ```sh
+    pip install -e . --group all      # conda env
+    uv pip install -e . --group all   # uv env
+    ```
 
 2. Finally, initialise the [pre-commit hooks](#formatting-and-pre-commit-hooks):
 
@@ -602,10 +608,10 @@ This keeps the documentation aligned with releases, while allowing manual redepl
 ### Editing the documentation
 To edit the documentation, ensure you have already set up a [development environment](#creating-a-development-environment).
 
-To build the documentation locally, install the extra dependencies by running the following command from the repository root:
+To build the documentation locally, install the `docs` dependencies by running the following command from the repository root:
 ```sh
-pip install -e ".[docs]"      # conda env
-uv pip install -e ".[docs]"   # uv env
+pip install -e . --group docs      # conda env
+uv pip install -e . --group docs   # uv env
 ```
 
 Now create a new branch, edit the documentation source files (`.md` or `.rst` in the `docs` folder),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,7 +218,7 @@ passenv =
     XAUTHORITY
     NUMPY_EXPERIMENTAL_ARRAY_FUNCTION
     PYVISTA_OFF_SCREEN
-extras =
+dependency_groups =
     dev
 commands =
     pytest -v --color=yes --cov=movement --cov-report=xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,8 @@ entry-points."napari.manifest".movement = "movement.napari:napari.yaml"
 
 [project.optional-dependencies]
 napari = ["napari[all]>=0.6.0"]
+
+[dependency-groups]
 dev = [
   "pytest",
   "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,9 @@ entry-points."napari.manifest".movement = "movement.napari:napari.yaml"
 
 [project.optional-dependencies]
 napari = ["napari[all]>=0.6.0"]
+
+[dependency-groups]
+all = [{include-group = "dev"}, {include-group = "docs"}]
 dev = [
   "pytest",
   "pytest-cov",


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Closes #955 

**What does this PR do?**
- moves `docs` and `dev` dependencies from "optional dependencies" (extras) to "dependency groups"
- updates pip install instructions to use `--group`
- ~~temporarily uses `build_sphinx_docs@build-docs-group-dep`~~ (from https://github.com/neuroinformatics-unit/actions/pull/158)

## References
https://github.com/neuroinformatics-unit/actions/pull/158

## How has this PR been tested?
- build docs@main [fails](https://github.com/neuroinformatics-unit/movement/actions/runs/24256424665/job/70829024250?pr=956) 
- build docs@build-docs-group-dep [passes](https://github.com/neuroinformatics-unit/movement/actions/runs/24355193043/job/71120187411?pr=956)

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
