### PR TITLE
Handle individual-wise confidence during DLC/LP export

### DIFF
--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -37,6 +37,8 @@ def _ds_to_dlc_style_df(
     pandas.DataFrame
 
     """
+    # DLC stores confidence scores per keypoint. If confidence is provided
+    # per individual, expand it across all keypoints before export.
     confidence = ds.confidence.data
     if "keypoint" not in ds.confidence.dims:
         logger.warning(
@@ -49,8 +51,6 @@ def _ds_to_dlc_style_df(
         )
     # Keep position data as is, if data is 3D (i.e. contains 'z' coordinate)
     # Otherwise, concatenate position and confidence scores into one array
-    # DLC stores confidence scores per keypoint. If confidence is provided
-    # per individual, expand it across all keypoints before export.
     tracks = (
         ds.position.data
         if "z" in columns.get_level_values("coords")

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -39,13 +39,34 @@ def _ds_to_dlc_style_df(
     """
     # Keep position data as is, if data is 3D (i.e. contains 'z' coordinate)
     # Otherwise, concatenate position and confidence scores into one array
+    # DLC stores confidence scores per keypoint. If confidence is provided
+    # per individual, expand it across all keypoints before export.
+    confidence = ds.confidence.data
+    if "keypoint" not in ds.confidence.dims:
+        logger.warning(
+            "Dataset contains individual-wise confidence scores. "
+            "DeepLabCut only supports keypoint-wise confidence scores, "
+            "so confidence values will be expanded to all keypoints."
+        )
+        if confidence.ndim == 1:
+            confidence = np.repeat(
+                confidence[:, np.newaxis],
+                ds.sizes["keypoint"],
+                axis=1,
+            )
+        else:
+            confidence = np.repeat(
+                confidence[:, np.newaxis, :],
+                ds.sizes["keypoint"],
+                axis=1,
+            )
     tracks = (
         ds.position.data
         if "z" in columns.get_level_values("coords")
         else np.concatenate(
             (
                 ds.position.data,
-                ds.confidence.data[:, np.newaxis, ...],
+                confidence[:, np.newaxis, ...],
             ),
             axis=1,
         )

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -37,29 +37,20 @@ def _ds_to_dlc_style_df(
     pandas.DataFrame
 
     """
-    # Keep position data as is, if data is 3D (i.e. contains 'z' coordinate)
-    # Otherwise, concatenate position and confidence scores into one array
-    # DLC stores confidence scores per keypoint. If confidence is provided
-    # per individual, expand it across all keypoints before export.
     confidence = ds.confidence.data
     if "keypoint" not in ds.confidence.dims:
         logger.warning(
             "Dataset contains individual-wise confidence scores. "
-            "DeepLabCut only supports keypoint-wise confidence scores, "
+            "DLC-style formats only supports keypoint-wise confidence scores, "
             "so confidence values will be expanded to all keypoints."
         )
-        if confidence.ndim == 1:
-            confidence = np.repeat(
-                confidence[:, np.newaxis],
-                ds.sizes["keypoint"],
-                axis=1,
-            )
-        else:
-            confidence = np.repeat(
-                confidence[:, np.newaxis, :],
-                ds.sizes["keypoint"],
-                axis=1,
-            )
+        confidence = np.repeat(
+            np.expand_dims(confidence, axis=1), ds.sizes["keypoint"], axis=1
+        )
+    # Keep position data as is, if data is 3D (i.e. contains 'z' coordinate)
+    # Otherwise, concatenate position and confidence scores into one array
+    # DLC stores confidence scores per keypoint. If confidence is provided
+    # per individual, expand it across all keypoints before export.
     tracks = (
         ds.position.data
         if "z" in columns.get_level_values("coords")

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -312,6 +312,18 @@ def valid_poses_dataset_with_nan(valid_poses_dataset):
 
 
 @pytest.fixture
+def valid_poses_dataset_with_individual_wise_confidence(valid_poses_dataset):
+    """Return a valid poses dataset with individual-wise (rather than
+    keypoint-wise) confidence scores, derived from the centroid
+    keypoint's confidence values in ``valid_poses_dataset``.
+    """
+    valid_poses_dataset["confidence"] = valid_poses_dataset.confidence.isel(
+        keypoint=0
+    )
+    return valid_poses_dataset
+
+
+@pytest.fixture
 def valid_dlc_poses_df():
     """Return a valid DLC-style poses DataFrame."""
     return pd.read_hdf(pytest.DATA_PATHS.get("DLC_single-wasp.predictions.h5"))

--- a/tests/test_unit/test_io/test_save_poses.py
+++ b/tests/test_unit/test_io/test_save_poses.py
@@ -136,20 +136,18 @@ def test_to_dlc_style_df_with_individual_confidence(
     ds = valid_poses_dataset_with_individual_wise_confidence
     df = save_poses.to_dlc_style_df(ds, split_individuals=split_individuals)
     bodyparts = ds.coords["keypoint"].data.tolist()
-    if split_individuals:
-        assert isinstance(df, dict)
-        for ind in ds.individual.values:
-            expected = ds.confidence.sel(individual=ind).values
-            for bp in bodyparts:
-                actual = df[ind][("movement", bp, "likelihood")].to_numpy()
-                np.testing.assert_array_equal(actual, expected)
-    else:
-        assert isinstance(df, pd.DataFrame)
-        for ind in ds.individual.values:
-            expected = ds.confidence.sel(individual=ind).values
-            for bp in bodyparts:
-                actual = df[("movement", ind, bp, "likelihood")].to_numpy()
-                np.testing.assert_array_equal(actual, expected)
+    assert isinstance(df, dict if split_individuals else pd.DataFrame)
+    for ind in ds.individual.values:
+        expected = ds.confidence.sel(individual=ind).values
+        sub_df = df[ind] if split_individuals else df
+        for bp in bodyparts:
+            col = (
+                ("movement", bp, "likelihood")
+                if split_individuals
+                else ("movement", ind, bp, "likelihood")
+            )
+            actual = sub_df[col].to_numpy()
+            np.testing.assert_array_equal(actual, expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_unit/test_io/test_save_poses.py
+++ b/tests/test_unit/test_io/test_save_poses.py
@@ -118,42 +118,67 @@ def test_to_dlc_style_df(ds, expected_exception):
             ]
 
 
-def test_to_dlc_style_df_with_individual_confidence():
+@pytest.mark.parametrize(
+    "valid_poses_dataset",
+    ["single_individual_array", "multi_individual_array"],
+    indirect=True,
+)
+@pytest.mark.parametrize("split_individuals", [True, False])
+def test_to_dlc_style_df_with_individual_confidence(
+    valid_poses_dataset_with_individual_wise_confidence, split_individuals
+):
     """Test that datasets with individual-wise confidence scores can
-    be converted to a DLC-style DataFrame.
+    be converted to DLC-style DataFrame(s), for single- and
+    multi-individual datasets, and both ``split_individuals`` settings.
+    The individual-wise confidence values should be expanded (repeated)
+    across all keypoints in the output DataFrame(s).
     """
-    ds = load_poses.from_dlc_file(
-        DATA_PATHS.get("DLC_single-wasp.predictions.h5")
-    )
+    ds = valid_poses_dataset_with_individual_wise_confidence
+    df = save_poses.to_dlc_style_df(ds, split_individuals=split_individuals)
+    bodyparts = ds.coords["keypoint"].data.tolist()
+    if split_individuals:
+        assert isinstance(df, dict)
+        for ind in ds.individual.values:
+            expected = ds.confidence.sel(individual=ind).values
+            for bp in bodyparts:
+                actual = df[ind][("movement", bp, "likelihood")].to_numpy()
+                np.testing.assert_array_equal(actual, expected)
+    else:
+        assert isinstance(df, pd.DataFrame)
+        for ind in ds.individual.values:
+            expected = ds.confidence.sel(individual=ind).values
+            for bp in bodyparts:
+                actual = df[("movement", ind, bp, "likelihood")].to_numpy()
+                np.testing.assert_array_equal(actual, expected)
 
-    # Convert keypoint-wise confidence to individual-wise confidence
-    ds["confidence"] = ds.confidence.isel(keypoint=0)
 
-    df = save_poses.to_dlc_style_df(
-        ds,
-        split_individuals=False,
-    )
-
-    assert isinstance(df, pd.DataFrame)
-
-
-def test_to_dlc_file_with_individual_confidence(tmp_path):
+@pytest.mark.parametrize(
+    "valid_poses_dataset",
+    ["single_individual_array", "multi_individual_array"],
+    indirect=True,
+)
+@pytest.mark.parametrize("split_individuals", [True, False])
+def test_to_dlc_file_with_individual_confidence(
+    valid_poses_dataset_with_individual_wise_confidence,
+    split_individuals,
+    tmp_path,
+):
     """Test that datasets with individual-wise confidence scores can
-    be exported to DLC format.
+    be exported to DLC format, for single- and multi-individual
+    datasets, and both ``split_individuals`` settings.
+    The exported DLC file should be created successfully.
     """
-    ds = load_poses.from_dlc_file(
-        DATA_PATHS.get("DLC_single-wasp.predictions.h5")
-    )
-
-    ds["confidence"] = ds.confidence.isel(keypoint=0)
-
+    ds = valid_poses_dataset_with_individual_wise_confidence
     save_poses.to_dlc_file(
         ds,
         tmp_path / "test.h5",
-        split_individuals=False,
+        split_individuals=split_individuals,
     )
-
-    assert (tmp_path / "test.h5").is_file()
+    if split_individuals:
+        for ind in ds.individual.values:
+            assert (tmp_path / f"test_{ind}.h5").is_file()
+    else:
+        assert (tmp_path / "test.h5").is_file()
 
 
 def test_to_dlc_file_valid_dataset(
@@ -313,20 +338,23 @@ def test_to_lp_file_invalid_dataset(
         )
 
 
-def test_to_lp_file_with_individual_confidence(tmp_path):
+@pytest.mark.parametrize(
+    "valid_poses_dataset",
+    ["single_individual_array", "multi_individual_array"],
+    indirect=True,
+)
+def test_to_lp_file_with_individual_confidence(
+    valid_poses_dataset_with_individual_wise_confidence, tmp_path
+):
     """Test that datasets with individual-wise confidence scores can
-    be exported to LightningPose format.
+    be exported to LightningPose format, for single- and multi-individual
+    datasets settings. The exported LightningPose file should be created
+    successfully.
     """
-    ds = load_poses.from_dlc_file(
-        DATA_PATHS.get("LP_mouse-face_AIND.predictions.csv")
-    )
-
-    ds["confidence"] = ds.confidence.isel(keypoint=0)
-
-    save_poses.to_lp_file(
-        ds,
-        tmp_path / "test.csv",
-    )
+    ds = valid_poses_dataset_with_individual_wise_confidence
+    save_poses.to_lp_file(ds, tmp_path / "test.csv")
+    for ind in ds.individual.values:
+        assert (tmp_path / f"test_{ind}.csv").is_file()
 
 
 def test_to_sleap_analysis_file_valid_dataset(

--- a/tests/test_unit/test_io/test_save_poses.py
+++ b/tests/test_unit/test_io/test_save_poses.py
@@ -202,11 +202,10 @@ def test_to_dlc_file_invalid_dataset(
     """Test that saving an invalid pose dataset to a valid
     DeepLabCut-style file returns the appropriate errors.
     """
+    ds = request.getfixturevalue(invalid_poses_dataset)
     with pytest.raises(expected_exception):
         save_poses.to_dlc_file(
-            request.getfixturevalue(invalid_poses_dataset),
-            tmp_path / "test.h5",
-            split_individuals=False,
+            ds, tmp_path / "test.h5", split_individuals=False
         )
 
 
@@ -225,15 +224,11 @@ def test_auto_split_individuals(valid_poses_dataset, split_value):
 
 
 @pytest.mark.parametrize(
-    "valid_poses_dataset, split_individuals",
-    [
-        ("single_individual_array", True),  # single-individual, split
-        ("multi_individual_array", False),  # multi-individual, no split
-        ("single_individual_array", False),  # single-individual, no split
-        ("multi_individual_array", True),  # multi-individual, split
-    ],
-    indirect=["valid_poses_dataset"],
+    "valid_poses_dataset",
+    ["single_individual_array", "multi_individual_array"],
+    indirect=True,
 )
+@pytest.mark.parametrize("split_individuals", [True, False])
 def test_to_dlc_style_df_split_individuals(
     valid_poses_dataset, split_individuals
 ):
@@ -329,11 +324,9 @@ def test_to_lp_file_invalid_dataset(
     """Test that saving an invalid pose dataset to a valid
     LightningPose-style file returns the appropriate errors.
     """
+    ds = request.getfixturevalue(invalid_poses_dataset)
     with pytest.raises(expected_exception):
-        save_poses.to_lp_file(
-            request.getfixturevalue(invalid_poses_dataset),
-            tmp_path / "test.csv",
-        )
+        save_poses.to_lp_file(ds, tmp_path / "test.csv")
 
 
 @pytest.mark.parametrize(
@@ -378,11 +371,9 @@ def test_to_sleap_analysis_file_invalid_dataset(
     """Test that saving an invalid pose dataset to a valid
     SLEAP-style file returns the appropriate errors.
     """
+    ds = request.getfixturevalue(invalid_poses_dataset)
     with pytest.raises(expected_exception):
-        save_poses.to_sleap_analysis_file(
-            request.getfixturevalue(invalid_poses_dataset),
-            new_h5_file,
-        )
+        save_poses.to_sleap_analysis_file(ds, new_h5_file)
 
 
 nwb_file_expectations_ind = {

--- a/tests/test_unit/test_io/test_save_poses.py
+++ b/tests/test_unit/test_io/test_save_poses.py
@@ -118,6 +118,44 @@ def test_to_dlc_style_df(ds, expected_exception):
             ]
 
 
+def test_to_dlc_style_df_with_individual_confidence():
+    """Test that datasets with individual-wise confidence scores can
+    be converted to a DLC-style DataFrame.
+    """
+    ds = load_poses.from_dlc_file(
+        DATA_PATHS.get("DLC_single-wasp.predictions.h5")
+    )
+
+    # Convert keypoint-wise confidence to individual-wise confidence
+    ds["confidence"] = ds.confidence.isel(keypoint=0)
+
+    df = save_poses.to_dlc_style_df(
+        ds,
+        split_individuals=False,
+    )
+
+    assert isinstance(df, pd.DataFrame)
+
+
+def test_to_dlc_file_with_individual_confidence(tmp_path):
+    """Test that datasets with individual-wise confidence scores can
+    be exported to DLC format.
+    """
+    ds = load_poses.from_dlc_file(
+        DATA_PATHS.get("DLC_single-wasp.predictions.h5")
+    )
+
+    ds["confidence"] = ds.confidence.isel(keypoint=0)
+
+    save_poses.to_dlc_file(
+        ds,
+        tmp_path / "test.h5",
+        split_individuals=False,
+    )
+
+    assert (tmp_path / "test.h5").is_file()
+
+
 def test_to_dlc_file_valid_dataset(
     output_file_params, valid_poses_dataset, request
 ):
@@ -273,6 +311,22 @@ def test_to_lp_file_invalid_dataset(
             request.getfixturevalue(invalid_poses_dataset),
             tmp_path / "test.csv",
         )
+
+
+def test_to_lp_file_with_individual_confidence(tmp_path):
+    """Test that datasets with individual-wise confidence scores can
+    be exported to LightningPose format.
+    """
+    ds = load_poses.from_dlc_file(
+        DATA_PATHS.get("LP_mouse-face_AIND.predictions.csv")
+    )
+
+    ds["confidence"] = ds.confidence.isel(keypoint=0)
+
+    save_poses.to_lp_file(
+        ds,
+        tmp_path / "test.csv",
+    )
 
 
 def test_to_sleap_analysis_file_valid_dataset(


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Datasets with individual-wise confidence scores could not be exported to `DeepLabCut` (DLC) or `LightningPose` formats. Exporting such datasets resulted in a dimension mismatch error because these formats expect keypoint-wise confidence scores.

**What does this PR do?**

Expands individual-wise confidence scores to keypoint-wise confidence scores by assigning the same confidence value to all keypoints belonging to an individual. Emits a `logger.warning` informing users that the conversion is being performed and that the original individual-wise confidence representation will not be preserved when the exported file is reloaded. Adds tests covering DLC and LightningPose exports with individual-wise confidence scores.

## References

#1003 

## How has this PR been tested?

Reproduced the issue locally using a dataset with individual-wise confidence scores.
Verified that `save_poses.to_dlc_style_df()` no longer raises an exception.
Verified that `save_poses.to_dlc_file()` successfully exports datasets with individual-wise confidence scores.
Verified that `save_poses.to_lp_file()` successfully exports datasets with individual-wise confidence scores.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

Yes.
This PR introduces a new export behaviour for datasets with individual-wise confidence scores. When exporting to formats that only support keypoint-wise confidence scores, individual-wise confidence scores are expanded to all keypoints belonging to an individual.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
