### PR TITLE
Allow individual-wise confidence arrays

### DIFF
--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -118,10 +118,11 @@ class _BaseDatasetInputs(ABC):
     # --- Lifecycle hooks ---
     def __attrs_post_init__(self):
         """Assign default values to optional attributes (if None)."""
-        # confidence_array default: array of NaNs with appropriate shape
+        # confidence_array default: array of NaNs with shape matching
+        # position_array without the space dimension
         if self.confidence_array is None:
             self.confidence_array = np.full(
-                self._confidence_expected_shape[0], np.nan, dtype="float32"
+                self._confidence_expected_shapes[0], np.nan, dtype="float32"
             )
             logger.info(
                 "Confidence array was not provided."
@@ -140,7 +141,7 @@ class _BaseDatasetInputs(ABC):
 
     # --- Properties (derived attributes) ---
     @property
-    def _confidence_expected_shape(self):
+    def _confidence_expected_shapes(self):
         """Return list of expected shapes for confidence_array.
 
         Default is the shape of position_array without the space dimension, but
@@ -191,7 +192,7 @@ class _BaseDatasetInputs(ABC):
         """Check confidence_array type and shape."""
         if value is not None:
             self._validate_array_shape(
-                attribute, value, self._confidence_expected_shape
+                attribute, value, self._confidence_expected_shapes
             )
 
     @individual_names.validator
@@ -353,7 +354,7 @@ class ValidPosesInputs(_BaseDatasetInputs):
     _ALLOWED_SPACE_DIM_SIZE: ClassVar[Iterable[int]] = (2, 3)
 
     @property
-    def _confidence_expected_shape(self):
+    def _confidence_expected_shapes(self):
         """Return list of expected shapes for confidence_array.
 
         Overrides the base implementation to allow for two possible shapes:

--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -141,18 +141,21 @@ class _BaseDatasetInputs(ABC):
     # --- Properties (derived attributes) ---
     @property
     def _confidence_expected_shape(self):
-        """Return expected shape for confidence_array."""
-        # confidence shape == position_array shape without the space dim
-        keypoint_level = tuple(
-            dim
-            for i, dim in enumerate(self.position_array.shape)
-            if i != self.DIM_NAMES.index("space")
-        )
-        individual_level = (
-            keypoint_level[0],
-            keypoint_level[-1],
-        )
-        return [keypoint_level, individual_level]
+        """Return list of expected shapes for confidence_array.
+
+        Default is the shape of position_array without the space dimension, but
+        can be overridden by subclasses if they allow for different confidence
+        array shapes (e.g. point-wise and individual-wise confidence).
+        """
+        return [
+            tuple(
+                s
+                for d, s in zip(
+                    self.DIM_NAMES, self.position_array.shape, strict=True
+                )
+                if d != "space"
+            )
+        ]
 
     # --- Validators ---
     @position_array.validator
@@ -187,14 +190,8 @@ class _BaseDatasetInputs(ABC):
     def _validate_confidence_array(self, attribute, value):
         """Check confidence_array type and shape."""
         if value is not None:
-            expected_shapes = self._confidence_expected_shape
-            if value.shape == expected_shapes[0]:
-                expected_shape = expected_shapes[0]
-            else:
-                expected_shape = expected_shapes[1]
-
             self._validate_array_shape(
-                attribute, value, expected_shape=expected_shape
+                attribute, value, self._confidence_expected_shape
             )
 
     @individual_names.validator
@@ -212,10 +209,14 @@ class _BaseDatasetInputs(ABC):
     # --- Utility methods ---
     @staticmethod
     def _validate_array_shape(
-        attribute: attrs.Attribute, value: np.ndarray, expected_shape: tuple
+        attribute: attrs.Attribute,
+        value: np.ndarray,
+        expected_shape: tuple | list[tuple],
     ):
         """Raise ValueError if the value does not have the expected shape."""
-        if value.shape != expected_shape:
+        if isinstance(expected_shape, tuple):
+            expected_shape = [expected_shape]
+        if value.shape not in expected_shape:
             raise logger.error(
                 ValueError(
                     f"Expected '{attribute.name}' to have shape "
@@ -350,6 +351,21 @@ class ValidPosesInputs(_BaseDatasetInputs):
     )
     VAR_NAMES: ClassVar[tuple[str, ...]] = ("position", "confidence")
     _ALLOWED_SPACE_DIM_SIZE: ClassVar[Iterable[int]] = (2, 3)
+
+    @property
+    def _confidence_expected_shape(self):
+        """Return list of expected shapes for confidence_array.
+
+        Overrides the base implementation to allow for two possible shapes:
+        - point-wise: (n_frames, n_keypoints, n_individuals)
+        - individual-wise: (n_frames, n_individuals)
+        """
+        point_wise = super()._confidence_expected_shape[0]
+        individual_wise = (
+            self.position_array.shape[self.DIM_NAMES.index("time")],
+            self.position_array.shape[self.DIM_NAMES.index("individual")],
+        )
+        return [point_wise, individual_wise]
 
     @keypoint_names.validator
     def _validate_keypoint_names(self, attribute, value):

--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -361,7 +361,7 @@ class ValidPosesInputs(_BaseDatasetInputs):
         - point-wise: (n_frames, n_keypoints, n_individuals)
         - individual-wise: (n_frames, n_individuals)
         """
-        point_wise = super()._confidence_expected_shape[0]
+        point_wise = super()._confidence_expected_shapes[0]
         individual_wise = (
             self.position_array.shape[self.DIM_NAMES.index("time")],
             self.position_array.shape[self.DIM_NAMES.index("individual")],

--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -121,7 +121,7 @@ class _BaseDatasetInputs(ABC):
         # confidence_array default: array of NaNs with appropriate shape
         if self.confidence_array is None:
             self.confidence_array = np.full(
-                self._confidence_expected_shape, np.nan, dtype="float32"
+                self._confidence_expected_shape[0], np.nan, dtype="float32"
             )
             logger.info(
                 "Confidence array was not provided."
@@ -143,11 +143,16 @@ class _BaseDatasetInputs(ABC):
     def _confidence_expected_shape(self):
         """Return expected shape for confidence_array."""
         # confidence shape == position_array shape without the space dim
-        return tuple(
+        keypoint_level = tuple(
             dim
             for i, dim in enumerate(self.position_array.shape)
             if i != self.DIM_NAMES.index("space")
         )
+        individual_level = (
+            keypoint_level[0],
+            keypoint_level[-1],
+        )
+        return [keypoint_level, individual_level]
 
     # --- Validators ---
     @position_array.validator
@@ -182,7 +187,12 @@ class _BaseDatasetInputs(ABC):
     def _validate_confidence_array(self, attribute, value):
         """Check confidence_array type and shape."""
         if value is not None:
-            expected_shape = self._confidence_expected_shape
+            expected_shapes = self._confidence_expected_shape
+            if value.shape == expected_shapes[0]:
+                expected_shape = expected_shapes[0]
+            else:
+                expected_shape = expected_shapes[1]
+
             self._validate_array_shape(
                 attribute, value, expected_shape=expected_shape
             )

--- a/tests/test_unit/test_validators/test_datasets_validators.py
+++ b/tests/test_unit/test_validators/test_datasets_validators.py
@@ -200,9 +200,25 @@ class TestBaseDatasetInputs:
                 (3, 2),
                 pytest.raises(
                     ValueError,
-                    match=re.escape("have shape (3, 2), but got (2, 3)"),
+                    match=re.escape("have shape [(3, 2)], but got (2, 3)"),
                 ),
             ),
+            ([(2, 3), (5, 2)], does_not_raise()),
+            (
+                [(3, 2), (5, 2)],
+                pytest.raises(
+                    ValueError,
+                    match=re.escape(
+                        "have shape [(3, 2), (5, 2)], but got (2, 3)"
+                    ),
+                ),
+            ),
+        ],
+        ids=[
+            "Shape matches expected shape (tuple)",
+            "Shape does not match expected shape (tuple)",
+            "Shape matches one of expected shapes (list of tuples)",
+            "Shape does not match any of expected shapes (list of tuples)",
         ],
     )
     def test_validate_array_shape(self, expected_shape, expected_exception):
@@ -397,7 +413,9 @@ class TestValidBboxesInputs:
                 np.zeros((5, 2, 1)),
                 pytest.raises(
                     ValueError,
-                    match=re.escape("have shape (5, 2, 3), but got (5, 2, 1)"),
+                    match=re.escape(
+                        "have shape [(5, 2, 3)], but got (5, 2, 1)"
+                    ),
                 ),
             ),
             (
@@ -454,14 +472,14 @@ class TestValidBboxesInputs:
                 np.zeros((5, 2)),
                 pytest.raises(
                     ValueError,
-                    match=re.escape("have shape (5, 1), but got (5, 2)"),
+                    match=re.escape("have shape [(5, 1)], but got (5, 2)"),
                 ),
             ),
             (
                 np.zeros((7, 1)),
                 pytest.raises(
                     ValueError,
-                    match=re.escape("have shape (5, 1), but got (7, 1)"),
+                    match=re.escape("have shape [(5, 1)], but got (7, 1)"),
                 ),
             ),
         ],

--- a/tests/test_unit/test_validators/test_datasets_validators.py
+++ b/tests/test_unit/test_validators/test_datasets_validators.py
@@ -350,6 +350,38 @@ class TestValidPosesInputs:
             expected_ds.time.attrs["units"] = "seconds"
             xr.testing.assert_equal(ds, expected_ds)
 
+    @pytest.mark.parametrize(
+        "confidence_array, expected_context",
+        [
+            (
+                np.zeros((5, 3, 2)),
+                does_not_raise(),
+            ),
+            (
+                np.zeros((5, 2)),
+                does_not_raise(),
+            ),
+            (
+                np.zeros((5, 3)),
+                pytest.raises(ValueError),
+            ),
+        ],
+        ids=[
+            "Keypoint-level confidence",
+            "Individual-level confidence",
+            "Invalid confidence shape",
+        ],
+    )
+    def test_confidence_array(self, confidence_array, expected_context):
+        """Test confidence_array validation in ValidPosesInputs."""
+        position_array = np.zeros((5, 2, 3, 2))
+
+        with expected_context:
+            ValidPosesInputs(
+                position_array=position_array,
+                confidence_array=confidence_array,
+            )
+
 
 class TestValidBboxesInputs:
     """Test the ValidBboxesInputs class."""


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Currently, `confidence_array` validation only supports keypoint-level confidence arrays with shape `(time, keypoint, individual)`. However, some pose estimation formats such as COCO may provide confidence values at the individual level instead, with shape `(time, individual)`.

This PR is needed to support these valid confidence formats without breaking existing behavior.

**What does this PR do?**

This PR extends `confidence_array` validation to support both keypoint-level confidence arrays with shape `(time, keypoint, individual)` and `individual-level confidence arrays` with shape `(time, individual)`. Existing validation behavior for invalid shapes is preserved, and `_validate_array_shape` remains unchanged. In addition, tests were added to cover valid `keypoint-level confidence arrays`, `valid individual-level confidence arrays`, and `invalid confidence array shapes`.

## References

Related to COCO-format compatibility discussions.

## How has this PR been tested?

The changes were tested locally by instantiating `ValidPosesInputs` with valid keypoint-level confidence arrays, valid individual-level confidence arrays, and invalid confidence array shapes to verify the expected validation behavior. Validator tests were also run locally using pytest, and existing validation behavior was confirmed to remain unchanged.

## Is this a breaking change?

No.

Existing `keypoint-level confidence arrays` continue to behave as before. This PR only adds support for an additional valid confidence array shape.

## Does this PR require an update to the documentation?

Documentation updates are required since this PR extends the accepted `confidence_array` validation behavior by adding support for individual-level confidence arrays with shape `(time, individual)`. So documentation has to reflect the new available shape of `confidence_array`.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
