### PR TITLE
Convert CLI from argparse to typer

### DIFF
--- a/docs/source/community/contributing.md
+++ b/docs/source/community/contributing.md
@@ -481,6 +481,17 @@ SourceSoftware: TypeAlias = Literal[
 ]
 ```
 
+### Developing the CLI
+
+The `movement` command-line interface lives in `movement/cli_entrypoint`
+and is built with [Typer](https://typer.tiangolo.com/). Subcommands are
+defined by decorating functions with `@app.command()` on the shared `app`
+instance (see the existing `info` and `launch` subcommands as a template).
+The console script is registered via `[project.scripts]` in `pyproject.toml`,
+pointing to `movement.cli_entrypoint:main`. Tests for the CLI live in
+`tests/test_unit/test_cli_entrypoint.py` and use `typer.testing.CliRunner`
+to invoke the app and assert on exit codes and output.
+
 ### Developing the napari plugin
 
 The `movement` plugin for `napari` is built following the

--- a/movement/cli_entrypoint.py
+++ b/movement/cli_entrypoint.py
@@ -1,6 +1,5 @@
 """CLI entrypoint for the ``movement`` package."""
 
-import argparse
 import platform
 import subprocess
 import sys
@@ -8,6 +7,7 @@ import sys
 import numpy as np
 import pandas as pd
 import scipy as sp
+import typer
 import xarray as xr
 
 import movement
@@ -39,34 +39,23 @@ ASCII_ART = r"""
                              ,..###(
     """
 
-
-def main() -> None:
-    """Entrypoint for the CLI."""
-    parser = argparse.ArgumentParser(prog="movement")
-    subparsers = parser.add_subparsers(dest="command", title="commands")
-
-    # Add 'info' command
-    info_parser = subparsers.add_parser(
-        "info", help="output diagnostic information about the environment"
-    )
-    info_parser.set_defaults(func=info)
-
-    # Add 'launch' command
-    launch_parser = subparsers.add_parser(
-        "launch", help="launch the movement plugin in napari"
-    )
-    launch_parser.set_defaults(func=launch)
-
-    args = parser.parse_args()
-    if args.command is None:
-        help_message = parser.format_help()
-        print(help_message)
-    else:
-        args.func()
+app = typer.Typer(
+    name="movement",
+    help="A Python toolbox for analysing animal body movements.",
+    add_completion=False,
+)
 
 
+@app.callback(invoke_without_command=True)
+def callback(ctx: typer.Context) -> None:
+    """Show help when no subcommand is provided."""
+    if ctx.invoked_subcommand is None:
+        typer.echo(ctx.get_help())
+
+
+@app.command()
 def info() -> None:
-    """Output diagnostic information."""
+    """Output diagnostic information about the environment."""
     text = (
         f"{ASCII_ART}\n"
         f"     movement: {movement.__version__}\n"
@@ -85,9 +74,10 @@ def info() -> None:
         text += "     napari: not installed\n"
 
     text += f"     Platform: {platform.platform()}\n"
-    print(text)
+    typer.echo(text)
 
 
+@app.command()
 def launch() -> None:
     """Launch the movement plugin in napari."""
     try:
@@ -97,10 +87,16 @@ def launch() -> None:
         )
     except subprocess.CalledProcessError as e:
         # if subprocess.run() fails with non-zero exit code
-        print(
+        typer.echo(
             "\nAn error occurred while launching the movement plugin "
             f"for napari:\n  {e}"
         )
+        raise typer.Exit(code=1)
+
+
+def main() -> None:
+    """Entrypoint for the CLI."""
+    app()
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/movement/cli_entrypoint.py
+++ b/movement/cli_entrypoint.py
@@ -42,7 +42,6 @@ ASCII_ART = r"""
 app = typer.Typer(
     name="movement",
     help="A Python toolbox for analysing animal body movements.",
-    add_completion=False,
 )
 
 

--- a/movement/cli_entrypoint.py
+++ b/movement/cli_entrypoint.py
@@ -90,7 +90,7 @@ def launch() -> None:
             "\nAn error occurred while launching the movement plugin "
             f"for napari:\n  {e}"
         )
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from e
 
 
 def main() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ dependencies = [
   "pynwb",
   "ndx-pose>=0.2.1",
   "jsonschema",
-  "orjson"
+  "orjson",
+  "typer>=0.9.0"
 ]
 
 classifiers = [

--- a/tests/test_unit/test_cli_entrypoint.py
+++ b/tests/test_unit/test_cli_entrypoint.py
@@ -1,38 +1,29 @@
 import builtins
 import subprocess
 import sys
-from contextlib import nullcontext as does_not_raise
 from unittest.mock import patch
 
 import pytest
+from typer.testing import CliRunner
 
-from movement.cli_entrypoint import main
+from movement.cli_entrypoint import app
+
+runner = CliRunner()
 
 
 @pytest.mark.parametrize(
-    "command, expected_exception",
+    "args, expected_exit_code, expected_output",
     [
-        (
-            ["movement", "info"],
-            does_not_raise("Platform: "),
-        ),  # Valid arg
-        (
-            ["movement", "invalid"],
-            pytest.raises(SystemExit),
-        ),  # Invalid arg
-        (["movement"], does_not_raise("usage: movement")),  # Empty arg
+        (["info"], 0, "Platform: "),  # Valid command
+        (["invalid"], 2, ""),  # Invalid command exits with code 2
+        ([], 0, "movement"),  # No command shows help
     ],
 )
-def test_entrypoint_command(command, expected_exception):
+def test_entrypoint_command(args, expected_exit_code, expected_output):
     """Test the entrypoint with different commands: 'info', 'invalid', ''."""
-    with (
-        patch("sys.argv", command),
-        patch("builtins.print") as mock_print,
-        expected_exception as e,
-    ):
-        main()
-        printed_message = " ".join(map(str, mock_print.call_args.args))
-        assert e in printed_message
+    result = runner.invoke(app, args)
+    assert result.exit_code == expected_exit_code
+    assert expected_output in result.output
 
 
 original_import = builtins.__import__
@@ -47,38 +38,35 @@ def fake_import(name, globals, locals, fromlist, level):
 
 def test_info_without_napari_installed():
     """Test the 'movement info' can report that napari is not installed."""
-    with (
-        patch("sys.argv", ["movement", "info"]),
-        patch("builtins.print") as mock_print,
-        patch("builtins.__import__", side_effect=fake_import),
-    ):
-        main()
-        printed_message = " ".join(map(str, mock_print.call_args.args))
-        assert "napari: not installed" in printed_message
+    with patch("builtins.__import__", side_effect=fake_import):
+        result = runner.invoke(app, ["info"])
+    assert result.exit_code == 0
+    assert "napari: not installed" in result.output
 
 
 @pytest.mark.parametrize(
-    "run_side_effect, expected_message",
+    "run_side_effect, expected_exit_code, expected_output",
     [
-        (None, ""),  # No error
-        (subprocess.CalledProcessError(1, "napari"), "error occurred while"),
+        (None, 0, ""),  # No error
+        (
+            subprocess.CalledProcessError(1, "napari"),
+            1,
+            "error occurred while",
+        ),
     ],
 )
-def test_launch_command(run_side_effect, expected_message, capsys):
+def test_launch_command(run_side_effect, expected_exit_code, expected_output):
     """Test the 'launch' command.
 
     We mock the subprocess.run function to avoid actually launching napari.
     """
-    with (
-        patch("sys.argv", ["movement", "launch"]),
-        patch("subprocess.run", side_effect=run_side_effect) as mock_run,
-    ):
-        main()
-        # Assert that subprocess.run was called with the correct arguments
-        mock_run.assert_called_once()
-        args = mock_run.call_args[0][0]
-        assert args[0] == sys.executable
-        assert args[1:] == ["-m", "napari", "-w", "movement"]
-        # Assert that the expected message was printed
-        captured = capsys.readouterr()
-        assert expected_message in captured.out
+    with patch("subprocess.run", side_effect=run_side_effect) as mock_run:
+        result = runner.invoke(app, ["launch"])
+    # Assert that subprocess.run was called with the correct arguments
+    mock_run.assert_called_once()
+    args = mock_run.call_args[0][0]
+    assert args[0] == sys.executable
+    assert args[1:] == ["-m", "napari", "-w", "movement"]
+    # Assert exit code and output
+    assert result.exit_code == expected_exit_code
+    assert expected_output in result.output

--- a/tests/test_unit/test_cli_entrypoint.py
+++ b/tests/test_unit/test_cli_entrypoint.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 from typer.testing import CliRunner
 
-from movement.cli_entrypoint import app
+from movement.cli_entrypoint import app, main
 
 runner = CliRunner()
 
@@ -70,3 +70,10 @@ def test_launch_command(run_side_effect, expected_exit_code, expected_output):
     # Assert exit code and output
     assert result.exit_code == expected_exit_code
     assert expected_output in result.output
+
+
+def test_main_invokes_app():
+    """Test that ``main()`` invokes the Typer app."""
+    with patch("movement.cli_entrypoint.app") as mock_app:
+        main()
+    mock_app.assert_called_once_with()


### PR DESCRIPTION
## Summary

Closes #961

Replaces the `argparse`-based CLI with [Typer](https://typer.tiangolo.com/), giving automatic well-formatted help pages, shell completion support, and a cleaner foundation for adding future commands.

### Changes

- **`movement/cli_entrypoint.py`** — rewritten using `typer.Typer()`. The two subcommands (`info`, `launch`) are decorated with `@app.command()`. A `@app.callback(invoke_without_command=True)` handles the no-subcommand case (shows help, exits 0). `typer.echo()` replaces `print()` throughout; `raise typer.Exit(code=1)` is used on `launch` failure so the process exits with a non-zero status code instead of silently returning 0. Shell completions (`--install-completion` / `--show-completion`) are enabled by default via Typer.
- **`pyproject.toml`** — `typer>=0.9.0` added to core `dependencies`. Note: `typer` is already a transitive dependency of `npe2` (the napari plugin engine), so this makes an existing dependency explicit rather than adding a new one.
- **`tests/test_unit/test_cli_entrypoint.py`** — tests rewritten to use `typer.testing.CliRunner`, the idiomatic approach for Typer apps. Coverage is equivalent to the previous suite (valid command, invalid command, no command, napari-not-installed, launch success, launch failure).

### Open questions for maintainers

1. **`typer` version floor** — `typer>=0.9.0` is proposed. Is there a preferred minimum, or should it be left unpinned (`typer`)?
2. **`launch` error exit code** — previously a `CalledProcessError` in `launch` printed a message and returned exit code 0. This PR changes that to exit code 1, which is more correct for signalling failure to calling processes/scripts. Happy to revert if the existing behaviour was intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)