### PR TITLE
Use GitHub App token in contributors workflow

### DIFF
--- a/.github/workflows/update_contributors_list.yml
+++ b/.github/workflows/update_contributors_list.yml
@@ -17,6 +17,12 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.NIU_BOT_APP_ID }}
+          private-key: ${{ secrets.NIU_BOT_PRIVATE_KEY }}
       - name: Contribute List
         uses: akhilmhdh/contributors-readme-action@v2.3.11
         with:
@@ -24,4 +30,4 @@ jobs:
           commit_message: 'Update contributors list'
           pr_title_on_protected: 'Contributors-Readme-Action: Update contributors list'
         env:
-          GITHUB_TOKEN: ${{ secrets.CONTRIBUTORS_PAT }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/update_contributors_list.yml
+++ b/.github/workflows/update_contributors_list.yml
@@ -19,9 +19,9 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.NIU_BOT_APP_ID }}
+          client-id: ${{ secrets.NIU_BOT_CLIENT_ID }}
           private-key: ${{ secrets.NIU_BOT_PRIVATE_KEY }}
       - name: Contribute List
         uses: akhilmhdh/contributors-readme-action@v2.3.11

--- a/.github/workflows/update_contributors_list.yml
+++ b/.github/workflows/update_contributors_list.yml
@@ -24,4 +24,4 @@ jobs:
           commit_message: 'Update contributors list'
           pr_title_on_protected: 'Contributors-Readme-Action: Update contributors list'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CONTRIBUTORS_PAT }}

--- a/.github/workflows/update_contributors_list.yml
+++ b/.github/workflows/update_contributors_list.yml
@@ -21,7 +21,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ secrets.NIU_BOT_CLIENT_ID }}
+          client-id: ${{ vars.NIU_BOT_CLIENT_ID }}
           private-key: ${{ secrets.NIU_BOT_PRIVATE_KEY }}
       - name: Contribute List
         uses: akhilmhdh/contributors-readme-action@v2.3.11

--- a/docs/source/community/people.md
+++ b/docs/source/community/people.md
@@ -426,8 +426,6 @@ providing sample data, or by actively participating in discussions).
                     <sub><b>Angela Albi</b></sub>
                 </a>
             </td>
-		</tr>
-		<tr>
             <td align="center">
                 <a href="https://github.com/edeno">
                     <img src="https://avatars.githubusercontent.com/u/8053989?v=4" width="100;" alt="edeno"/>
@@ -435,6 +433,8 @@ providing sample data, or by actively participating in discussions).
                     <sub><b>Eric Denovellis</b></sub>
                 </a>
             </td>
+		</tr>
+		<tr>
             <td align="center">
                 <a href="https://github.com/luiztauffer">
                     <img src="https://avatars.githubusercontent.com/u/24541631?v=4" width="100;" alt="luiztauffer"/>

--- a/docs/source/community/people.md
+++ b/docs/source/community/people.md
@@ -72,6 +72,13 @@ This is automatically updated via GitHub Actions and should not be modified.
 		</tr>
 		<tr>
             <td align="center">
+                <a href="https://github.com/Tushar7012">
+                    <img src="https://avatars.githubusercontent.com/u/169586650?v=4" width="100;" alt="Tushar7012"/>
+                    <br />
+                    <sub><b>Tushar Das</b></sub>
+                </a>
+            </td>
+            <td align="center">
                 <a href="https://github.com/b-peri">
                     <img src="https://avatars.githubusercontent.com/u/77279592?v=4" width="100;" alt="b-peri"/>
                     <br />
@@ -90,13 +97,6 @@ This is automatically updated via GitHub Actions and should not be modified.
                     <img src="https://avatars.githubusercontent.com/u/35690029?v=4" width="100;" alt="Ishaan0132"/>
                     <br />
                     <sub><b>Ishaan Shaikh</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/Tushar7012">
-                    <img src="https://avatars.githubusercontent.com/u/169586650?v=4" width="100;" alt="Tushar7012"/>
-                    <br />
-                    <sub><b>Tushar Das</b></sub>
                 </a>
             </td>
             <td align="center">
@@ -151,14 +151,21 @@ This is automatically updated via GitHub Actions and should not be modified.
                 </a>
             </td>
             <td align="center">
+                <a href="https://github.com/ishan372or">
+                    <img src="https://avatars.githubusercontent.com/u/181570708?v=4" width="100;" alt="ishan372or"/>
+                    <br />
+                    <sub><b>ishan372or</b></sub>
+                </a>
+            </td>
+		</tr>
+		<tr>
+            <td align="center">
                 <a href="https://github.com/CeliaLrt">
                     <img src="https://avatars.githubusercontent.com/u/204997762?v=4" width="100;" alt="CeliaLrt"/>
                     <br />
                     <sub><b>CeliaLrt</b></sub>
                 </a>
             </td>
-		</tr>
-		<tr>
             <td align="center">
                 <a href="https://github.com/DPWebster">
                     <img src="https://avatars.githubusercontent.com/u/185731034?v=4" width="100;" alt="DPWebster"/>
@@ -188,12 +195,14 @@ This is automatically updated via GitHub Actions and should not be modified.
                 </a>
             </td>
             <td align="center">
-                <a href="https://github.com/HARSHDIPSAHA">
-                    <img src="https://avatars.githubusercontent.com/u/141698575?v=4" width="100;" alt="HARSHDIPSAHA"/>
+                <a href="https://github.com/HarshdipSaha">
+                    <img src="https://avatars.githubusercontent.com/u/141698575?v=4" width="100;" alt="HarshdipSaha"/>
                     <br />
                     <sub><b>Harshdip Saha</b></sub>
                 </a>
             </td>
+		</tr>
+		<tr>
             <td align="center">
                 <a href="https://github.com/IgorTatarnikov">
                     <img src="https://avatars.githubusercontent.com/u/61896994?v=4" width="100;" alt="IgorTatarnikov"/>
@@ -201,8 +210,6 @@ This is automatically updated via GitHub Actions and should not be modified.
                     <sub><b>Igor Tatarnikov</b></sub>
                 </a>
             </td>
-		</tr>
-		<tr>
             <td align="center">
                 <a href="https://github.com/Kasra-Shirvanian">
                     <img src="https://avatars.githubusercontent.com/u/164632798?v=4" width="100;" alt="Kasra-Shirvanian"/>
@@ -238,6 +245,8 @@ This is automatically updated via GitHub Actions and should not be modified.
                     <sub><b>Lauraschwarz</b></sub>
                 </a>
             </td>
+		</tr>
+		<tr>
             <td align="center">
                 <a href="https://github.com/roaldarbol">
                     <img src="https://avatars.githubusercontent.com/u/25629697?v=4" width="100;" alt="roaldarbol"/>
@@ -245,8 +254,6 @@ This is automatically updated via GitHub Actions and should not be modified.
                     <sub><b>Mikkel Roald-Arbøl</b></sub>
                 </a>
             </td>
-		</tr>
-		<tr>
             <td align="center">
                 <a href="https://github.com/M0hammed-Reda">
                     <img src="https://avatars.githubusercontent.com/u/174648255?v=4" width="100;" alt="M0hammed-Reda"/>
@@ -282,6 +289,8 @@ This is automatically updated via GitHub Actions and should not be modified.
                     <sub><b>Vedant Vakharia</b></sub>
                 </a>
             </td>
+		</tr>
+		<tr>
             <td align="center">
                 <a href="https://github.com/yarikoptic">
                     <img src="https://avatars.githubusercontent.com/u/39889?v=4" width="100;" alt="yarikoptic"/>
@@ -289,8 +298,6 @@ This is automatically updated via GitHub Actions and should not be modified.
                     <sub><b>Yaroslav Halchenko</b></sub>
                 </a>
             </td>
-		</tr>
-		<tr>
             <td align="center">
                 <a href="https://github.com/angkul07">
                     <img src="https://avatars.githubusercontent.com/u/129066458?v=4" width="100;" alt="angkul07"/>
@@ -303,13 +310,6 @@ This is automatically updated via GitHub Actions and should not be modified.
                     <img src="https://avatars.githubusercontent.com/u/224357980?v=4" width="100;" alt="bhanushaliparthhitesh"/>
                     <br />
                     <sub><b>bhanushali parth hitesh</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/ishan372or">
-                    <img src="https://avatars.githubusercontent.com/u/181570708?v=4" width="100;" alt="ishan372or"/>
-                    <br />
-                    <sub><b>ishan372or</b></sub>
                 </a>
             </td>
             <td align="center">
@@ -326,6 +326,15 @@ This is automatically updated via GitHub Actions and should not be modified.
                     <sub><b>maxstaras</b></sub>
                 </a>
             </td>
+            <td align="center">
+                <a href="https://github.com/vybhav72954">
+                    <img src="https://avatars.githubusercontent.com/u/49750343?v=4" width="100;" alt="vybhav72954"/>
+                    <br />
+                    <sub><b>vybhav72954</b></sub>
+                </a>
+            </td>
+		</tr>
+		<tr>
             <td align="center">
                 <a href="https://github.com/yvonne0006">
                     <img src="https://avatars.githubusercontent.com/u/252261817?v=4" width="100;" alt="yvonne0006"/>


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

PRs opened by the `contributors-readme-action` were leaving required CI checks permanently pending (see #694). The root cause is a deliberate GitHub Actions security restriction: when `GITHUB_TOKEN` creates a PR, GitHub suppresses the resulting `pull_request` event to prevent infinite workflow loops. This means `test_and_deploy.yml` never gets triggered, and required status checks hang indefinitely.

Manually triggering the workflow via `workflow_dispatch` suffered from the same issue.

The only workaround used to be pushing to the branch manually, because that event is not subject to the same restriction.

**What does this PR do?**

~Replaces `secrets.GITHUB_TOKEN` with `secrets.CONTRIBUTORS_PAT` (a fine-grained PAT I created and saved in repo secrets, scoped to this repository with `contents: write` and `pull-requests: write` permissions) in the contributors workflow. PRs opened via a PAT are treated as user-authored, so the `pull_request` event fires normally and CI runs without any manual intervention.~

Replaces `secrets.GITHUB_TOKEN` with a token generated by the `neuroinformatics-unit-bot` - an org-wide GitHub app I created for this and similar automations. 

**Why a Github app**?

The usual ways to give a CI workflow write access all have drawbacks:

- The built-in `GITHUB_TOKEN` can't trigger other workflows, which is the exact problem we are facing here.
- A personal access token (PAT) works (it's the first alternative we tried), but it's tied to one person, expires (so someone has to remember to rotate it), and carries that person's full access. It's a single point of failure and a security liability.

A **GitHub App** avoids all of this:

- Org-owned: not tied to any individual, so survives people leaving the team.
- No expiry: the app's private key is long-lived; the *tokens* it mints are short-lived (1 hour) and minted fresh per workflow run.
- Least-privilege: you grant it only the specific permissions it needs, and install it only on the repos that need it.
- Triggers CI normally: PRs/commits made with an app token are treated as app-authored, so downstream workflows fire.

## References

Fixes #694. Supersedes #806.

## How has this PR been tested?

We can only test the fix by manually triggering the workflow from `main`.

The fix will be fully verified when the next scheduled contributors PR is opened and CI runs automatically without requiring a manual push.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)