### PR TITLE
feat(io): add unified save_dataset entry point (#965)

### DIFF
--- a/movement/io/__init__.py
+++ b/movement/io/__init__.py
@@ -3,8 +3,10 @@ from .load import (
     load_dataset,
     load_multiview_dataset,
 )
+from .save import save_dataset
 
 __all__ = [
     "load_dataset",
     "load_multiview_dataset",
+    "save_dataset",
 ]

--- a/movement/io/save.py
+++ b/movement/io/save.py
@@ -1,0 +1,198 @@
+"""Save ``movement`` datasets to various file formats."""
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Literal
+
+import pynwb
+import xarray as xr
+
+from movement.io import save_bboxes, save_poses
+from movement.utils.logging import logger
+from movement.validators.files import validate_file_path
+
+type SaveTarget = Literal[
+    "netCDF",
+    "DeepLabCut",
+    "SLEAP",
+    "LightningPose",
+    "NWB",
+    "VIA-tracks",
+]
+
+# Mapping of pose-format names to the writer that handles them. Each writer
+# accepts ``(ds, file_path, **kwargs)`` and saves directly to disk.
+_POSES_WRITERS: dict[str, Callable] = {
+    "DeepLabCut": save_poses.to_dlc_file,
+    "SLEAP": save_poses.to_sleap_analysis_file,
+    "LightningPose": save_poses.to_lp_file,
+}
+
+# Mapping of bounding-boxes-format names to the writer that handles them.
+_BBOXES_WRITERS: dict[str, Callable] = {
+    "VIA-tracks": save_bboxes.to_via_tracks_file,
+}
+
+# The ``ds_type`` each non-netCDF target is compatible with.
+_TARGET_DS_TYPE: dict[str, Literal["poses", "bboxes"]] = {
+    **{name: "poses" for name in _POSES_WRITERS},
+    "NWB": "poses",
+    **{name: "bboxes" for name in _BBOXES_WRITERS},
+}
+
+
+def save_dataset(
+    ds: xr.Dataset,
+    file: str | Path,
+    source_software: SaveTarget | None = None,
+    **kwargs,
+) -> None:
+    """Save a ``movement`` dataset to a file in any supported format.
+
+    This is a unified entry point for saving ``movement`` datasets, mirroring
+    :func:`movement.io.load_dataset`. Based on the value of
+    ``source_software``, the appropriate format-specific writer is called.
+
+    Parameters
+    ----------
+    ds
+        The ``movement`` poses or bounding boxes dataset to save.
+    file
+        Path to the file to save the dataset to. The required file extension
+        depends on the target format (see the format-specific writers listed
+        under "See Also").
+    source_software
+        The format to save the dataset in. If None (default), the dataset is
+        saved in ``movement``'s native netCDF format (the file extension must
+        be ``.nc``). Otherwise, one of the supported third-party formats:
+        ``"DeepLabCut"``, ``"SLEAP"``, ``"LightningPose"``, ``"NWB"`` (poses
+        only), or ``"VIA-tracks"`` (bounding boxes only). The value
+        ``"netCDF"`` may also be passed explicitly.
+    **kwargs
+        Additional keyword arguments passed to the format-specific writer
+        (e.g. ``split_individuals`` for DeepLabCut, ``config`` for NWB, or any
+        :meth:`xarray.Dataset.to_netcdf` argument for netCDF).
+
+    Raises
+    ------
+    TypeError
+        If ``ds`` is not an :class:`xarray.Dataset`.
+    ValueError
+        If ``source_software`` is not a supported target, or if it is
+        incompatible with the dataset's ``ds_type`` (e.g. saving a bounding
+        boxes dataset to a poses-only format).
+
+    See Also
+    --------
+    movement.io.save_poses.to_dlc_file
+    movement.io.save_poses.to_sleap_analysis_file
+    movement.io.save_poses.to_lp_file
+    movement.io.save_poses.to_nwb_file
+    movement.io.save_bboxes.to_via_tracks_file
+
+    Notes
+    -----
+    For NWB, each individual is written to a separate file (as required by the
+    NWB format). For a single-individual dataset, the dataset is written to
+    ``file``. For a multi-individual dataset, the individual's name is appended
+    to the file path, just before the extension, e.g.
+    ``"/path/to/file_id_0.nwb"``.
+
+    Writers for the Anipose format and changes to the DeepLabCut splitting
+    default are not yet covered by this function (see issues #314 and #965).
+
+    Examples
+    --------
+    Save a dataset to ``movement``'s native netCDF format:
+
+    >>> from movement.io import save_dataset
+    >>> save_dataset(ds, "/path/to/file.nc")
+
+    Save a poses dataset to a DeepLabCut .h5 file:
+
+    >>> save_dataset(ds, "/path/to/file.h5", source_software="DeepLabCut")
+
+    Save a bounding boxes dataset to a VIA-tracks .csv file:
+
+    >>> save_dataset(ds, "/path/to/file.csv", source_software="VIA-tracks")
+
+    """
+    if not isinstance(ds, xr.Dataset):
+        raise logger.error(
+            TypeError(f"Expected an xarray Dataset, but got {type(ds)}.")
+        )
+
+    target = source_software if source_software is not None else "netCDF"
+
+    if target == "netCDF":
+        _save_netcdf(ds, file, **kwargs)
+        return
+
+    if target not in _TARGET_DS_TYPE:
+        supported = ", ".join(["netCDF", *_TARGET_DS_TYPE])
+        raise logger.error(
+            ValueError(
+                f"Unsupported source_software for saving: '{target}'. "
+                f"Supported values are: {supported}."
+            )
+        )
+
+    _validate_ds_type(ds, target)
+
+    if target == "NWB":
+        _save_nwb(ds, file, **kwargs)
+        return
+
+    writer = {**_POSES_WRITERS, **_BBOXES_WRITERS}[target]
+    writer(ds, file, **kwargs)
+
+
+def _validate_ds_type(ds: xr.Dataset, target: str) -> None:
+    """Check that the dataset's ``ds_type`` is compatible with the target.
+
+    The check is skipped if the dataset has no ``ds_type`` attribute, in which
+    case the format-specific writer's own validation will catch any mismatch.
+    """
+    expected = _TARGET_DS_TYPE[target]
+    ds_type = ds.attrs.get("ds_type")
+    if ds_type is not None and ds_type != expected:
+        raise logger.error(
+            ValueError(
+                f"Cannot save a '{ds_type}' dataset to the '{target}' format, "
+                f"which expects a '{expected}' dataset."
+            )
+        )
+
+
+def _save_netcdf(ds: xr.Dataset, file: str | Path, **kwargs) -> None:
+    """Save a ``movement`` dataset to a netCDF file."""
+    valid_path = validate_file_path(file, permission="w", suffixes={".nc"})
+    ds.to_netcdf(valid_path, **kwargs)
+    logger.info(f"Saved dataset to {valid_path}.")
+
+
+def _save_nwb(ds: xr.Dataset, file: str | Path, **kwargs) -> None:
+    """Save a ``movement`` poses dataset to one or more NWB files.
+
+    :func:`movement.io.save_poses.to_nwb_file` builds the NWBFile object(s)
+    but does not write them to disk; this helper writes them. Multi-individual
+    datasets yield one file per individual, with the individual name appended
+    to the file path.
+    """
+    valid_path = validate_file_path(file, permission="w", suffixes={".nwb"})
+    nwb_files = save_poses.to_nwb_file(ds, **kwargs)
+    if isinstance(nwb_files, pynwb.file.NWBFile):
+        _write_nwb_to_disk(nwb_files, valid_path)
+    else:
+        for nwb_file in nwb_files:
+            individual_path = valid_path.with_name(
+                f"{valid_path.stem}_{nwb_file.identifier}{valid_path.suffix}"
+            )
+            _write_nwb_to_disk(nwb_file, individual_path)
+
+
+def _write_nwb_to_disk(nwb_file: pynwb.file.NWBFile, file_path: Path) -> None:
+    """Write a single NWBFile object to disk."""
+    with pynwb.NWBHDF5IO(file_path, mode="w") as io:
+        io.write(nwb_file)
+    logger.info(f"Saved dataset to {file_path}.")

--- a/tests/test_unit/test_io/test_save.py
+++ b/tests/test_unit/test_io/test_save.py
@@ -1,0 +1,121 @@
+"""Test the unified ``save_dataset`` entry point."""
+
+import pytest
+import xarray as xr
+
+from movement.io import save_dataset
+
+
+@pytest.mark.parametrize("source_software", [None, "netCDF"])
+def test_save_dataset_netcdf_roundtrip(
+    valid_poses_dataset, source_software, tmp_path
+):
+    """A dataset saved to netCDF (default target) loads back unchanged."""
+    file_path = tmp_path / "dataset.nc"
+    save_dataset(valid_poses_dataset, file_path, source_software)
+    assert file_path.is_file()
+    loaded = xr.load_dataset(file_path)
+    xr.testing.assert_allclose(loaded, valid_poses_dataset)
+    assert loaded.attrs == valid_poses_dataset.attrs
+
+
+def test_save_dataset_netcdf_requires_nc_suffix(valid_poses_dataset, tmp_path):
+    """Saving to netCDF with a non-.nc suffix raises an error."""
+    with pytest.raises(ValueError, match="Expected file with suffix"):
+        save_dataset(valid_poses_dataset, tmp_path / "dataset.csv")
+
+
+def test_save_dataset_rejects_non_dataset(tmp_path):
+    """Passing a non-Dataset object raises a TypeError."""
+    with pytest.raises(TypeError, match="Expected an xarray Dataset"):
+        save_dataset([1, 2, 3], tmp_path / "dataset.nc")
+
+
+def test_save_dataset_invalid_source_software(valid_poses_dataset, tmp_path):
+    """An unsupported target raises a helpful ValueError."""
+    with pytest.raises(ValueError, match="Unsupported source_software"):
+        save_dataset(
+            valid_poses_dataset, tmp_path / "f.txt", source_software="bogus"
+        )
+
+
+@pytest.mark.parametrize(
+    "source_software, dict_name, dataset_fixture",
+    [
+        ("DeepLabCut", "_POSES_WRITERS", "valid_poses_dataset"),
+        ("SLEAP", "_POSES_WRITERS", "valid_poses_dataset"),
+        ("LightningPose", "_POSES_WRITERS", "valid_poses_dataset"),
+        ("VIA-tracks", "_BBOXES_WRITERS", "valid_bboxes_dataset"),
+    ],
+)
+def test_save_dataset_dispatches_to_writer(
+    source_software, dict_name, dataset_fixture, request, mocker, tmp_path
+):
+    """``save_dataset`` forwards to the correct format-specific writer,
+    passing the dataset, file path and extra kwargs through unchanged.
+    """
+    ds = request.getfixturevalue(dataset_fixture)
+    mock_writer = mocker.MagicMock()
+    mocker.patch.dict(
+        f"movement.io.save.{dict_name}",
+        {source_software: mock_writer},
+    )
+    file_path = tmp_path / "output"
+    save_dataset(ds, file_path, source_software=source_software, foo="bar")
+    mock_writer.assert_called_once_with(ds, file_path, foo="bar")
+
+
+@pytest.mark.parametrize(
+    "source_software, dataset_fixture",
+    [
+        ("DeepLabCut", "valid_bboxes_dataset"),  # poses-only target
+        ("VIA-tracks", "valid_poses_dataset"),  # bboxes-only target
+    ],
+)
+def test_save_dataset_ds_type_mismatch(
+    source_software, dataset_fixture, request, tmp_path
+):
+    """Saving a dataset to a format meant for the other ds_type errors out."""
+    ds = request.getfixturevalue(dataset_fixture)
+    with pytest.raises(ValueError, match="Cannot save a"):
+        save_dataset(ds, tmp_path / "output", source_software=source_software)
+
+
+def test_save_dataset_nwb_single_individual(
+    valid_poses_dataset, mocker, tmp_path
+):
+    """A single-individual NWB save writes to the given path verbatim."""
+    import pynwb
+
+    single = valid_poses_dataset.isel(individual=[0])
+    fake_nwb = mocker.MagicMock(spec=pynwb.file.NWBFile)
+    mocker.patch(
+        "movement.io.save.save_poses.to_nwb_file", return_value=fake_nwb
+    )
+    mock_write = mocker.patch("movement.io.save._write_nwb_to_disk")
+    file_path = tmp_path / "out.nwb"
+    save_dataset(single, file_path, source_software="NWB")
+    mock_write.assert_called_once_with(fake_nwb, file_path)
+
+
+def test_save_dataset_nwb_multi_individual(
+    valid_poses_dataset, mocker, tmp_path
+):
+    """A multi-individual NWB save writes one file per individual, with the
+    individual name appended to the file path.
+    """
+    fake_files = [
+        mocker.MagicMock(identifier="id_0"),
+        mocker.MagicMock(identifier="id_1"),
+    ]
+    mocker.patch(
+        "movement.io.save.save_poses.to_nwb_file", return_value=fake_files
+    )
+    mock_write = mocker.patch("movement.io.save._write_nwb_to_disk")
+    file_path = tmp_path / "out.nwb"
+    save_dataset(valid_poses_dataset, file_path, source_software="NWB")
+    written_paths = [call.args[1] for call in mock_write.call_args_list]
+    assert written_paths == [
+        tmp_path / "out_id_0.nwb",
+        tmp_path / "out_id_1.nwb",
+    ]


### PR DESCRIPTION
## Description

Closes #965

Adds `save_dataset`, a single entry point for saving `movement` datasets that
mirrors `load_dataset` on the write side. Previously users had to reach for the
format-specific `to_*_file` writers (or raw xarray) directly.

```python
from movement.io import save_dataset

save_dataset(ds, "out.nc")                                   # native netCDF (default)
save_dataset(ds, "out.h5", source_software="DeepLabCut")     # poses → DLC
save_dataset(ds, "out.csv", source_software="VIA-tracks")    # bboxes → VIA
