### PR TITLE
Use custom `typehints_formatter` to handle PEP 695 `TypeAliasType`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,8 +8,11 @@
 
 import os
 import sys
+import types
+from typing import TypeAliasType
 
 import setuptools_scm
+from sphinx_autodoc_typehints import format_annotation
 
 # Used when building API docs, put the dependencies
 # of any class you are documenting here
@@ -88,8 +91,57 @@ autodoc_default_options = {
     "member-order": "groupwise",
 }
 
+
+def _get_canonical_type_alias_name(annotation):
+    """Get canonical public qualified name for a TypeAliasType.
+
+    For types defined in private modules (e.g. ``numpy._typing.ArrayLike``),
+    search ``sys.modules`` for a public re-export
+    (e.g. ``numpy.typing.ArrayLike``).
+    """
+    module = getattr(annotation, "__module__", "") or ""
+    name = getattr(annotation, "__name__", "") or ""
+    if not module or not name:
+        return ""
+    if not any(part.startswith("_") for part in module.split(".")):
+        return f"{module}.{name}"
+    top_pkg = module.split(".")[0]
+    for mod_name in sorted(sys.modules):
+        if not mod_name.startswith(top_pkg):
+            continue
+        mod = sys.modules[mod_name]
+        if not isinstance(mod, types.ModuleType):
+            continue
+        if any(part.startswith("_") for part in mod_name.split(".")):
+            continue
+        if getattr(mod, name, None) is annotation:
+            return f"{mod_name}.{name}"
+    return f"{module}.{name}"
+
+
+def _typehints_formatter(annotation, config):
+    """Handle formatting of PEP695 type aliases in sphinx-autodoc-typehints."""
+    if isinstance(annotation, TypeAliasType):
+        module = getattr(annotation, "__module__", "") or ""
+        name = getattr(annotation, "__name__", "") or ""
+        intersphinx_mapping = getattr(config, "intersphinx_mapping", {})
+        is_external = module and any(
+            module == pkg or module.startswith(f"{pkg}.")
+            for pkg in intersphinx_mapping
+        )
+        # Handle external PEP695 type aliases
+        if is_external and name:
+            canonical = _get_canonical_type_alias_name(annotation)
+            if canonical:
+                return f":py:data:`~{canonical}`"
+        # Unwrap internal PEP695 type aliases to their underlying types
+        return format_annotation(annotation.__value__, config)
+    return None
+
+
 # sphinx-autodoc-typehints configuration
 always_use_bars_union = True
+typehints_formatter = _typehints_formatter
 
 # Prefix section labels with the document name
 autosectionlabel_prefix_document = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -87,6 +87,10 @@ autodoc_default_options = {
     "special-members": "__call__",
     "member-order": "groupwise",
 }
+
+# sphinx-autodoc-typehints configuration
+always_use_bars_union = True
+
 # Prefix section labels with the document name
 autosectionlabel_prefix_document = True
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -133,7 +133,7 @@ def _typehints_formatter(annotation, config):
         if is_external and name:
             canonical = _get_canonical_type_alias_name(annotation)
             if canonical:
-                return f":py:data:`~{canonical}`"
+                return f":py:obj:`~{canonical}`"
         # Unwrap internal PEP695 type aliases to their underlying types
         return format_annotation(annotation.__value__, config)
     return None

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -146,6 +146,10 @@ typehints_formatter = _typehints_formatter
 # Prefix section labels with the document name
 autosectionlabel_prefix_document = True
 
+# Suppress config cache warning caused by `typehints_formatter`
+# as Sphinx cannot pickle callables
+suppress_warnings = ["config.cache"]
+
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Closes #958 

**What does this PR do?**
- works around https://github.com/tox-dev/sphinx-autodoc-typehints/issues/690 using a custom `typehint_formatter` that automatically expands `TypeAliasType` instances to their underlying type(s), for external `TypeAliasType`, create a shortened cross-ref if intersphinx is configured, otherwise it's just the name of the `TypeAliasType`. 
- configures sphinx to suppress config.cache warnings caused by setting `typehint_formatter` to a Callable - CI fails on warning (a closed [issue](https://github.com/tox-dev/sphinx-autodoc-typehints/issues/457) at sphinx-autodoc-typehints but is still happening)
- configures sphinx-autodoc-typehints to use `|` instead of `Unions` for a cleaner look, otherwise Unions of Unions get messy, e.g. with `SourceSoftwareOrAuto`. The default for py3.14+ is `True` anyway.

## References
- sphinx-autodoc-typehints
  - [open issue](https://github.com/tox-dev/sphinx-autodoc-typehints/issues/690) for `TypeAliasType` 
  - [open PR](https://github.com/tox-dev/sphinx-autodoc-typehints/pull/691) to support `TypeAliasType`
  - [issue](https://github.com/tox-dev/sphinx-autodoc-typehints/issues/457) on Sphinx config.cache warning upon setting `typehint_formatter`
 - sphinx
   - [more open PEP 695 issues ](https://github.com/sphinx-doc/sphinx/issues?q=is%3Aissue%20state%3Aopen%20pep%20695)
 
## How has this PR been tested?
Docs have been generated locally; note that this fix does not deal with the [Bases types problem](https://movement.neuroinformatics.dev/latest/api/movement.roi.LineOfInterest.html#movement.roi.LineOfInterest), i.e. `LineLike` should expand to `LinearRing | LineString`
<img width="931" height="90" alt="image" src="https://github.com/user-attachments/assets/fed71c77-aa9b-49e1-8d00-df11b9189355" />
vs
<img width="879" height="101" alt="image" src="https://github.com/user-attachments/assets/fcdec63a-0100-4b35-a772-1a9e30734e00" />
I presume this is one of those issues with [sphinx-autodoc :show-inheritance: ](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directive-option-autoclass-show-inheritance) 🤷 

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
