### PR TITLE
Add pre-commit hook to prevent hardcoded movement website references in docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,14 +27,14 @@ repos:
     - repo: https://github.com/pre-commit/pygrep-hooks
       rev: v1.10.0
       hooks:
-        - id: rst-backticks
-        - id: rst-directive-colons
-        - id: rst-inline-touching-normal
+          - id: rst-backticks
+          - id: rst-directive-colons
+          - id: rst-inline-touching-normal
     - repo: https://github.com/astral-sh/ruff-pre-commit
       rev: v0.15.12
       hooks:
-        - id: ruff
-        - id: ruff-format
+          - id: ruff
+          - id: ruff-format
     - repo: https://github.com/pre-commit/mirrors-mypy
       rev: v1.20.2
       hooks:
@@ -62,13 +62,13 @@ repos:
       # Configuration for codespell is in pyproject.toml
       rev: v2.4.2
       hooks:
-      - id: codespell
+          - id: codespell
     - repo: local
       hooks:
-      - id: no-movement-url
-        name: block hardcoded movement URL in docs - use relative refs
-        language: pygrep
-        entry: "https://movement\\.neuroinformatics\\.dev"
-        files: ^docs/
-        exclude: ^docs/source/conf\.py
-        types: [text]
+          - id: no-movement-url
+            name: block hardcoded movement URL in docs - use relative refs
+            language: pygrep
+            entry: "https://movement\\.neuroinformatics\\.dev"
+            files: ^docs/
+            exclude: ^docs/source/conf\.py
+            types: [text]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,3 +63,12 @@ repos:
       rev: v2.4.2
       hooks:
       - id: codespell
+    - repo: local
+      hooks:
+      - id: no-movement-url
+        name: block hardcoded movement URL in docs - use relative refs
+        language: pygrep
+        entry: "https://movement\\.neuroinformatics\\.dev"
+        files: ^docs/
+        exclude: ^docs/conf\.py
+        types: [text]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,5 +70,5 @@ repos:
         language: pygrep
         entry: "https://movement\\.neuroinformatics\\.dev"
         files: ^docs/
-        exclude: ^docs/conf\.py
+        exclude: ^docs/source/conf\.py
         types: [text]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,5 +70,4 @@ repos:
             language: pygrep
             entry: "https://movement\\.neuroinformatics\\.dev"
             files: ^docs/
-            exclude: ^docs/source/conf\.py
             types: [text]


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Closes #645 

A simpler alternative to #765 that uses pre-commit to catch hardcoded movement website references in all files in docs, except for conf.py.

## How has this PR been tested?
commit fails when I try to add https://movement.neuroinformatics.dev/latest/examples/index.html in docs/source/index.md
<img width="1047" height="191" alt="image" src="https://github.com/user-attachments/assets/1961fdea-7a0e-456f-8472-726be3730007" />

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
