### PR TITLE
Add compute_path_sinuosity to path metrics

### DIFF
--- a/movement/kinematics/__init__.py
+++ b/movement/kinematics/__init__.py
@@ -19,6 +19,7 @@ from movement.kinematics.path import (
     compute_directional_change,
     compute_path_deviation,
     compute_path_length,
+    compute_path_sinuosity,
     compute_path_straightness,
     compute_turning_angle,
 )
@@ -35,6 +36,7 @@ __all__ = [
     "compute_directional_change",
     "compute_path_deviation",
     "compute_time_derivative",
+    "compute_path_sinuosity",
     "compute_pairwise_distances",
     "compute_forward_vector",
     "compute_head_direction_vector",

--- a/movement/kinematics/path.py
+++ b/movement/kinematics/path.py
@@ -409,14 +409,7 @@ def compute_path_sinuosity(
 
     # --- Benhamou 2004 Eq. 8 ------------------------------------------------
     # c_bar -> 1 for a perfectly straight path, giving S -> 0.
-    # Guard the division so the zero denominator does not emit a warning.
-    one_minus_c = 1.0 - c_bar
-    angle_term = xr.where(
-        one_minus_c == 0,
-        np.inf,
-        (1.0 + c_bar) / one_minus_c.where(one_minus_c != 0),
-    )
-    result = 2.0 * (p_bar * (angle_term + b**2)) ** -0.5
+    result = 2.0 * (p_bar * ((1.0 + c_bar) / (1.0 - c_bar) + b**2)) ** -0.5
 
     result.name = "sinuosity"
     result.attrs["long_name"] = "Path Sinuosity"

--- a/movement/kinematics/path.py
+++ b/movement/kinematics/path.py
@@ -326,8 +326,6 @@ def compute_path_sinuosity(
     data : xarray.DataArray
         The input data containing position information, with ``time``
         and ``space`` (in Cartesian coordinates) as required dimensions.
-        To compute sinuosity over a specific time window, pre-slice with
-        ``data.sel(time=slice(start, stop))`` before passing in.
     nan_warn_threshold : float, optional
         If any point track in the data has at least (:math:`\ge`)
         this proportion of values missing, a warning will be emitted.
@@ -354,40 +352,34 @@ def compute_path_sinuosity(
     Turning angles are computed via :func:`compute_turning_angle`.
 
     NaN positions propagate to NaN step lengths and turning angles;
-    the statistics are then computed over the remaining valid samples
-    via ``skipna=True``.
+    the statistics are then computed over the remaining valid samples.
+    An entirely stationary track, or one with all NaN values,
+    will produce NaN sinuosity.
 
     Sinuosity has units of :math:`1/\sqrt{\text{length}}`, so its
     numerical value depends on the position units of the input data.
     Values are not directly comparable across datasets recorded in
     different spatial units.
 
-    **Edge cases**:
-
-    - :math:`\bar{c} = 1` (perfectly straight path): handled without
-      division-by-zero warnings; the formula naturally evaluates to
-      :math:`S = 0`.
-    - :math:`\bar{p} = 0` (entirely stationary track): S is NaN.
-    - All steps NaN: returns NaN.
-
     References
     ----------
     .. [1] Benhamou, S. (2004). How to reliably estimate the tortuosity
        of an animal's path: straightness, sinuosity, or fractal dimension?
-       *Journal of Theoretical Biology*, 229(2), 209–220.
+       *Journal of Theoretical Biology*, 229(2), 209-220.
        https://doi.org/10.1016/j.jtbi.2004.03.016
 
     Examples
     --------
-    Compute sinuosity for all individuals and keypoints:
+    >>> from movement.kinematics import compute_path_sinuosity
 
-    >>> sinuosity = compute_path_sinuosity(ds.position)
+    Compute sinuosity for the centroid trajectory of a poses dataset ``ds``:
 
-    Constrain to a specific time window using xarray's ``.sel()``:
+    >>> centroid = ds.position.mean(dim="keypoint")
+    >>> sinuosity = compute_path_sinuosity(centroid)
 
-    >>> sinuosity = compute_path_sinuosity(
-    ...     ds.position.sel(time=slice(10.0, 60.0))
-    ... )
+    Compute sinuosity over a specific time window:
+
+    >>> sinuosity = compute_path_sinuosity(centroid.sel(time=slice(0, 100)))
 
     """
     data = _validate_time_points(
@@ -396,19 +388,15 @@ def compute_path_sinuosity(
 
     _warn_about_nan_proportion(data, nan_warn_threshold)
 
-    # --- Step lengths -------------------------------------------------------
     step_lengths = _segment_lengths(data)
-
-    # --- Turning angles -----------------------------------------------------
     theta = compute_turning_angle(data)
 
-    # --- Summary statistics (NaN-aware) -------------------------------------
+    # Summary statistics (NaN-aware)
     p_bar = step_lengths.mean(dim="time", skipna=True)
     c_bar = xr.apply_ufunc(np.cos, theta).mean(dim="time", skipna=True)
     b = step_lengths.std(dim="time", skipna=True) / p_bar
 
-    # --- Benhamou 2004 Eq. 8 ------------------------------------------------
-    # c_bar -> 1 for a perfectly straight path, giving S -> 0.
+    # Benhamou 2004 Eq. 8
     result = 2.0 * (p_bar * ((1.0 + c_bar) / (1.0 - c_bar) + b**2)) ** -0.5
 
     result.name = "sinuosity"

--- a/movement/kinematics/path.py
+++ b/movement/kinematics/path.py
@@ -392,12 +392,17 @@ def compute_path_sinuosity(
     theta = compute_turning_angle(data)
 
     # Summary statistics (NaN-aware)
-    p_bar = step_lengths.mean(dim="time", skipna=True)
-    c_bar = xr.apply_ufunc(np.cos, theta).mean(dim="time", skipna=True)
-    b = step_lengths.std(dim="time", skipna=True) / p_bar
+    mean_step_length = step_lengths.mean(dim="time", skipna=True)
+    mean_cosine = xr.apply_ufunc(np.cos, theta).mean(dim="time", skipna=True)
+    step_length_cv = (
+        step_lengths.std(dim="time", skipna=True) / mean_step_length
+    )
 
     # Benhamou 2004 Eq. 8
-    result = 2.0 * (p_bar * ((1.0 + c_bar) / (1.0 - c_bar) + b**2)) ** -0.5
+    angular_term = (1.0 + mean_cosine) / (1.0 - mean_cosine)
+    result = (
+        2.0 * (mean_step_length * (angular_term + step_length_cv**2)) ** -0.5
+    )
 
     result.name = "sinuosity"
     result.attrs["long_name"] = "Path Sinuosity"

--- a/movement/kinematics/path.py
+++ b/movement/kinematics/path.py
@@ -643,8 +643,8 @@ def _validate_time_points(
     data : xarray.DataArray
         Position data with ``time`` and ``space`` dimensions.
     metric_name : str
-         Used in the error message when there are fewer than
-        `min_points` time points.
+        Used in the error message when there are fewer than ``min_points``
+        time points.
     min_points : int, optional
         The minimum number of time points required. Defaults to 2.
 

--- a/movement/kinematics/path.py
+++ b/movement/kinematics/path.py
@@ -296,6 +296,134 @@ def compute_turning_angle(
     return turning
 
 
+def compute_path_sinuosity(
+    data: xr.DataArray,
+    nan_warn_threshold: float = 0.2,
+) -> xr.DataArray:
+    r"""Compute the sinuosity of a path.
+
+    Sinuosity (S) quantifies the tortuosity of a path by combining
+    turning angle statistics with step-length variability. Higher
+    values indicate more tortuous movement. A perfectly straight
+    path has S = 0.
+
+    The corrected sinuosity index (Eq. 8 in [1]_) is defined as:
+
+    .. math::
+
+        S = 2\left[\bar{p}\left(
+            \frac{1+\bar{c}}{1-\bar{c}} + b^{2}
+        \right)\right]^{-1/2}
+
+    where :math:`\bar{p}` is the mean step length,
+    :math:`\bar{c} = \tfrac{1}{n}\sum_{i=1}^{n}\cos(\phi_i)` is the mean
+    cosine of turning angles, and
+    :math:`b = \mathrm{SD}(p_i)\,/\,\bar{p}` is the coefficient of
+    variation of step length.
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        The input data containing position information, with ``time``
+        and ``space`` (in Cartesian coordinates) as required dimensions.
+        To compute sinuosity over a specific time window, pre-slice with
+        ``data.sel(time=slice(start, stop))`` before passing in.
+    nan_warn_threshold : float, optional
+        If any point track in the data has at least (:math:`\ge`)
+        this proportion of values missing, a warning will be emitted.
+        Defaults to ``0.2`` (20%).
+
+    Returns
+    -------
+    xarray.DataArray
+        An xarray DataArray containing the computed sinuosity,
+        with dimensions matching those of the input data,
+        except ``time`` and ``space`` are removed.
+
+    See Also
+    --------
+    compute_path_length : Total distance travelled along a path.
+    compute_path_straightness : Net displacement divided by path length.
+    compute_turning_angle : Step-wise turning angle along a path.
+
+    Notes
+    -----
+    Step lengths are computed as the norm of backward displacement vectors
+    via :func:`~movement.utils.vector.compute_norm` and
+    :func:`~movement.kinematics.compute_backward_displacement`.
+    Turning angles are computed via :func:`compute_turning_angle`.
+
+    NaN positions propagate to NaN step lengths and turning angles;
+    the statistics are then computed over the remaining valid samples
+    via ``skipna=True``.
+
+    Sinuosity has units of :math:`1/\sqrt{\text{length}}`, so its
+    numerical value depends on the position units of the input data.
+    Values are not directly comparable across datasets recorded in
+    different spatial units.
+
+    **Edge cases**:
+
+    - :math:`\bar{c} = 1` (perfectly straight path): handled without
+      division-by-zero warnings; the formula naturally evaluates to
+      :math:`S = 0`.
+    - :math:`\bar{p} = 0` (entirely stationary track): S is NaN.
+    - All steps NaN: returns NaN.
+
+    References
+    ----------
+    .. [1] Benhamou, S. (2004). How to reliably estimate the tortuosity
+       of an animal's path: straightness, sinuosity, or fractal dimension?
+       *Journal of Theoretical Biology*, 229(2), 209–220.
+       https://doi.org/10.1016/j.jtbi.2004.03.016
+
+    Examples
+    --------
+    Compute sinuosity for all individuals and keypoints:
+
+    >>> sinuosity = compute_path_sinuosity(ds.position)
+
+    Constrain to a specific time window using xarray's ``.sel()``:
+
+    >>> sinuosity = compute_path_sinuosity(
+    ...     ds.position.sel(time=slice(10.0, 60.0))
+    ... )
+
+    """
+    data = _validate_time_points(
+        data, metric_name="path sinuosity", min_points=3
+    )
+
+    _warn_about_nan_proportion(data, nan_warn_threshold)
+
+    # --- Step lengths -------------------------------------------------------
+    step_lengths = _segment_lengths(data)
+
+    # --- Turning angles -----------------------------------------------------
+    theta = compute_turning_angle(data)
+
+    # --- Summary statistics (NaN-aware) -------------------------------------
+    p_bar = step_lengths.mean(dim="time", skipna=True)
+    c_bar = xr.apply_ufunc(np.cos, theta).mean(dim="time", skipna=True)
+    b = step_lengths.std(dim="time", skipna=True) / p_bar
+
+    # --- Benhamou 2004 Eq. 8 ------------------------------------------------
+    # c_bar -> 1 for a perfectly straight path, giving S -> 0.
+    # Guard the division so the zero denominator does not emit a warning.
+    one_minus_c = 1.0 - c_bar
+    angle_term = xr.where(
+        one_minus_c == 0,
+        np.inf,
+        (1.0 + c_bar) / one_minus_c.where(one_minus_c != 0),
+    )
+    result = 2.0 * (p_bar * (angle_term + b**2)) ** -0.5
+
+    result.name = "sinuosity"
+    result.attrs["long_name"] = "Path Sinuosity"
+
+    return result
+
+
 def compute_directional_change(
     data: xr.DataArray,
     in_degrees: bool = False,
@@ -513,15 +641,19 @@ def compute_path_deviation(
 def _validate_time_points(
     data: xr.DataArray,
     metric_name: str,
+    min_points: int = 2,
 ) -> xr.DataArray:
-    """Validate dims/coords and require at least 2 time points.
+    """Validate dims/coords and require at least ``min_points`` time points.
 
     Parameters
     ----------
     data : xarray.DataArray
         Position data with ``time`` and ``space`` dimensions.
     metric_name : str
-        Used in the error message when there are fewer than 2 time points.
+         Used in the error message when there are fewer than
+        `min_points` time points.
+    min_points : int, optional
+        The minimum number of time points required. Defaults to 2.
 
     Returns
     -------
@@ -531,10 +663,10 @@ def _validate_time_points(
     """
     validate_dims_coords(data, {"time": [], "space": []})
     n_time = data.sizes["time"]
-    if n_time < 2:
+    if n_time < min_points:
         raise logger.error(
             ValueError(
-                "At least 2 time points are required to compute "
+                f"At least {min_points} time points are required to compute "
                 f"{metric_name}, but {n_time} were found."
             )
         )

--- a/tests/test_unit/test_kinematics/test_path.py
+++ b/tests/test_unit/test_kinematics/test_path.py
@@ -849,6 +849,19 @@ def scaled_zigzag_path(regular_zigzag_path):
     return regular_zigzag_path * 4
 
 
+@pytest.fixture
+def zigzag_path_with_nan(regular_zigzag_path):
+    """Return the zigzag path with the position at time=10 missing.
+
+    The missing position invalidates 2 step lengths and 3 turning angles,
+    but every remaining step still has length 1 and every remaining turn
+    is still 90 degrees, so S is unchanged at 2.0.
+    """
+    path = regular_zigzag_path.copy()
+    path.loc[{"time": 10}] = np.nan
+    return path
+
+
 @pytest.mark.parametrize(
     "fixture_name, expected_value",
     [
@@ -856,6 +869,7 @@ def scaled_zigzag_path(regular_zigzag_path):
         pytest.param("stationary_paths", np.nan, id="stationary"),
         pytest.param("regular_zigzag_path", 2.0, id="zigzag"),
         pytest.param("scaled_zigzag_path", 1.0, id="zigzag-scaled-4x"),
+        pytest.param("zigzag_path_with_nan", 2.0, id="zigzag-with-nan"),
     ],
 )
 def test_path_sinuosity_known_values(request, fixture_name, expected_value):
@@ -872,6 +886,15 @@ def test_path_sinuosity_known_values(request, fixture_name, expected_value):
             xr.full_like(result, expected_value),
             atol=1e-7,
         )
+
+
+def test_path_sinuosity_all_nan(straight_paths):
+    """Test that fully missing tracks warn and yield NaN sinuosity."""
+    position = straight_paths.copy()
+    position[:] = np.nan
+    with pytest.warns(UserWarning, match="The result may be unreliable"):
+        result = compute_path_sinuosity(position)
+    assert result.isnull().all()
 
 
 def test_path_sinuosity_variable_reversals():

--- a/tests/test_unit/test_kinematics/test_path.py
+++ b/tests/test_unit/test_kinematics/test_path.py
@@ -14,10 +14,11 @@ from movement.kinematics import (
     compute_turning_angle,
 )
 
-# Shared by all metrics that require at least 2 time points.
+# Shared by all metrics with a minimum number of time points.
+# The number itself is metric-specific, so it is left out of the match.
 time_points_value_error = pytest.raises(
     ValueError,
-    match="At least 2 time points are required",
+    match="time points are required",
 )
 
 # Pre-sliced time-range cases shared by multiple unit tests
@@ -178,6 +179,7 @@ def lateral_detour_paths(straight_paths):
         pytest.param(compute_path_straightness, id="straightness"),
         pytest.param(compute_directional_change, id="directional-change"),
         pytest.param(compute_path_deviation, id="deviation"),
+        pytest.param(compute_path_sinuosity, id="sinuosity"),
     ],
 )
 def test_path_metrics_across_time_ranges(
@@ -809,11 +811,10 @@ def test_path_deviation_partially_degenerate_warns(straight_paths):
 # ─────────────────────────────────────────────
 
 
-def test_path_sinuosity_too_few_timepoints(valid_poses_dataset):
-    """Test that sinuosity enforces the minimum length requirement."""
+def test_path_sinuosity_too_few_timepoints(straight_paths):
+    """Test that sinuosity enforces the minimum length (3) requirement."""
     # Slice the data to exactly 2 time points (which is only 1 segment)
-    position = valid_poses_dataset.position.isel(time=slice(0, 2))
-
+    position = straight_paths.isel(time=slice(0, 2))
     with pytest.raises(ValueError, match="3 time points are required"):
         compute_path_sinuosity(position)
 
@@ -861,10 +862,10 @@ def test_path_sinuosity_known_values(request, fixture_name, expected_value):
 
 
 def test_path_sinuosity_variable_reversals():
-    """Biological edge case: Natural tortuous pacing.
+    """Biological edge case: back-and-forth pacing with variable step lengths.
 
-    An animal repeatedly reversing direction but with natural, variable
-    step lengths. This is genuinely tortuous movement and should compute
+    An animal repeatedly reversing direction but with naturalistic, variable
+    step lengths. This is a highly tortuous movement and should compute
     successfully to a finite, positive value.
     """
     rng = np.random.default_rng(11)
@@ -888,7 +889,7 @@ def test_path_sinuosity_variable_reversals():
 
 
 def test_path_sinuosity_outlier_step():
-    """Artefact edge case: Tracking teleportation.
+    """Artefact edge case: Tracking 'teleportation'.
 
     Simulates a tracker losing ID and assigning a point across the arena.
     The massive jump creates an extreme standard deviation in step length (b).

--- a/tests/test_unit/test_kinematics/test_path.py
+++ b/tests/test_unit/test_kinematics/test_path.py
@@ -838,12 +838,24 @@ def regular_zigzag_path():
     )
 
 
+@pytest.fixture
+def scaled_zigzag_path(regular_zigzag_path):
+    """Return the zigzag path with all positions scaled by a factor of 4.
+
+    Sinuosity has units of 1/sqrt(length), so scaling the positions by
+    k leaves the shape unchanged but divides S by sqrt(k).
+    Here S = 2.0 / sqrt(4) = 1.0.
+    """
+    return regular_zigzag_path * 4
+
+
 @pytest.mark.parametrize(
     "fixture_name, expected_value",
     [
         pytest.param("straight_paths", 0.0, id="straight-line"),
         pytest.param("stationary_paths", np.nan, id="stationary"),
         pytest.param("regular_zigzag_path", 2.0, id="zigzag"),
+        pytest.param("scaled_zigzag_path", 1.0, id="zigzag-scaled-4x"),
     ],
 )
 def test_path_sinuosity_known_values(request, fixture_name, expected_value):

--- a/tests/test_unit/test_kinematics/test_path.py
+++ b/tests/test_unit/test_kinematics/test_path.py
@@ -171,10 +171,12 @@ def lateral_detour_paths(straight_paths):
 def regular_zigzag_path():
     """Unit-step 90-degree zigzag (East, North, East, North, ...).
 
-    Every step has length 1 (so b = 0) and every turn is 90 degrees
-    (so c_bar = cos(90) = 0). Benhamou 2004 Eq. 8
-    (the one used to compute sinuosity) then reduces to
-    S = 2 * [p * (1 + c_bar) / (1 - c_bar)]^(-1/2) = 2 / sqrt(1) = 2.0
+    Every step has length 1, so the mean step length is 1 and the
+    coefficient of variation of step length is 0. Every turn is 90
+    degrees, so the mean cosine of the turning angles is
+    cos(90 deg) = 0. Benhamou 2004 Eq. 8 (the one used to compute
+    sinuosity) then reduces to
+    S = 2 * [1 * (1 + 0) / (1 - 0)]^(-1/2) = 2 / sqrt(1) = 2.0
     """
     n = 20
     xy = np.zeros((n, 2))

--- a/tests/test_unit/test_kinematics/test_path.py
+++ b/tests/test_unit/test_kinematics/test_path.py
@@ -9,6 +9,7 @@ from movement.kinematics import (
     compute_directional_change,
     compute_path_deviation,
     compute_path_length,
+    compute_path_sinuosity,
     compute_path_straightness,
     compute_turning_angle,
 )
@@ -801,3 +802,111 @@ def test_path_deviation_partially_degenerate_warns(straight_paths):
         assert np.isnan(result.sel(individual="id_0").values).all()
         id_1 = result.sel(individual="id_1")
         xr.testing.assert_allclose(id_1, xr.zeros_like(id_1))
+
+
+# ─────────────────────────────────────────────
+# Path sinuosity tests
+# ─────────────────────────────────────────────
+
+
+def test_path_sinuosity_too_few_timepoints(valid_poses_dataset):
+    """Test that sinuosity enforces the minimum length requirement."""
+    # Slice the data to exactly 2 time points (which is only 1 segment)
+    position = valid_poses_dataset.position.isel(time=slice(0, 2))
+
+    with pytest.raises(ValueError, match="3 time points are required"):
+        compute_path_sinuosity(position)
+
+
+@pytest.fixture
+def regular_zigzag_path():
+    """Unit-step 90-degree zigzag (East, North, East, North, ...).
+
+    Every step has length 1 (so b = 0) and every turn is 90 degrees
+    (so c_bar = cos(90) = 0). Benhamou 2004 Eq. 8 then reduces to
+    S = 2 * [p * (1 + c_bar) / (1 - c_bar)]^(-1/2) = 2 / sqrt(1) = 2.0
+    """
+    n = 20
+    xy = np.zeros((n, 2))
+    for i in range(1, n):
+        xy[i] = xy[i - 1] + ([1, 0] if i % 2 else [0, 1])
+    return xr.DataArray(
+        xy,
+        dims=["time", "space"],
+        coords={"time": np.arange(n), "space": ["x", "y"]},
+    )
+
+
+@pytest.mark.parametrize(
+    "fixture_name, expected_value",
+    [
+        pytest.param("straight_paths", 0.0, id="straight-line"),
+        pytest.param("stationary_paths", np.nan, id="stationary"),
+        pytest.param("regular_zigzag_path", 2.0, id="zigzag"),
+    ],
+)
+def test_path_sinuosity_known_values(request, fixture_name, expected_value):
+    """Test that sinuosity matches expected values for standard geometries."""
+    position = request.getfixturevalue(fixture_name)
+    result = compute_path_sinuosity(position)
+
+    if np.isnan(expected_value):
+        assert result.isnull().all()
+    else:
+        xr.testing.assert_allclose(
+            result,
+            xr.full_like(result, expected_value),
+            atol=1e-7,
+        )
+
+
+def test_path_sinuosity_variable_reversals():
+    """Biological edge case: Natural tortuous pacing.
+
+    An animal repeatedly reversing direction but with natural, variable
+    step lengths. This is genuinely tortuous movement and should compute
+    successfully to a finite, positive value.
+    """
+    rng = np.random.default_rng(11)
+    n = 30
+    x = np.zeros(n)
+    for i in range(1, n):
+        # Reverse direction each step, but multiply by a random stride length
+        x[i] = x[i - 1] + rng.choice([-1, 1]) * rng.uniform(0.5, 2.0)
+    xy = np.column_stack([x, np.zeros(n)])
+
+    data = xr.DataArray(
+        xy,
+        dims=["time", "space"],
+        coords={"time": np.arange(n), "space": ["x", "y"]},
+    )
+    result = compute_path_sinuosity(data)
+
+    assert not result.isnull().any()
+    assert float(result.item()) > 0
+    assert np.isfinite(result.item())
+
+
+def test_path_sinuosity_outlier_step():
+    """Artefact edge case: Tracking teleportation.
+
+    Simulates a tracker losing ID and assigning a point across the arena.
+    The massive jump creates an extreme standard deviation in step length (b).
+    The metric should not crash, but rather return a valid, finite float.
+    """
+    rng = np.random.default_rng(20)
+    n = 50
+    # Normal erratic movement
+    xy = np.column_stack([np.arange(n, dtype=float), rng.normal(0, 0.3, n)])
+    # Single massive tracking failure
+    xy[25] = [1000.0, 1000.0]
+
+    data = xr.DataArray(
+        xy,
+        dims=["time", "space"],
+        coords={"time": np.arange(n), "space": ["x", "y"]},
+    )
+    result = compute_path_sinuosity(data)
+
+    assert not result.isnull().any()
+    assert np.isfinite(result.item())

--- a/tests/test_unit/test_kinematics/test_path.py
+++ b/tests/test_unit/test_kinematics/test_path.py
@@ -876,6 +876,8 @@ def test_path_sinuosity_known_values(request, fixture_name, expected_value):
     """Test that sinuosity matches expected values for standard geometries."""
     position = request.getfixturevalue(fixture_name)
     result = compute_path_sinuosity(position)
+    assert result.name == "sinuosity"
+    assert result.long_name == "Path Sinuosity"
 
     assert set(result.dims) == set(position.dims) - {"time", "space"}
     if np.isnan(expected_value):

--- a/tests/test_unit/test_kinematics/test_path.py
+++ b/tests/test_unit/test_kinematics/test_path.py
@@ -851,6 +851,7 @@ def test_path_sinuosity_known_values(request, fixture_name, expected_value):
     position = request.getfixturevalue(fixture_name)
     result = compute_path_sinuosity(position)
 
+    assert set(result.dims) == set(position.dims) - {"time", "space"}
     if np.isnan(expected_value):
         assert result.isnull().all()
     else:

--- a/tests/test_unit/test_kinematics/test_path.py
+++ b/tests/test_unit/test_kinematics/test_path.py
@@ -167,6 +167,50 @@ def lateral_detour_paths(straight_paths):
     return path
 
 
+@pytest.fixture
+def regular_zigzag_path():
+    """Unit-step 90-degree zigzag (East, North, East, North, ...).
+
+    Every step has length 1 (so b = 0) and every turn is 90 degrees
+    (so c_bar = cos(90) = 0). Benhamou 2004 Eq. 8
+    (the one used to compute sinuosity) then reduces to
+    S = 2 * [p * (1 + c_bar) / (1 - c_bar)]^(-1/2) = 2 / sqrt(1) = 2.0
+    """
+    n = 20
+    xy = np.zeros((n, 2))
+    for i in range(1, n):
+        xy[i] = xy[i - 1] + ([1, 0] if i % 2 else [0, 1])
+    return xr.DataArray(
+        xy,
+        dims=["time", "space"],
+        coords={"time": np.arange(n), "space": ["x", "y"]},
+    )
+
+
+@pytest.fixture
+def scaled_zigzag_path(regular_zigzag_path):
+    """Return the zigzag path with all positions scaled by a factor of 4.
+
+    Sinuosity has units of 1/sqrt(length), so scaling the positions by
+    k leaves the shape unchanged but divides S by sqrt(k).
+    Here S = 2.0 / sqrt(4) = 1.0.
+    """
+    return regular_zigzag_path * 4
+
+
+@pytest.fixture
+def zigzag_path_with_nan(regular_zigzag_path):
+    """Return the zigzag path with the position at time=10 missing.
+
+    The missing position invalidates 2 step lengths and 3 turning angles,
+    but every remaining step still has length 1 and every remaining turn
+    is still 90 degrees, so sinuosity (S) is unchanged at 2.0.
+    """
+    path = regular_zigzag_path.copy()
+    path.loc[{"time": 10}] = np.nan
+    return path
+
+
 # ─────────────────────────────────────────────
 # Cross-metric time-range tests
 # ─────────────────────────────────────────────
@@ -817,49 +861,6 @@ def test_path_sinuosity_too_few_timepoints(straight_paths):
     position = straight_paths.isel(time=slice(0, 2))
     with pytest.raises(ValueError, match="3 time points are required"):
         compute_path_sinuosity(position)
-
-
-@pytest.fixture
-def regular_zigzag_path():
-    """Unit-step 90-degree zigzag (East, North, East, North, ...).
-
-    Every step has length 1 (so b = 0) and every turn is 90 degrees
-    (so c_bar = cos(90) = 0). Benhamou 2004 Eq. 8 then reduces to
-    S = 2 * [p * (1 + c_bar) / (1 - c_bar)]^(-1/2) = 2 / sqrt(1) = 2.0
-    """
-    n = 20
-    xy = np.zeros((n, 2))
-    for i in range(1, n):
-        xy[i] = xy[i - 1] + ([1, 0] if i % 2 else [0, 1])
-    return xr.DataArray(
-        xy,
-        dims=["time", "space"],
-        coords={"time": np.arange(n), "space": ["x", "y"]},
-    )
-
-
-@pytest.fixture
-def scaled_zigzag_path(regular_zigzag_path):
-    """Return the zigzag path with all positions scaled by a factor of 4.
-
-    Sinuosity has units of 1/sqrt(length), so scaling the positions by
-    k leaves the shape unchanged but divides S by sqrt(k).
-    Here S = 2.0 / sqrt(4) = 1.0.
-    """
-    return regular_zigzag_path * 4
-
-
-@pytest.fixture
-def zigzag_path_with_nan(regular_zigzag_path):
-    """Return the zigzag path with the position at time=10 missing.
-
-    The missing position invalidates 2 step lengths and 3 turning angles,
-    but every remaining step still has length 1 and every remaining turn
-    is still 90 degrees, so S is unchanged at 2.0.
-    """
-    path = regular_zigzag_path.copy()
-    path.loc[{"time": 10}] = np.nan
-    return path
 
 
 @pytest.mark.parametrize(

--- a/tests/test_unit/test_kinematics/test_path.py
+++ b/tests/test_unit/test_kinematics/test_path.py
@@ -890,6 +890,14 @@ def test_path_sinuosity_known_values(request, fixture_name, expected_value):
         )
 
 
+def test_path_sinuosity_raises_on_3d(straight_paths_3d):
+    """Sinuosity is only defined for 2D data (inherited from turning angle)."""
+    with pytest.raises(
+        ValueError, match="Dimension 'space' must only contain"
+    ):
+        compute_path_sinuosity(straight_paths_3d)
+
+
 def test_path_sinuosity_all_nan(straight_paths):
     """Test that fully missing tracks warn and yield NaN sinuosity."""
     position = straight_paths.copy()


### PR DESCRIPTION
Opening this as a draft to get early eyes on the core logic and math implementation (Benhamou 2004). 

Key implementation details:
* Added min_step_length to propagate down to compute_turning_angle for noise filtering.
* Reused internal _slice_and_validate and _warn_about_nan_proportion.
* Added NaN safety for stationary paths to prevent division-by-zero.

I will start adding the pytest suite for this once the core mathematical approach looks good.


# EDITED 2026-07-23 by @niksirbi 

Adds `compute_path_sinuosity` (Benhamou 2004's corrected sinuosity index) to `movement.kinematics.path`.

## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Sinuosity is a standard measure of path tortuosity. Unlike the straightness index $D/L$, it does not depend on the number of steps in the path, so it can be compared across trajectories of different durations. It complements the path metrics already available in `movement`. See #904.

**What does this PR do?**

- Adds `compute_path_sinuosity(data, nan_warn_threshold=0.2)`, implementing Eq. 8 of Benhamou (2004):

  $$S = 2\left[\bar{p}\left(\frac{1+\bar{c}}{1-\bar{c}} + b^{2}\right)\right]^{-1/2}$$

  where $\bar{p}$ is the mean step length, $\bar{c}$ the mean cosine of the turning angles, and $b$ the coefficient of variation of step length. A perfectly straight path gives $S = 0$; higher values mean more tortuous movement.
- Reuses the existing `_segment_lengths`, `compute_turning_angle` and `_warn_about_nan_proportion` helpers rather than recomputing anything.
- Generalises the private `_validate_time_points` helper with a `min_points` argument (default `2`, so existing callers are unaffected). Sinuosity passes `min_points=3`, since at least one turning angle is required.
- Deliberately does **not** expose `min_step_length` (per #957 and the 2026-06-12 community call) or a `nan_policy`. NaN positions propagate to NaN steps and turning angles, and the summary statistics are computed over the remaining valid samples. Time windows are selected with `data.sel(time=slice(start, stop))` rather than dedicated arguments.
- Exports the function from `movement.kinematics`.

## References

- Closes #904
- Related to #406
- Sibling metric PR #1032 (`compute_maximum_expected_displacement`), which shares the same turning-angle machinery.


Benhamou, S. (2004). How to reliably estimate the tortuosity of an animal's path: straightness, sinuosity, or fractal dimension? *Journal of Theoretical Biology*, 229(2), 209-220. https://doi.org/10.1016/j.jtbi.2004.03.016

## How has this PR been tested?

New tests in `tests/test_unit/test_kinematics/test_path.py`, all passing locally alongside the existing suite:

- **Known closed-form values**: straight path → `0.0`; stationary path → `NaN`; a unit-step 90° zigzag → `2.0`.
- **Units**: the same zigzag scaled by 4 → `1.0`, confirming that sinuosity scales as $1/\sqrt{\text{length}}$.
- **Missing data**: a zigzag with one missing position still returns `2.0`, verifying that statistics are computed over the remaining valid samples; a fully missing track warns and returns `NaN`.
- **Validation**: `ValueError` for fewer than 3 time points and for 3D input.
- **Output contract**: `time` and `space` are dropped while other dimensions are preserved; `name` and `long_name` are set.
- **Robustness**: realistic direction reversals with variable stride, and a large tracking outlier, both return finite positive values.
- Sinuosity was also added to the shared `test_path_metrics_across_time_ranges` parametrisation, so it is exercised across the same pre-sliced time ranges as the other path metrics. The shared error matcher was relaxed to be metric-agnostic, since the required minimum differs per metric.

Existing functionality is unchanged: `_validate_time_points` keeps its previous behaviour for all current callers via the default `min_points=2`.

## Is this a breaking change?

No. Only additions, plus a new keyword argument with a backwards-compatible default on a private helper.

## Does this PR require an update to the documentation?

No manual changes needed. The function has a full numpydoc docstring (maths, notes on NaN handling and units, references, examples), and the API reference page is generated automatically from the `movement.kinematics` exports.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
