### PR TITLE
Fix invalid --all-groups flag in contributing docs

### DIFF
--- a/docs/source/community/contributing.md
+++ b/docs/source/community/contributing.md
@@ -99,11 +99,11 @@ Now that you have the repository locally, you need to set up a Python environmen
 
     ::::
     If you also want to [edit the documentation](#editing-the-documentation) and preview the changes locally, you will additionally need the `docs` dependencies.
-    To install both `dev` and `docs` dependencies at once, use `--all-groups`:
+    To install both `dev` and `docs` dependencies at once:
 
     ```sh
-    pip install -e . --all-groups      # conda env
-    uv pip install -e . --all-groups   # uv env
+    pip install -e . --group dev --group docs        # conda env
+    uv pip install -e . --group dev --group docs     # uv env
     ```
 
 2. Finally, initialise the [pre-commit hooks](#formatting-and-pre-commit-hooks):


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Neither `pip install` nor `uv pip install` support the `--all-groups` syntax. Only `uv sync` does.

```bash
error: unexpected argument '--all-groups' found

  tip: a similar argument exists: '--group'

Usage: uv pip install <PACKAGE|--requirements <REQUIREMENTS>|--editable <EDITABLE>|--group <GROUP>>

For more information, try '--help'
```

**What does this PR do?**

Updated the Creating a development environment section of the contributing guide to use the correct (and more explicit/transparent) syntax:

`--group dev --group docs`

## References

Mistake introduced in https://github.com/neuroinformatics-unit/movement/pull/956

## How has this PR been tested?

Locally run the commands.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

It is an update of docs.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
