### PR TITLE
Pin `sphinx-autodoc-typehints>=3.10.4`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,11 +8,8 @@
 
 import os
 import sys
-import types
-from typing import TypeAliasType
 
 import setuptools_scm
-from sphinx_autodoc_typehints import format_annotation
 
 # Used when building API docs, put the dependencies
 # of any class you are documenting here
@@ -91,64 +88,11 @@ autodoc_default_options = {
     "member-order": "groupwise",
 }
 
-
-def _get_canonical_type_alias_name(annotation):
-    """Get canonical public qualified name for a TypeAliasType.
-
-    For types defined in private modules (e.g. ``numpy._typing.ArrayLike``),
-    search ``sys.modules`` for a public re-export
-    (e.g. ``numpy.typing.ArrayLike``).
-    """
-    module = getattr(annotation, "__module__", "") or ""
-    name = getattr(annotation, "__name__", "") or ""
-    if not module or not name:
-        return ""
-    if not any(part.startswith("_") for part in module.split(".")):
-        return f"{module}.{name}"
-    top_pkg = module.split(".")[0]
-    for mod_name in sorted(sys.modules):
-        if not mod_name.startswith(top_pkg):
-            continue
-        mod = sys.modules[mod_name]
-        if not isinstance(mod, types.ModuleType):
-            continue
-        if any(part.startswith("_") for part in mod_name.split(".")):
-            continue
-        if getattr(mod, name, None) is annotation:
-            return f"{mod_name}.{name}"
-    return f"{module}.{name}"
-
-
-def _typehints_formatter(annotation, config):
-    """Handle formatting of PEP695 type aliases in sphinx-autodoc-typehints."""
-    if isinstance(annotation, TypeAliasType):
-        module = getattr(annotation, "__module__", "") or ""
-        name = getattr(annotation, "__name__", "") or ""
-        intersphinx_mapping = getattr(config, "intersphinx_mapping", {})
-        is_external = module and any(
-            module == pkg or module.startswith(f"{pkg}.")
-            for pkg in intersphinx_mapping
-        )
-        # Handle external PEP695 type aliases
-        if is_external and name:
-            canonical = _get_canonical_type_alias_name(annotation)
-            if canonical:
-                return f":py:obj:`~{canonical}`"
-        # Unwrap internal PEP695 type aliases to their underlying types
-        return format_annotation(annotation.__value__, config)
-    return None
-
-
 # sphinx-autodoc-typehints configuration
 always_use_bars_union = True
-typehints_formatter = _typehints_formatter
 
 # Prefix section labels with the document name
 autosectionlabel_prefix_document = True
-
-# Suppress config cache warning caused by `typehints_formatter`
-# as Sphinx cannot pickle callables
-suppress_warnings = ["config.cache"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ docs = [
   "nbsphinx",
   "pydata-sphinx-theme",
   "sphinx",
-  "sphinx-autodoc-typehints",
+  "sphinx-autodoc-typehints>=3.10.4",
   "sphinx-design",
   "sphinx-gallery",
   "sphinx-notfound-page",


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Closes #975 

**What does this PR do?**
- Upstream PR to fix TypeAliasType issues (#958) has been released, sets an upper pin to the latest `sphinx-autodoc-typehints` version
- Removes the workaround added in #969

## How has this PR been tested?
Local docs build

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
