### PR TITLE
Add `get_supported_source_software()` to expose supported formats

### DIFF
--- a/docs/source/user_guide/input_output.md
+++ b/docs/source/user_guide/input_output.md
@@ -23,6 +23,10 @@ You are also welcome to try `movement` by loading some [sample data](target-samp
 which are represented as [movement datasets](target-poses-and-bboxes-dataset)
 and can be loaded from and saved to various third-party formats.
 
+:::{tip}
+To programmatically query the supported source software names and their file suffixes, use {func}`~movement.io.load.get_supported_source_software`.
+:::
+
 | Source Software                                                             | Abbreviation | Source Format                                                                                                             | Dataset Type         | Supported Operations |
 | --------------------------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------- | -------------------- | -------------------- |
 | [DeepLabCut](dlc:)                                                          | DLC          | DLC-style .h5 or .csv file, or corresponding pandas DataFrame                                                             | Pose                 | Load & Save          |

--- a/movement/io/__init__.py
+++ b/movement/io/__init__.py
@@ -1,4 +1,14 @@
 from . import load_bboxes, load_poses  # Trigger register_loader decorators
-from .load import infer_source_software, load_dataset, load_multiview_dataset
+from .load import (
+    get_supported_source_software,
+    infer_source_software,
+    load_dataset,
+    load_multiview_dataset,
+)
 
-__all__ = ["infer_source_software", "load_dataset", "load_multiview_dataset"]
+__all__ = [
+    "get_supported_source_software",
+    "infer_source_software",
+    "load_dataset",
+    "load_multiview_dataset",
+]

--- a/movement/io/load.py
+++ b/movement/io/load.py
@@ -98,14 +98,12 @@ def get_supported_source_software() -> dict[str, set[str]]:
         without file validators will map to an empty set.
 
     """
-    result: dict[str, set[str]] = {}
-    for sw, validators_list in _LOADER_VALIDATORS_REGISTRY.items():
-        result[sw] = {
-            suffix
-            for validator_cls in validators_list
-            for suffix in getattr(validator_cls, "suffixes", set())
-        }
-    return result
+    return {
+        sw: set().union(
+            *(validator_cls.suffixes for validator_cls in validators_list)
+        )
+        for sw, validators_list in _LOADER_VALIDATORS_REGISTRY.items()
+    }
 
 
 def infer_source_software(

--- a/movement/io/load.py
+++ b/movement/io/load.py
@@ -82,6 +82,32 @@ _LOADER_REGISTRY: dict[str, LoaderProtocol] = {}
 _LOADER_VALIDATORS_REGISTRY: dict[SourceSoftware, list[type[ValidFile]]] = {}
 
 
+def get_supported_source_software() -> dict[str, set[str]]:
+    """Return registered source software and supported file suffixes.
+
+    Returns a mapping of each registered source software name to the
+    set of file suffixes (extensions) it can load. This is useful for
+    downstream packages that depend on ``movement`` for I/O and want to
+    programmatically discover supported formats.
+
+    Returns
+    -------
+    dict[str, set[str]]
+        Mapping of source software names to sets of supported file
+        suffixes (e.g. ``{".h5", ".csv"}``). Loaders registered
+        without file validators will map to an empty set.
+
+    """
+    result: dict[str, set[str]] = {}
+    for sw, validators_list in _LOADER_VALIDATORS_REGISTRY.items():
+        result[sw] = {
+            suffix
+            for validator_cls in validators_list
+            for suffix in getattr(validator_cls, "suffixes", set())
+        }
+    return result
+
+
 def infer_source_software(
     file: Path | str | pynwb.file.NWBFile,
     **loader_kwargs,
@@ -340,6 +366,8 @@ def load_dataset(
     source_software
         The source software of the file. If set to ``"auto"`` (default),
         it is inferred from the file format via :func:`infer_source_software`.
+        Use :func:`get_supported_source_software` to list all registered
+        source software names and their supported file suffixes.
     fps
         The number of frames per second in the video. If None (default),
         the ``time`` coordinates will be in frame numbers.
@@ -409,6 +437,8 @@ def load_multiview_dataset(
     source_software
         The source software of the files. If set to ``"auto"`` (default),
         it is inferred from the file format via :func:`infer_source_software`.
+        Use :func:`get_supported_source_software` to list all registered
+        source software names and their supported file suffixes.
     fps
         The number of frames per second in the video. If None (default),
         the ``time`` coordinates will be in frame numbers.

--- a/tests/test_unit/test_io/test_load.py
+++ b/tests/test_unit/test_io/test_load.py
@@ -174,6 +174,26 @@ def test_build_suffix_map():
     assert suffix_map == {".stub": StubValidFile}
 
 
+def test_get_supported_source_software():
+    """Test that get_supported_source_software returns a non-empty
+    mapping whose keys match the loader registry and whose values
+    are sets of file-suffix strings.
+
+    We intentionally avoid checking exact values here, to avoid
+    having to update this test every time we add a new format.
+    """
+    supported = load.get_supported_source_software()
+    assert isinstance(supported, dict)
+    assert len(supported) > 0
+    assert set(supported) == set(load._LOADER_REGISTRY)
+    for sw, suffixes in supported.items():
+        assert isinstance(sw, str)
+        assert isinstance(suffixes, set)
+        for suffix in suffixes:
+            assert isinstance(suffix, str)
+            assert suffix.startswith(".")
+
+
 @pytest.mark.parametrize(
     "file_fixture, expected_source_software", AUTO_SOURCE_SOFTWARE_CASES
 )

--- a/tests/test_unit/test_io/test_load.py
+++ b/tests/test_unit/test_io/test_load.py
@@ -178,20 +178,13 @@ def test_get_supported_source_software():
     """Test that get_supported_source_software returns a non-empty
     mapping whose keys match the loader registry and whose values
     are sets of file-suffix strings.
-
-    We intentionally avoid checking exact values here, to avoid
-    having to update this test every time we add a new format.
     """
     supported = load.get_supported_source_software()
     assert isinstance(supported, dict)
-    assert len(supported) > 0
     assert set(supported) == set(load._LOADER_REGISTRY)
     for sw, suffixes in supported.items():
-        assert isinstance(sw, str)
-        assert isinstance(suffixes, set)
-        for suffix in suffixes:
-            assert isinstance(suffix, str)
-            assert suffix.startswith(".")
+        for validator_cls in load._LOADER_VALIDATORS_REGISTRY.get(sw, []):
+            assert validator_cls.suffixes.issubset(suffixes)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

See #966.

**What does this PR do?**

Adds `get_supported_source_software()` to expose the supported `source_software_values` and their corresponding file suffixes.

This allows downstream packages to programmatically discover which source software formats `movement` supports, along with their file suffixes, without hard-coding the list.

## References

- Closes #966.
- See also discussion on Zulip [#Movement > expose registries](https://neuroinformatics.zulipchat.com/#narrow/channel/406001-Movement/topic/expose.20registries/with/591783893)

## How has this PR been tested?

A unit test has been added to verify the returned structure, but not the exact values, to avoid having to update this test everytime we add a new format. 

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

API docs are updated automatically (I've  checked this). 

The new functions is also cross-referenced from the docstrings of `load_dataset` and `load_multiview_dataset`, and from the Input/Output user guide, for discoverability.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
