### PR TITLE
Implement `compute_path_deviation` 

### DIFF
--- a/movement/kinematics/__init__.py
+++ b/movement/kinematics/__init__.py
@@ -17,6 +17,7 @@ from movement.kinematics.orientation import (
 from movement.kinematics.kinetic_energy import compute_kinetic_energy
 from movement.kinematics.path import (
     compute_directional_change,
+    compute_path_deviation,
     compute_path_length,
     compute_path_straightness,
     compute_turning_angle,
@@ -32,6 +33,7 @@ __all__ = [
     "compute_path_length",
     "compute_path_straightness",
     "compute_directional_change",
+    "compute_path_deviation",
     "compute_time_derivative",
     "compute_pairwise_distances",
     "compute_forward_vector",

--- a/movement/kinematics/path.py
+++ b/movement/kinematics/path.py
@@ -315,14 +315,14 @@ def compute_directional_change(
 
     Parameters
     ----------
-    data : xarray.DataArray
+    data
         The input data containing position information, with ``time``
         and ``space`` (in Cartesian coordinates) as required dimensions.
-    in_degrees : bool, optional
+    in_degrees
         If ``True``, the turning angles (and hence the directional
         change) are expressed in degrees rather than radians. Defaults
         to ``False``.
-    min_step_length : float, optional
+    min_step_length
         The minimum step length used when computing turning angles.
         Steps shorter than or equal to this value produce ``NaN``
         turning angles, which propagate to ``NaN`` directional change
@@ -354,7 +354,7 @@ def compute_directional_change(
 
     See Also
     --------
-    :func:`compute_turning_angle` :
+    compute_turning_angle :
         The underlying function used to compute turning angles.
 
     Examples
@@ -432,7 +432,9 @@ def compute_path_deviation(
     For each time point :math:`t`, the path deviation is the perpendicular
     (unsigned) distance between the position :math:`P(t)` and the infinite
     straight line passing through the first and last valid positions in
-    the data, denoted :math:`A` and :math:`B` respectively.
+    the data, denoted :math:`A` and :math:`B` respectively. Zero means the
+    position lies exactly on the straight line; larger values indicate greater
+    lateral excursion.
 
     Formally, let :math:`\mathbf{u} = B - A` be the chord vector and
     :math:`\hat{\mathbf{u}} = \mathbf{u} / \|\mathbf{u}\|` its unit vector.
@@ -452,7 +454,7 @@ def compute_path_deviation(
 
     Parameters
     ----------
-    data : xarray.DataArray
+    data
         The input data containing position information, with ``time``
         and ``space`` (in Cartesian coordinates) as required dimensions.
 
@@ -462,21 +464,21 @@ def compute_path_deviation(
         An xarray DataArray containing the perpendicular deviation from
         the chord at each time point, with dimensions matching those of
         the input data, except ``space`` is removed. Values are in the
-        same spatial units as the input. Zero means the position lies
-        exactly on the chord line; larger values indicate greater lateral
-        excursion.
+        same spatial units as the input.
 
     Raises
     ------
     ValueError
-        If fewer than 2 time points exist in the sliced data, or if
-        the chord length is zero (i.e. ``A == B``), which means the start
-        and end positions are identical and the chord is degenerate.
+        If fewer than 2 time points exist in the data, or if
+        the chord length is zero (i.e. ``A == B``) for *all* tracks.
+        If the chord length is zero for *some* (but not all) tracks, a
+        warning is issued and those tracks will have ``NaN`` deviation.
+
 
     See Also
     --------
-    :func:`compute_path_length` : Total distance travelled along the path.
-    :func:`compute_path_straightness` : Ratio of chord length to path length.
+    compute_path_length : Total distance travelled along the path.
+    compute_path_straightness : Ratio of chord length to path length.
 
     Examples
     --------

--- a/movement/kinematics/path.py
+++ b/movement/kinematics/path.py
@@ -393,37 +393,6 @@ def compute_directional_change(
     return dc
 
 
-def _validate_time_points(
-    data: xr.DataArray,
-    metric_name: str,
-) -> xr.DataArray:
-    """Validate dims/coords and require at least 2 time points.
-
-    Parameters
-    ----------
-    data : xarray.DataArray
-        Position data with ``time`` and ``space`` dimensions.
-    metric_name : str
-        Used in the error message when there are fewer than 2 time points.
-
-    Returns
-    -------
-    xarray.DataArray
-        The validated data.
-
-    """
-    validate_dims_coords(data, {"time": [], "space": []})
-    n_time = data.sizes["time"]
-    if n_time < 2:
-        raise logger.error(
-            ValueError(
-                "At least 2 time points are required to compute "
-                f"{metric_name}, but {n_time} were found."
-            )
-        )
-    return data
-
-
 def compute_path_deviation(
     data: xr.DataArray,
 ) -> xr.DataArray:
@@ -539,6 +508,37 @@ def compute_path_deviation(
     deviation.name = "path_deviation"
     deviation.attrs["long_name"] = "Path Deviation"
     return deviation
+
+
+def _validate_time_points(
+    data: xr.DataArray,
+    metric_name: str,
+) -> xr.DataArray:
+    """Validate dims/coords and require at least 2 time points.
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        Position data with ``time`` and ``space`` dimensions.
+    metric_name : str
+        Used in the error message when there are fewer than 2 time points.
+
+    Returns
+    -------
+    xarray.DataArray
+        The validated data.
+
+    """
+    validate_dims_coords(data, {"time": [], "space": []})
+    n_time = data.sizes["time"]
+    if n_time < 2:
+        raise logger.error(
+            ValueError(
+                "At least 2 time points are required to compute "
+                f"{metric_name}, but {n_time} were found."
+            )
+        )
+    return data
 
 
 def _segment_lengths(data: xr.DataArray) -> xr.DataArray:

--- a/movement/kinematics/path.py
+++ b/movement/kinematics/path.py
@@ -396,8 +396,10 @@ def compute_directional_change(
 def _validate_time_points(
     data: xr.DataArray,
     metric_name: str,
+    start: float | None = None,
+    stop: float | None = None,
 ) -> xr.DataArray:
-    """Validate dims/coords and require at least 2 time points.
+    """Validate dims/coords, optionally slice, and require >= 2 time points.
 
     Parameters
     ----------
@@ -405,23 +407,148 @@ def _validate_time_points(
         Position data with ``time`` and ``space`` dimensions.
     metric_name : str
         Used in the error message when there are fewer than 2 time points.
+    start, stop : float, optional
+        Time slice bounds. ``None`` means "use the data's extent".
 
     Returns
     -------
     xarray.DataArray
-        The validated data.
+        The validated, optionally time-sliced data.
 
     """
     validate_dims_coords(data, {"time": [], "space": []})
+    if start is not None or stop is not None:
+        data = data.sel(time=slice(start, stop))
     n_time = data.sizes["time"]
     if n_time < 2:
+        hint = (
+            " Double-check the start and stop times."
+            if (start is not None or stop is not None)
+            else ""
+        )
         raise logger.error(
             ValueError(
                 "At least 2 time points are required to compute "
-                f"{metric_name}, but {n_time} were found."
+                f"{metric_name}, but {n_time} were found.{hint}"
             )
         )
     return data
+
+
+def compute_path_deviation(
+    data: xr.DataArray,
+    start: float | None = None,
+    stop: float | None = None,
+) -> xr.DataArray:
+    r"""Compute the perpendicular deviation from the chord at each time point.
+
+    For each time point :math:`t`, the path deviation is the perpendicular
+    (unsigned) distance between the position :math:`P(t)` and the infinite
+    line passing through the chord endpoints :math:`A` (position at
+    ``start``) and :math:`B` (position at ``stop``).
+
+    Formally, let :math:`\mathbf{u} = B - A` be the chord vector and
+    :math:`\hat{\mathbf{u}} = \mathbf{u} / \|\mathbf{u}\|` its unit vector.
+    The deviation at time :math:`t` is:
+
+    .. math::
+
+        d(t) = \left\|
+            (P(t) - A) -
+            \left[(P(t) - A) \cdot \hat{\mathbf{u}}\right] \hat{\mathbf{u}}
+        \right\|
+
+    This is the norm of the component of :math:`P(t) - A` that is
+    perpendicular to the chord, and is equivalent to the distance from
+    :math:`P(t)` to the infinite line through :math:`A` and :math:`B`.
+    The formulation is dimension-agnostic (works for 2D and 3D data).
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        The input data containing position information, with ``time``
+        and ``space`` (in Cartesian coordinates) as required dimensions.
+    start : float, optional
+        The start time of the path. If None (default),
+        the minimum time coordinate in the data is used.
+    stop : float, optional
+        The end time of the path. If None (default),
+        the maximum time coordinate in the data is used.
+
+    Returns
+    -------
+    xarray.DataArray
+        An xarray DataArray containing the perpendicular deviation from
+        the chord at each time point, with dimensions matching those of
+        the input data, except ``space`` is removed. Values are in the
+        same spatial units as the input. Zero means the position lies
+        exactly on the chord line; larger values indicate greater lateral
+        excursion.
+
+    Raises
+    ------
+    ValueError
+        If fewer than 2 time points exist in the sliced data, or if
+        the chord length is zero (i.e. ``A == B``), which means the start
+        and end positions are identical and the chord is degenerate.
+
+    See Also
+    --------
+    :func:`compute_path_straightness` : Ratio of chord length to path length.
+    :func:`compute_path_length` : Total distance travelled along the path.
+
+    Examples
+    --------
+    >>> from movement.kinematics import compute_path_deviation
+
+    Compute per-frame path deviation from the centroid trajectory of a
+    poses dataset ``ds``:
+
+    >>> centroid = ds.position.mean(dim="keypoint")
+    >>> deviation = compute_path_deviation(centroid)
+
+    Compute the maximum lateral excursion over the trajectory:
+
+    >>> max_deviation = deviation.max(dim="time")
+
+    Compute the mean deviation over a specific time window:
+
+    >>> mean_deviation = compute_path_deviation(
+    ...     centroid, start=10, stop=50
+    ... ).mean(dim="time")
+
+    """
+    data = _validate_time_points(
+        data, "path deviation", start=start, stop=stop
+    )
+
+    anchored = data.ffill(dim="time").bfill(dim="time")
+    A = anchored.isel(time=0)
+    B = anchored.isel(time=-1)
+
+    chord = B - A
+    chord_length = compute_norm(chord)
+
+    if (chord_length == 0).all():
+        raise logger.error(
+            ValueError(
+                "The chord length is zero (start and end positions are "
+                "identical). Path deviation is undefined for a degenerate "
+                "chord. Consider using a different metric, such as "
+                "compute_path_length."
+            )
+        )
+
+    chord_unit = chord / chord_length
+    p_minus_a = data - A
+    scalar_proj = (p_minus_a * chord_unit).sum(dim="space")
+    vector_proj = scalar_proj * chord_unit
+    rejection = p_minus_a - vector_proj
+
+    deviation = compute_norm(rejection)
+    deviation.name = "path_deviation"
+    deviation.attrs["long_name"] = "Path Deviation"
+    return deviation
 
 
 def _segment_lengths(data: xr.DataArray) -> xr.DataArray:

--- a/movement/kinematics/path.py
+++ b/movement/kinematics/path.py
@@ -427,12 +427,12 @@ def _validate_time_points(
 def compute_path_deviation(
     data: xr.DataArray,
 ) -> xr.DataArray:
-    r"""Compute the perpendicular deviation from the chord at each time point.
+    r"""Compute deviation from the straight-line path at each time point.
 
     For each time point :math:`t`, the path deviation is the perpendicular
     (unsigned) distance between the position :math:`P(t)` and the infinite
-    line passing through the chord endpoints :math:`A` (position at
-    ``start``) and :math:`B` (position at ``stop``).
+    straight line passing through the first and last valid positions in
+    the data, denoted :math:`A` and :math:`B` respectively.
 
     Formally, let :math:`\mathbf{u} = B - A` be the chord vector and
     :math:`\hat{\mathbf{u}} = \mathbf{u} / \|\mathbf{u}\|` its unit vector.
@@ -475,8 +475,8 @@ def compute_path_deviation(
 
     See Also
     --------
-    :func:`compute_path_straightness` : Ratio of chord length to path length.
     :func:`compute_path_length` : Total distance travelled along the path.
+    :func:`compute_path_straightness` : Ratio of chord length to path length.
 
     Examples
     --------
@@ -508,14 +508,23 @@ def compute_path_deviation(
     chord = B - A
     chord_length = compute_norm(chord)
 
-    if (chord_length == 0).all():
+    degenerate = chord_length == 0
+    if degenerate.all():
         raise logger.error(
             ValueError(
-                "The chord length is zero (start and end positions are "
-                "identical). Path deviation is undefined for a degenerate "
-                "chord. Consider using a different metric, such as "
-                "compute_path_length."
+                "Path deviation is undefined because the start and end "
+                "positions are identical for all tracks."
             )
+        )
+    if degenerate.any():
+        stacked = degenerate.stack(tracks=list(degenerate.dims))
+        bad_tracks = stacked.sel(tracks=stacked).coords["tracks"].values
+        warnings.warn(
+            "Path deviation is undefined for tracks where the start and end "
+            "positions are identical. The following tracks will return NaN: "
+            f"{bad_tracks}",
+            UserWarning,
+            stacklevel=2,
         )
 
     chord_unit = chord / chord_length

--- a/movement/kinematics/path.py
+++ b/movement/kinematics/path.py
@@ -396,10 +396,8 @@ def compute_directional_change(
 def _validate_time_points(
     data: xr.DataArray,
     metric_name: str,
-    start: float | None = None,
-    stop: float | None = None,
 ) -> xr.DataArray:
-    """Validate dims/coords, optionally slice, and require >= 2 time points.
+    """Validate dims/coords and require at least 2 time points.
 
     Parameters
     ----------
@@ -407,29 +405,20 @@ def _validate_time_points(
         Position data with ``time`` and ``space`` dimensions.
     metric_name : str
         Used in the error message when there are fewer than 2 time points.
-    start, stop : float, optional
-        Time slice bounds. ``None`` means "use the data's extent".
 
     Returns
     -------
     xarray.DataArray
-        The validated, optionally time-sliced data.
+        The validated data.
 
     """
     validate_dims_coords(data, {"time": [], "space": []})
-    if start is not None or stop is not None:
-        data = data.sel(time=slice(start, stop))
     n_time = data.sizes["time"]
     if n_time < 2:
-        hint = (
-            " Double-check the start and stop times."
-            if (start is not None or stop is not None)
-            else ""
-        )
         raise logger.error(
             ValueError(
                 "At least 2 time points are required to compute "
-                f"{metric_name}, but {n_time} were found.{hint}"
+                f"{metric_name}, but {n_time} were found."
             )
         )
     return data
@@ -437,8 +426,6 @@ def _validate_time_points(
 
 def compute_path_deviation(
     data: xr.DataArray,
-    start: float | None = None,
-    stop: float | None = None,
 ) -> xr.DataArray:
     r"""Compute the perpendicular deviation from the chord at each time point.
 
@@ -468,12 +455,6 @@ def compute_path_deviation(
     data : xarray.DataArray
         The input data containing position information, with ``time``
         and ``space`` (in Cartesian coordinates) as required dimensions.
-    start : float, optional
-        The start time of the path. If None (default),
-        the minimum time coordinate in the data is used.
-    stop : float, optional
-        The end time of the path. If None (default),
-        the maximum time coordinate in the data is used.
 
     Returns
     -------
@@ -514,13 +495,11 @@ def compute_path_deviation(
     Compute the mean deviation over a specific time window:
 
     >>> mean_deviation = compute_path_deviation(
-    ...     centroid, start=10, stop=50
+    ...     centroid.sel(time=slice(10, 50))
     ... ).mean(dim="time")
 
     """
-    data = _validate_time_points(
-        data, "path deviation", start=start, stop=stop
-    )
+    data = _validate_time_points(data, "path deviation")
 
     anchored = data.ffill(dim="time").bfill(dim="time")
     A = anchored.isel(time=0)

--- a/tests/test_unit/test_kinematics/test_path.py
+++ b/tests/test_unit/test_kinematics/test_path.py
@@ -691,7 +691,10 @@ time_points_value_error_deviation = pytest.raises(
 
 degenerate_chord_error = pytest.raises(
     ValueError,
-    match="Path deviation is undefined because the start and end positions are identical for all tracks.",
+    match=(
+        "Path deviation is undefined because the start and end positions "
+        "are identical for all tracks."
+    ),
 )
 
 

--- a/tests/test_unit/test_kinematics/test_path.py
+++ b/tests/test_unit/test_kinematics/test_path.py
@@ -124,6 +124,35 @@ def sharp_turn_paths(straight_paths):
 
 
 # ─────────────────────────────────────────────
+# Cross-metric time-range tests
+# ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("time_slice, expected_exception", time_range_cases)
+@pytest.mark.parametrize(
+    "compute_fn",
+    [
+        pytest.param(compute_path_straightness, id="straightness"),
+        pytest.param(compute_directional_change, id="directional-change"),
+        pytest.param(compute_path_deviation, id="deviation"),
+    ],
+)
+def test_path_metrics_across_time_ranges(
+    straight_paths,
+    time_slice,
+    expected_exception,
+    compute_fn,
+):
+    """Test that path metrics accept valid time ranges and raise
+    on too-few time points. Path length is tested separately because
+    its time-range test also validates computed values.
+    """
+    position = straight_paths.sel(time=time_slice)
+    with expected_exception:
+        compute_fn(position)
+
+
+# ─────────────────────────────────────────────
 # Path length tests
 # ─────────────────────────────────────────────
 
@@ -284,26 +313,6 @@ def test_path_length_nan_warn_threshold(
 # ─────────────────────────────────────────────
 # Path straightness tests
 # ─────────────────────────────────────────────
-
-
-@pytest.mark.parametrize("time_slice, expected_exception", time_range_cases)
-def test_path_straightness_across_time_ranges(
-    valid_poses_dataset, time_slice, expected_exception
-):
-    """Test straightness index for a uniform linear motion case.
-
-    The ``valid_poses_dataset`` contains 2 individuals moving in
-    straight lines, so the straightness index should always be 1.0.
-    """
-    position = valid_poses_dataset.position.sel(time=time_slice)
-    with expected_exception:
-        result = compute_path_straightness(position)
-        assert result.name == "straightness_index"
-        assert result.attrs["long_name"] == "Path Straightness Index"
-        xr.testing.assert_allclose(
-            result,
-            xr.ones_like(result),
-        )
 
 
 @pytest.mark.parametrize(
@@ -666,28 +675,9 @@ def test_directional_change_nonuniform_time(
     assert dc.isel(time=slice(2, None)).notnull().all()
 
 
-@pytest.mark.parametrize("time_slice, expected_exception", time_range_cases)
-def test_directional_change_across_time_ranges(
-    valid_poses_dataset, time_slice, expected_exception
-):
-    """Test that DC raises with too few time points, and works
-    otherwise.
-    """
-    position = valid_poses_dataset.position.sel(time=time_slice)
-    with expected_exception:
-        dc = compute_directional_change(position)
-        assert dc.name == "directional_change"
-        assert dc.attrs["long_name"] == "Directional Change"
-
-
 # ─────────────────────────────────────────────
 # Path deviation tests
 # ─────────────────────────────────────────────
-
-time_points_value_error_deviation = pytest.raises(
-    ValueError,
-    match="At least 2 time points are required to compute path deviation",
-)
 
 degenerate_chord_error = pytest.raises(
     ValueError,
@@ -696,33 +686,6 @@ degenerate_chord_error = pytest.raises(
         "are identical for all tracks."
     ),
 )
-
-
-@pytest.mark.parametrize(
-    "time_slice, expected_exception",
-    [
-        pytest.param(slice(None, None), does_not_raise(), id="full-range"),
-        pytest.param(slice(0, 9), does_not_raise(), id="explicit-full-range"),
-        pytest.param(slice(1, 8), does_not_raise(), id="partial-range"),
-        pytest.param(
-            slice(9, 0),
-            time_points_value_error_deviation,
-            id="start-greater-than-stop",
-        ),
-        pytest.param(
-            slice(0, 0.5),
-            time_points_value_error_deviation,
-            id="too-few-time-points",
-        ),
-    ],
-)
-def test_path_deviation_time_ranges(
-    straight_paths, time_slice, expected_exception
-):
-    with expected_exception:
-        result = compute_path_deviation(straight_paths.sel(time=time_slice))
-        assert result.sizes.get("time") is not None
-        assert "space" not in result.dims
 
 
 def test_path_deviation_output_metadata(straight_paths):

--- a/tests/test_unit/test_kinematics/test_path.py
+++ b/tests/test_unit/test_kinematics/test_path.py
@@ -696,27 +696,28 @@ degenerate_chord_error = pytest.raises(
 
 
 @pytest.mark.parametrize(
-    "start, stop, expected_exception",
+    "time_slice, expected_exception",
     [
-        pytest.param(None, None, does_not_raise(), id="full-range"),
-        pytest.param(0, 9, does_not_raise(), id="explicit-full-range"),
-        pytest.param(1, 8, does_not_raise(), id="partial-range"),
+        pytest.param(slice(None, None), does_not_raise(), id="full-range"),
+        pytest.param(slice(0, 9), does_not_raise(), id="explicit-full-range"),
+        pytest.param(slice(1, 8), does_not_raise(), id="partial-range"),
         pytest.param(
-            9,
-            0,
+            slice(9, 0),
             time_points_value_error_deviation,
             id="start-greater-than-stop",
         ),
         pytest.param(
-            0, 0.5, time_points_value_error_deviation, id="too-few-time-points"
+            slice(0, 0.5),
+            time_points_value_error_deviation,
+            id="too-few-time-points",
         ),
     ],
 )
 def test_path_deviation_time_ranges(
-    straight_paths, start, stop, expected_exception
+    straight_paths, time_slice, expected_exception
 ):
     with expected_exception:
-        result = compute_path_deviation(straight_paths, start=start, stop=stop)
+        result = compute_path_deviation(straight_paths.sel(time=time_slice))
         assert result.sizes.get("time") is not None
         assert "space" not in result.dims
 
@@ -779,5 +780,5 @@ def test_path_deviation_preserves_non_space_dims(straight_paths):
 
 
 def test_path_deviation_partial_chord_is_zero(straight_paths):
-    result = compute_path_deviation(straight_paths, start=2, stop=7)
+    result = compute_path_deviation(straight_paths.sel(time=slice(2, 7)))
     xr.testing.assert_allclose(result, xr.zeros_like(result))

--- a/tests/test_unit/test_kinematics/test_path.py
+++ b/tests/test_unit/test_kinematics/test_path.py
@@ -733,7 +733,9 @@ def test_path_deviation_straight_path_is_zero(straight_paths):
     xr.testing.assert_allclose(result, xr.zeros_like(result))
 
 
-@pytest.mark.parametrize("fixture_name", ["stationary_paths", "closed_loop_paths"])
+@pytest.mark.parametrize(
+    "fixture_name", ["stationary_paths", "closed_loop_paths"]
+)
 def test_path_deviation_degenerate_chord_raises(request, fixture_name):
     with degenerate_chord_error:
         compute_path_deviation(request.getfixturevalue(fixture_name))
@@ -741,7 +743,9 @@ def test_path_deviation_degenerate_chord_raises(request, fixture_name):
 
 @pytest.fixture
 def straight_paths_3d(straight_paths):
-    return straight_paths.pad(space=(0, 1)).assign_coords(space=["x", "y", "z"])
+    return straight_paths.pad(space=(0, 1)).assign_coords(
+        space=["x", "y", "z"]
+    )
 
 
 @pytest.fixture
@@ -766,8 +770,10 @@ def test_path_deviation_with_nan(straight_paths_with_nan):
 def test_path_deviation_partially_degenerate_warns(straight_paths):
     path = straight_paths.copy()
     # Make id_0 stationary
-    path.loc[{"individual": "id_0"}] = path.loc[{"individual": "id_0", "time": 0}]
-    
+    path.loc[{"individual": "id_0"}] = path.loc[
+        {"individual": "id_0", "time": 0}
+    ]
+
     with pytest.warns(
         UserWarning,
         match="Path deviation is undefined for tracks where the start and end",

--- a/tests/test_unit/test_kinematics/test_path.py
+++ b/tests/test_unit/test_kinematics/test_path.py
@@ -680,6 +680,7 @@ def test_directional_change_across_time_ranges(
         assert dc.attrs["long_name"] == "Directional Change"
 
 
+
 # ─────────────────────────────────────────────
 # Path deviation tests
 # ─────────────────────────────────────────────

--- a/tests/test_unit/test_kinematics/test_path.py
+++ b/tests/test_unit/test_kinematics/test_path.py
@@ -7,6 +7,7 @@ import xarray as xr
 
 from movement.kinematics import (
     compute_directional_change,
+    compute_path_deviation,
     compute_path_length,
     compute_path_straightness,
     compute_turning_angle,
@@ -677,3 +678,106 @@ def test_directional_change_across_time_ranges(
         dc = compute_directional_change(position)
         assert dc.name == "directional_change"
         assert dc.attrs["long_name"] == "Directional Change"
+
+
+# ─────────────────────────────────────────────
+# Path deviation tests
+# ─────────────────────────────────────────────
+
+time_points_value_error_deviation = pytest.raises(
+    ValueError,
+    match="At least 2 time points are required to compute path deviation",
+)
+
+degenerate_chord_error = pytest.raises(
+    ValueError,
+    match="The chord length is zero",
+)
+
+
+@pytest.mark.parametrize(
+    "start, stop, expected_exception",
+    [
+        pytest.param(None, None, does_not_raise(), id="full-range"),
+        pytest.param(0, 9, does_not_raise(), id="explicit-full-range"),
+        pytest.param(1, 8, does_not_raise(), id="partial-range"),
+        pytest.param(
+            9,
+            0,
+            time_points_value_error_deviation,
+            id="start-greater-than-stop",
+        ),
+        pytest.param(
+            0, 0.5, time_points_value_error_deviation, id="too-few-time-points"
+        ),
+    ],
+)
+def test_path_deviation_time_ranges(
+    straight_paths, start, stop, expected_exception
+):
+    with expected_exception:
+        result = compute_path_deviation(straight_paths, start=start, stop=stop)
+        assert result.sizes.get("time") is not None
+        assert "space" not in result.dims
+
+
+def test_path_deviation_output_metadata(straight_paths):
+    result = compute_path_deviation(straight_paths)
+    assert result.name == "path_deviation"
+    assert result.attrs["long_name"] == "Path Deviation"
+
+
+def test_path_deviation_straight_path_is_zero(straight_paths):
+    result = compute_path_deviation(straight_paths)
+    xr.testing.assert_allclose(result, xr.zeros_like(result))
+
+
+def test_path_deviation_degenerate_chord_raises(stationary_paths):
+    with degenerate_chord_error:
+        compute_path_deviation(stationary_paths)
+
+
+@pytest.fixture
+def lateral_detour_paths(straight_paths):
+    """Return path data where each individual takes a 1-unit lateral detour.
+
+    id_0 moves along x=y (chord unit: (1/√2, 1/√2)).
+    Its perpendicular is (-1/√2, +1/√2).
+
+    id_1 moves along x=-y (chord unit: (1/√2, -1/√2)).
+    Its perpendicular is (1/√2, +1/√2).
+
+    At time=5, each individual is displaced exactly 1 unit perpendicular
+    to its own chord. Expected deviation at time=5 is 1.0 for both.
+    """
+    path = straight_paths.copy()
+    perp = 1.0 / np.sqrt(2)
+    # id_0: perpendicular to x=y is (-1/√2, +1/√2)
+    path.loc[{"time": 5, "space": "x", "individual": "id_0"}] -= perp
+    path.loc[{"time": 5, "space": "y", "individual": "id_0"}] += perp
+    # id_1: perpendicular to x=-y is (+1/√2, +1/√2)
+    path.loc[{"time": 5, "space": "x", "individual": "id_1"}] += perp
+    path.loc[{"time": 5, "space": "y", "individual": "id_1"}] += perp
+    return path
+
+
+def test_path_deviation_known_value(lateral_detour_paths):
+    """Deviation at the detour frame is 1.0 for both individuals;
+    all other frames are 0.0.
+    """
+    result = compute_path_deviation(lateral_detour_paths)
+    at_detour = result.sel(time=5)
+    xr.testing.assert_allclose(at_detour, xr.full_like(at_detour, 1.0))
+    off_detour = result.sel(time=[t for t in result.time.values if t != 5])
+    xr.testing.assert_allclose(off_detour, xr.zeros_like(off_detour))
+
+
+def test_path_deviation_preserves_non_space_dims(straight_paths):
+    result = compute_path_deviation(straight_paths)
+    expected_dims = set(straight_paths.dims) - {"space"}
+    assert set(result.dims) == expected_dims
+
+
+def test_path_deviation_partial_chord_is_zero(straight_paths):
+    result = compute_path_deviation(straight_paths, start=2, stop=7)
+    xr.testing.assert_allclose(result, xr.zeros_like(result))

--- a/tests/test_unit/test_kinematics/test_path.py
+++ b/tests/test_unit/test_kinematics/test_path.py
@@ -691,7 +691,7 @@ time_points_value_error_deviation = pytest.raises(
 
 degenerate_chord_error = pytest.raises(
     ValueError,
-    match="The chord length is zero",
+    match="Path deviation is undefined because the start and end positions are identical for all tracks.",
 )
 
 
@@ -733,9 +733,48 @@ def test_path_deviation_straight_path_is_zero(straight_paths):
     xr.testing.assert_allclose(result, xr.zeros_like(result))
 
 
-def test_path_deviation_degenerate_chord_raises(stationary_paths):
+@pytest.mark.parametrize("fixture_name", ["stationary_paths", "closed_loop_paths"])
+def test_path_deviation_degenerate_chord_raises(request, fixture_name):
     with degenerate_chord_error:
-        compute_path_deviation(stationary_paths)
+        compute_path_deviation(request.getfixturevalue(fixture_name))
+
+
+@pytest.fixture
+def straight_paths_3d(straight_paths):
+    return straight_paths.pad(space=(0, 1)).assign_coords(space=["x", "y", "z"])
+
+
+@pytest.fixture
+def straight_paths_with_nan(straight_paths):
+    path = straight_paths.copy()
+    path.loc[{"time": 5}] = np.nan
+    return path
+
+
+def test_path_deviation_3d(straight_paths_3d):
+    result = compute_path_deviation(straight_paths_3d)
+    xr.testing.assert_allclose(result, xr.zeros_like(result))
+
+
+def test_path_deviation_with_nan(straight_paths_with_nan):
+    result = compute_path_deviation(straight_paths_with_nan)
+    assert np.isnan(result.sel(time=5).values).all()
+    off_nan = result.sel(time=[t for t in result.time.values if t != 5])
+    xr.testing.assert_allclose(off_nan, xr.zeros_like(off_nan))
+
+
+def test_path_deviation_partially_degenerate_warns(straight_paths):
+    path = straight_paths.copy()
+    # Make id_0 stationary
+    path.loc[{"individual": "id_0"}] = path.loc[{"individual": "id_0", "time": 0}]
+    
+    with pytest.warns(
+        UserWarning,
+        match="Path deviation is undefined for tracks where the start and end",
+    ):
+        result = compute_path_deviation(path)
+        assert np.isnan(result.sel(individual="id_0").values).all()
+        assert (result.sel(individual="id_1").values == 0).all()
 
 
 @pytest.fixture

--- a/tests/test_unit/test_kinematics/test_path.py
+++ b/tests/test_unit/test_kinematics/test_path.py
@@ -680,7 +680,6 @@ def test_directional_change_across_time_ranges(
         assert dc.attrs["long_name"] == "Directional Change"
 
 
-
 # ─────────────────────────────────────────────
 # Path deviation tests
 # ─────────────────────────────────────────────
@@ -747,8 +746,10 @@ def test_path_deviation_degenerate_chord_raises(request, fixture_name):
 
 @pytest.fixture
 def straight_paths_3d(straight_paths):
-    return straight_paths.pad(space=(0, 1)).assign_coords(
-        space=["x", "y", "z"]
+    return (
+        straight_paths.pad(space=(0, 1))
+        .fillna(0)
+        .assign_coords(space=["x", "y", "z"])
     )
 
 
@@ -784,7 +785,8 @@ def test_path_deviation_partially_degenerate_warns(straight_paths):
     ):
         result = compute_path_deviation(path)
         assert np.isnan(result.sel(individual="id_0").values).all()
-        assert (result.sel(individual="id_1").values == 0).all()
+        id_1 = result.sel(individual="id_1")
+        xr.testing.assert_allclose(id_1, xr.zeros_like(id_1))
 
 
 @pytest.fixture

--- a/tests/test_unit/test_kinematics/test_path.py
+++ b/tests/test_unit/test_kinematics/test_path.py
@@ -123,6 +123,48 @@ def sharp_turn_paths(straight_paths):
     return path
 
 
+@pytest.fixture
+def straight_paths_3d(straight_paths):
+    """Return straight paths extended to 3D with z=0."""
+    return (
+        straight_paths.pad(space=(0, 1))
+        .fillna(0)
+        .assign_coords(space=["x", "y", "z"])
+    )
+
+
+@pytest.fixture
+def straight_paths_with_nan(straight_paths):
+    """Return straight paths with NaN injected at time=5."""
+    path = straight_paths.copy()
+    path.loc[{"time": 5}] = np.nan
+    return path
+
+
+@pytest.fixture
+def lateral_detour_paths(straight_paths):
+    """Return path data where each individual takes a 1-unit lateral detour.
+
+    id_0 moves along x=y (chord unit: (1/sqrt(2), 1/sqrt(2))).
+    Its perpendicular is (-1/sqrt(2), +1/sqrt(2)).
+
+    id_1 moves along x=-y (chord unit: (1/sqrt(2), -1/sqrt(2))).
+    Its perpendicular is (1/sqrt(2), +1/sqrt(2)).
+
+    At time=5, each individual is displaced exactly 1 unit perpendicular
+    to its own chord. Expected deviation at time=5 is 1.0 for both.
+    """
+    path = straight_paths.copy()
+    perp = 1.0 / np.sqrt(2)
+    # id_0: perpendicular to x=y is (-1/sqrt(2), +1/sqrt(2))
+    path.loc[{"time": 5, "space": "x", "individual": "id_0"}] -= perp
+    path.loc[{"time": 5, "space": "y", "individual": "id_0"}] += perp
+    # id_1: perpendicular to x=-y is (+1/sqrt(2), +1/sqrt(2))
+    path.loc[{"time": 5, "space": "x", "individual": "id_1"}] += perp
+    path.loc[{"time": 5, "space": "y", "individual": "id_1"}] += perp
+    return path
+
+
 # ─────────────────────────────────────────────
 # Cross-metric time-range tests
 # ─────────────────────────────────────────────
@@ -688,54 +730,63 @@ degenerate_chord_error = pytest.raises(
 )
 
 
-def test_path_deviation_output_metadata(straight_paths):
-    result = compute_path_deviation(straight_paths)
+@pytest.mark.parametrize(
+    "fixture_name", ["straight_paths", "straight_paths_3d"]
+)
+@pytest.mark.parametrize(
+    # Should also hold true for partial slices of straight paths
+    "time_slice",
+    [slice(None), slice(2, 7)],
+)
+def test_path_deviation_straight_path_is_zero(
+    request, fixture_name, time_slice
+):
+    """Deviation from a straight-line path is zero (2D and 3D).
+    Also checks that the output has the expected attributes.
+    """
+    path = request.getfixturevalue(fixture_name).sel(time=time_slice)
+    result = compute_path_deviation(path)
+    xr.testing.assert_allclose(result, xr.zeros_like(result))
+
     assert result.name == "path_deviation"
     assert result.attrs["long_name"] == "Path Deviation"
 
 
-def test_path_deviation_straight_path_is_zero(straight_paths):
-    result = compute_path_deviation(straight_paths)
-    xr.testing.assert_allclose(result, xr.zeros_like(result))
-
-
-@pytest.mark.parametrize(
-    "fixture_name", ["stationary_paths", "closed_loop_paths"]
-)
-def test_path_deviation_degenerate_chord_raises(request, fixture_name):
-    with degenerate_chord_error:
-        compute_path_deviation(request.getfixturevalue(fixture_name))
-
-
-@pytest.fixture
-def straight_paths_3d(straight_paths):
-    return (
-        straight_paths.pad(space=(0, 1))
-        .fillna(0)
-        .assign_coords(space=["x", "y", "z"])
-    )
-
-
-@pytest.fixture
-def straight_paths_with_nan(straight_paths):
-    path = straight_paths.copy()
-    path.loc[{"time": 5}] = np.nan
-    return path
-
-
-def test_path_deviation_3d(straight_paths_3d):
-    result = compute_path_deviation(straight_paths_3d)
-    xr.testing.assert_allclose(result, xr.zeros_like(result))
-
-
 def test_path_deviation_with_nan(straight_paths_with_nan):
+    """Test that NaN positions result in NaN deviation at those time steps."""
     result = compute_path_deviation(straight_paths_with_nan)
     assert np.isnan(result.sel(time=5).values).all()
     off_nan = result.sel(time=[t for t in result.time.values if t != 5])
     xr.testing.assert_allclose(off_nan, xr.zeros_like(off_nan))
 
 
+def test_path_deviation_known_value(lateral_detour_paths):
+    """Deviation at the detour frame is 1.0 for both individuals;
+    all other frames are 0.0.
+    """
+    result = compute_path_deviation(lateral_detour_paths)
+    at_detour = result.sel(time=5)
+    xr.testing.assert_allclose(at_detour, xr.full_like(at_detour, 1.0))
+    off_detour = result.sel(time=[t for t in result.time.values if t != 5])
+    xr.testing.assert_allclose(off_detour, xr.zeros_like(off_detour))
+
+
+@pytest.mark.parametrize(
+    "fixture_name", ["stationary_paths", "closed_loop_paths"]
+)
+def test_path_deviation_degenerate_chord_raises(request, fixture_name):
+    """Test that a ValueError is raised when the start and end positions are
+    identical for all tracks (deviation is undefined).
+    """
+    with degenerate_chord_error:
+        compute_path_deviation(request.getfixturevalue(fixture_name))
+
+
 def test_path_deviation_partially_degenerate_warns(straight_paths):
+    """Test that a warning is raised when the start and end positions are
+    identical for some but not all tracks, and that the result is NaN for
+    the degenerate tracks and valid for the non-degenerate tracks.
+    """
     path = straight_paths.copy()
     # Make id_0 stationary
     path.loc[{"individual": "id_0"}] = path.loc[
@@ -750,49 +801,3 @@ def test_path_deviation_partially_degenerate_warns(straight_paths):
         assert np.isnan(result.sel(individual="id_0").values).all()
         id_1 = result.sel(individual="id_1")
         xr.testing.assert_allclose(id_1, xr.zeros_like(id_1))
-
-
-@pytest.fixture
-def lateral_detour_paths(straight_paths):
-    """Return path data where each individual takes a 1-unit lateral detour.
-
-    id_0 moves along x=y (chord unit: (1/√2, 1/√2)).
-    Its perpendicular is (-1/√2, +1/√2).
-
-    id_1 moves along x=-y (chord unit: (1/√2, -1/√2)).
-    Its perpendicular is (1/√2, +1/√2).
-
-    At time=5, each individual is displaced exactly 1 unit perpendicular
-    to its own chord. Expected deviation at time=5 is 1.0 for both.
-    """
-    path = straight_paths.copy()
-    perp = 1.0 / np.sqrt(2)
-    # id_0: perpendicular to x=y is (-1/√2, +1/√2)
-    path.loc[{"time": 5, "space": "x", "individual": "id_0"}] -= perp
-    path.loc[{"time": 5, "space": "y", "individual": "id_0"}] += perp
-    # id_1: perpendicular to x=-y is (+1/√2, +1/√2)
-    path.loc[{"time": 5, "space": "x", "individual": "id_1"}] += perp
-    path.loc[{"time": 5, "space": "y", "individual": "id_1"}] += perp
-    return path
-
-
-def test_path_deviation_known_value(lateral_detour_paths):
-    """Deviation at the detour frame is 1.0 for both individuals;
-    all other frames are 0.0.
-    """
-    result = compute_path_deviation(lateral_detour_paths)
-    at_detour = result.sel(time=5)
-    xr.testing.assert_allclose(at_detour, xr.full_like(at_detour, 1.0))
-    off_detour = result.sel(time=[t for t in result.time.values if t != 5])
-    xr.testing.assert_allclose(off_detour, xr.zeros_like(off_detour))
-
-
-def test_path_deviation_preserves_non_space_dims(straight_paths):
-    result = compute_path_deviation(straight_paths)
-    expected_dims = set(straight_paths.dims) - {"space"}
-    assert set(result.dims) == expected_dims
-
-
-def test_path_deviation_partial_chord_is_zero(straight_paths):
-    result = compute_path_deviation(straight_paths.sel(time=slice(2, 7)))
-    xr.testing.assert_allclose(result, xr.zeros_like(result))


### PR DESCRIPTION
Closes #964

## Summary
This PR adds compute_path_deviation to movement.kinematics, computing the perpendicular (unsigned) distance of each point P(t) from the infinite line defined by chord endpoints A and B.

## Key design decisions
- Unsigned distance only (3D safe)
- Infinite line projection
- Fully vectorized (no loops)
- Matches compute_path_length API
- A == B → ValueError
- n_time < 2 handled by _validate_time_points (extended with optional start/stop)

## Implementation notes
- ffill/bfill used for endpoints
- .sum(dim="space") for dot product
- xarray broadcasting safe

## Changes
- movement/kinematics/path.py
- movement/kinematics/__init__.py
- tests/test_unit/test_kinematics/test_path.py

## Test results
All tests pass locally (42 passed, 0 failed)