### PR TITLE
Warn wayland users about napari crash

### DIFF
--- a/docs/source/user_guide/installation.md
+++ b/docs/source/user_guide/installation.md
@@ -107,6 +107,36 @@ movement launch
 This is equivalent to running `napari -w movement` and should open the `napari`
 window with the `movement` widget docked on the right-hand side.
 
+:::{dropdown} Note for Linux users on wayland
+:color: warning
+:icon: alert
+
+On Linux systems with a wayland-based desktop environment, `movement launch`
+may fail with repeated error messages and a crash. This is a
+[known napari issue](https://github.com/napari/napari/issues/8808).
+
+If you are unsure whether you are affected by this,
+run `echo $XDG_SESSION_TYPE` and check if the output is `wayland`.
+
+To work around it, launch with the following environment variables:
+
+```sh
+QT_QPA_PLATFORM=xcb PYOPENGL_PLATFORM=glx movement launch
+```
+
+To avoid typing this every time, you can add the following lines to
+your shell configuration file (e.g. `~/.bashrc`):
+
+```sh
+export QT_QPA_PLATFORM=xcb
+export PYOPENGL_PLATFORM=glx
+```
+
+See napari's
+[troubleshooting guide](https://napari.org/stable/troubleshooting.html#running-napari-on-wayland-with-nvidia-cards)
+for more details.
+:::
+
 ## Update the package
 
 :::{dropdown} Always update using the same package manager used for installation


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other: docs

**Why is this PR needed?**

Closes 983.

**What does this PR do?**

Add a warning to the installation guide (in the "Verify the installation" section), targeted to Linux users with wayland-based desktop environments. `napari` (and therefore `movement`) won't launch on such environments without a workaround:

The warning:
- Includes a check for users to verify whether they are on wayland
- Provides them with a workaround (setting 2 env variables)
- Links to relevant napari issue and troubleshooting guide

We also considered an alternative, i.e. to automatically detect wayland and set the env variables accordingly in `cli_entrypoint.py`, as in ethograph: https://github.com/Akseli-Ilmanen/ethograph/issues/1#issuecomment-4491929877. But that fix feels like it belongs in `napari` itself, instead of in every `napari` plugin, so I've [proposed it to `napari` devs instead](https://github.com/napari/napari/issues/8808#issuecomment-4548771804). If they implement that upstream, this warning can potentially be removed.

## References

- https://github.com/neuroinformatics-unit/movement/issues/983
- https://github.com/napari/napari/issues/8808

## How has this PR been tested?

Local docs build, see preview below:

<img width="739" height="527" alt="image" src="https://github.com/user-attachments/assets/ba1357cc-2cfa-47e8-82d7-0a0e6b2ca33e" />

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

It is an update of docs.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
