### PR TITLE
Dropped `start`/`stop` `kwargs` from `compute_path_length` and `compute_path_straightness`

### DIFF
--- a/movement/kinematics/path.py
+++ b/movement/kinematics/path.py
@@ -20,30 +20,21 @@ from movement.validators.arrays import validate_dims_coords
 
 def compute_path_length(
     data: xr.DataArray,
-    start: float | None = None,
-    stop: float | None = None,
     nan_policy: Literal["ffill", "scale"] = "ffill",
     nan_warn_threshold: float = 0.2,
 ) -> xr.DataArray:
-    r"""Compute the length of a path travelled between two time points.
+    r"""Compute the length of a path travelled.
 
     The path length is defined as the sum of the norms (magnitudes) of the
-    displacement vectors between two time points ``start`` and ``stop``,
-    which should be provided in the time units of the data array.
-    If not specified, the minimum and maximum time coordinates of the data
-    array are used as start and stop times, respectively.
+    displacement vectors between consecutive time points in the data.
+    To constrain the computation to a specific time window, pre-slice the
+    input with ``data.sel(time=slice(start, stop))``.
 
     Parameters
     ----------
     data : xarray.DataArray
         The input data containing position information, with ``time``
         and ``space`` (in Cartesian coordinates) as required dimensions.
-    start : float, optional
-        The start time of the path. If None (default),
-        the minimum time coordinate in the data is used.
-    stop : float, optional
-        The end time of the path. If None (default),
-        the maximum time coordinate in the data is used.
     nan_policy : Literal["ffill", "scale"], optional
         Policy to handle NaN (missing) values. Can be one of the ``"ffill"``
         or ``"scale"``. Defaults to ``"ffill"`` (forward fill).
@@ -100,21 +91,19 @@ def compute_path_length(
 
     Compute path length over a specific time window:
 
-    >>> length = compute_path_length(centroid, start=0, stop=100)
+    >>> length = compute_path_length(centroid.sel(time=slice(0, 100)))
 
     Use the scale policy to handle missing values:
 
     >>> length = compute_path_length(centroid, nan_policy="scale")
 
     """
-    data = _slice_and_validate(data, start, stop, "path length")
+    data = _slice_and_validate(data, "path length")
     return _path_length(data, nan_policy, nan_warn_threshold)
 
 
 def compute_path_straightness(
     data: xr.DataArray,
-    start: float | None = None,
-    stop: float | None = None,
     nan_policy: Literal["ffill", "scale"] = "ffill",
     nan_warn_threshold: float = 0.2,
 ) -> xr.DataArray:
@@ -131,12 +120,6 @@ def compute_path_straightness(
     data : xarray.DataArray
         The input data containing position information, with ``time``
         and ``space`` (in Cartesian coordinates) as required dimensions.
-    start : float, optional
-        The start time of the path. If None (default),
-        the minimum time coordinate in the data is used.
-    stop : float, optional
-        The end time of the path. If None (default),
-        the maximum time coordinate in the data is used.
     nan_policy : Literal["ffill", "scale"], optional
         Policy to handle NaN (missing) values for the path length computation.
         Can be one of ``"ffill"`` or ``"scale"``. Defaults to ``"ffill"``
@@ -158,9 +141,9 @@ def compute_path_straightness(
     -----
     The Euclidean distance :math:`D`, also known as the "straight-line" or
     "beeline" distance, is calculated using the first and last valid (non-NaN)
-    spatial coordinates within the specified time window. This ensures that
-    missing data at the exact ``start`` or ``stop`` boundaries do not nullify
-    the result, provided there are valid observed positions within the slice.
+    spatial coordinates in the data. This ensures that missing data at the
+    edges of the time range do not nullify the result, provided there are
+    valid observed positions in between.
 
     Note that the total path length (L), and therefore the straightness index,
     is sensitive to the temporal sampling  rate (i.e. frames per second),
@@ -183,10 +166,10 @@ def compute_path_straightness(
 
     Compute straightness over a specific time window:
 
-    >>> si = compute_path_straightness(centroid, start=0, stop=100)
+    >>> si = compute_path_straightness(centroid.sel(time=slice(0, 100)))
 
     """
-    data = _slice_and_validate(data, start, stop, "path straightness")
+    data = _slice_and_validate(data, "path straightness")
     path_length = _path_length(data, nan_policy, nan_warn_threshold)
     # Compute D/L ratio, avoiding division by zero
     result = _path_distance(data) / path_length.where(path_length > 0)
@@ -197,38 +180,30 @@ def compute_path_straightness(
 
 def _slice_and_validate(
     data: xr.DataArray,
-    start: float | None,
-    stop: float | None,
     metric_name: str,
 ) -> xr.DataArray:
-    """Validate dims/coords and slice ``data`` along ``time``.
-
-    Requires the sliced data to contain at least 2 time points.
+    """Validate dims/coords and require at least 2 time points.
 
     Parameters
     ----------
     data : xarray.DataArray
         Position data with ``time`` and ``space`` dimensions.
-    start, stop : float, optional
-        Time slice bounds. ``None`` means "use the data's extent".
     metric_name : str
         Used in the error message when the time range is too short.
 
     Returns
     -------
     xarray.DataArray
-        The validated, time-sliced data.
+        The validated data.
 
     """
     validate_dims_coords(data, {"time": [], "space": []})
-    data = data.sel(time=slice(start, stop))
     n_time = data.sizes["time"]
     if n_time < 2:
         raise logger.error(
             ValueError(
                 "At least 2 time points are required to compute "
-                f"{metric_name}, but {n_time} were found. "
-                "Double-check the start and stop times."
+                f"{metric_name}, but {n_time} were found."
             )
         )
     return data

--- a/movement/kinematics/path.py
+++ b/movement/kinematics/path.py
@@ -1,9 +1,9 @@
 """Compute path-level metrics such as path length and straightness.
 
-By 'path' we refer to the spatial trajectory of an individual between two
-time points. While these metrics can be computed based on any set of
-keypoints, they are most meaningful when applied to a single keypoint
-representing the individual's overall position (e.g., centroid).
+By 'path' we refer to the spatial trajectory of an individual over the
+time span of the data. While these metrics can be computed based on any
+set of keypoints, they are most meaningful when applied to a single
+keypoint representing the individual's overall position (e.g., centroid).
 """
 
 import warnings
@@ -96,7 +96,7 @@ def compute_path_length(
     >>> length = compute_path_length(centroid, nan_policy="scale")
 
     """
-    data = _slice_and_validate(data, "path length")
+    data = _validate_time_points(data, "path length")
     return _path_length(data, nan_policy, nan_warn_threshold)
 
 
@@ -167,7 +167,7 @@ def compute_path_straightness(
     >>> si = compute_path_straightness(centroid.sel(time=slice(0, 100)))
 
     """
-    data = _slice_and_validate(data, "path straightness")
+    data = _validate_time_points(data, "path straightness")
     path_length = _path_length(data, nan_policy, nan_warn_threshold)
     # Compute D/L ratio, avoiding division by zero
     result = _path_distance(data) / path_length.where(path_length > 0)
@@ -176,7 +176,7 @@ def compute_path_straightness(
     return result
 
 
-def _slice_and_validate(
+def _validate_time_points(
     data: xr.DataArray,
     metric_name: str,
 ) -> xr.DataArray:

--- a/movement/kinematics/path.py
+++ b/movement/kinematics/path.py
@@ -27,8 +27,6 @@ def compute_path_length(
 
     The path length is defined as the sum of the norms (magnitudes) of the
     displacement vectors between consecutive time points in the data.
-    To constrain the computation to a specific time window, pre-slice the
-    input with ``data.sel(time=slice(start, stop))``.
 
     Parameters
     ----------
@@ -142,7 +140,7 @@ def compute_path_straightness(
     The Euclidean distance :math:`D`, also known as the "straight-line" or
     "beeline" distance, is calculated using the first and last valid (non-NaN)
     spatial coordinates in the data. This ensures that missing data at the
-    edges of the time range do not nullify the result, provided there are
+    first or last time points do not nullify the result, provided there are
     valid observed positions in between.
 
     Note that the total path length (L), and therefore the straightness index,
@@ -189,7 +187,7 @@ def _slice_and_validate(
     data : xarray.DataArray
         Position data with ``time`` and ``space`` dimensions.
     metric_name : str
-        Used in the error message when the time range is too short.
+        Used in the error message when there are fewer than 2 time points.
 
     Returns
     -------
@@ -225,7 +223,7 @@ def _path_distance(data: xr.DataArray) -> xr.DataArray:
     Also known as the "straight-line" or "beeline" distance.
     Uses forward and backward filling along the time dimension to ensure
     the distance is calculated between the first and last observed locations,
-    preventing NaNs at the exact start/stop boundaries from nullifying the
+    preventing NaNs at the first or last time points from nullifying the
     entire calculation.
     """
     anchored_data = data.ffill(dim="time").bfill(dim="time")

--- a/tests/test_unit/test_kinematics/test_path.py
+++ b/tests/test_unit/test_kinematics/test_path.py
@@ -100,30 +100,38 @@ time_points_value_error = pytest.raises(
 
 
 @pytest.mark.parametrize(
-    "start, stop, expected_exception",
+    "time_slice, expected_exception",
     [
         # full time ranges
-        (None, None, does_not_raise()),
-        (0, None, does_not_raise()),
-        (0, 9, does_not_raise()),
-        (0, 10, does_not_raise()),  # xarray.sel will truncate to 0, 9
-        (-1, 9, does_not_raise()),  # xarray.sel will truncate to 0, 9
+        pytest.param(slice(None, None), does_not_raise(), id="full-range"),
+        pytest.param(slice(0, None), does_not_raise(), id="from-zero"),
+        pytest.param(slice(0, 9), does_not_raise(), id="explicit-full-range"),
+        pytest.param(slice(0, 10), does_not_raise(), id="stop-beyond-data"),
+        pytest.param(slice(-1, 9), does_not_raise(), id="start-before-data"),
         # partial time ranges
-        (1, 8, does_not_raise()),
-        (1.5, 8.5, does_not_raise()),
-        (2, None, does_not_raise()),
-        # Empty time ranges
-        (9, 0, time_points_value_error),  # start > stop
-        ("text", 9, time_points_value_error),  # invalid start type
-        # Time range too short
-        (0, 0.5, time_points_value_error),
+        pytest.param(slice(1, 8), does_not_raise(), id="partial-range"),
+        pytest.param(
+            slice(1.5, 8.5), does_not_raise(), id="fractional-bounds"
+        ),
+        pytest.param(slice(2, None), does_not_raise(), id="from-two-to-end"),
+        # Empty or too-short slices
+        pytest.param(
+            slice(9, 0),
+            time_points_value_error,
+            id="start-greater-than-stop",
+        ),
+        pytest.param(
+            slice(0, 0.5),
+            time_points_value_error,
+            id="too-few-time-points",
+        ),
     ],
 )
 def test_path_length_across_time_ranges(
-    valid_poses_dataset, start, stop, expected_exception
+    valid_poses_dataset, time_slice, expected_exception
 ):
     """Test path length computation for a uniform linear motion case,
-    across different time ranges.
+    across different pre-sliced time ranges.
 
     The test dataset ``valid_poses_dataset``
     contains 2 individuals ("id_0" and "id_1"), moving
@@ -132,22 +140,13 @@ def test_path_length_across_time_ranges(
     we expect a path length of sqrt(2) * num_segments, where num_segments is
     the number of selected frames minus 1.
     """
-    position = valid_poses_dataset.position
+    position = valid_poses_dataset.position.sel(time=time_slice)
     with expected_exception:
-        path_length = compute_path_length(position, start=start, stop=stop)
+        path_length = compute_path_length(position)
         assert path_length.name == "path_length"
         assert path_length.long_name == "Path Length"
 
-        # Expected number of segments (displacements) in selected time range
-        num_segments = 9  # full time range: 10 frames - 1
-        start = max(0, start) if start is not None else 0
-        stop = min(9, stop) if stop is not None else 9
-        if start is not None:
-            num_segments -= np.ceil(max(0, start))
-        if stop is not None:
-            stop = min(9, stop)
-            num_segments -= 9 - np.floor(min(9, stop))
-
+        num_segments = position.sizes["time"] - 1
         expected_path_length = xr.DataArray(
             np.ones((3, 2)) * np.sqrt(2) * num_segments,
             dims=["keypoint", "individual"],
@@ -291,51 +290,46 @@ time_points_value_error_straightness = pytest.raises(
 
 
 @pytest.mark.parametrize(
-    "start, stop, expected_exception",
+    "time_slice, expected_exception",
     [
         pytest.param(
-            None,
-            None,
+            slice(None, None),
             does_not_raise(),
             id="full-range",
         ),
         pytest.param(
-            0,
-            9,
+            slice(0, 9),
             does_not_raise(),
             id="explicit-full-range",
         ),
         pytest.param(
-            1,
-            8,
+            slice(1, 8),
             does_not_raise(),
             id="partial-range",
         ),
         pytest.param(
-            9,
-            0,
+            slice(9, 0),
             time_points_value_error_straightness,
             id="start-greater-than-stop",
         ),
         pytest.param(
-            0,
-            0.5,
+            slice(0, 0.5),
             time_points_value_error_straightness,
             id="too-few-time-points",
         ),
     ],
 )
 def test_path_straightness_across_time_ranges(
-    valid_poses_dataset, start, stop, expected_exception
+    valid_poses_dataset, time_slice, expected_exception
 ):
     """Test straightness index for a uniform linear motion case.
 
     The ``valid_poses_dataset`` contains 2 individuals moving in
     straight lines, so the straightness index should always be 1.0.
     """
-    position = valid_poses_dataset.position
+    position = valid_poses_dataset.position.sel(time=time_slice)
     with expected_exception:
-        result = compute_path_straightness(position, start=start, stop=stop)
+        result = compute_path_straightness(position)
         assert result.name == "straightness_index"
         assert result.attrs["long_name"] == "Path Straightness Index"
         xr.testing.assert_allclose(


### PR DESCRIPTION
Fixes #986 

## Description

Remove `start`/`stop` `kwargs` from `compute_path_length` and `compute_path_straightness`. Users do the time-windowing with idiomatic xarray instead:

```python
compute_path_length(position.sel(time=slice(start, stop)))
```

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
- Refactoring will help reduce signature bloat.
- Unblocks downstream trajectory complexity metric work (#904, #905, #906, #907).

## References

Discussion on [Zulip](https://neuroinformatics.zulipchat.com/#narrow/channel/406001-Movement/topic/Potential.20trajectory.20complexity.20metrics/with/596086917)

## Is this a breaking change?

Yes, it would be included in the new release!

## Does this PR require an update to the documentation?

Yes, function docstrings updated to remove start/stop references; Examples now show the .sel() migration pattern.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
