### PR TITLE
Update bbox nan fixture

### DIFF
--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -148,9 +148,8 @@ def valid_bboxes_dataset_with_nan(valid_bboxes_dataset):
     """
     nan_selection = {"individual": "id_0", "time": [3, 7, 8]}
 
-
-for var in valid_bboxes_dataset.data_vars:
-    valid_bboxes_dataset[var].loc[nan_selection] = np.nan
+    for var in valid_bboxes_dataset.data_vars:
+        valid_bboxes_dataset[var].loc[nan_selection] = np.nan
     return valid_bboxes_dataset
 
 

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -147,9 +147,8 @@ def valid_bboxes_dataset_with_nan(valid_bboxes_dataset):
     Here, individual ``id_0`` is missing at frames 3, 7 and 8.
     """
     nan_selection = {"individual": "id_0", "time": [3, 7, 8]}
-    valid_bboxes_dataset.position.loc[nan_selection] = np.nan
-    valid_bboxes_dataset.shape.loc[nan_selection] = np.nan
-    valid_bboxes_dataset.confidence.loc[nan_selection] = np.nan
+for var in valid_bboxes_dataset.data_vars:
+    valid_bboxes_dataset[var].loc[nan_selection] = np.nan
     return valid_bboxes_dataset
 
 

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -140,11 +140,16 @@ def valid_bboxes_dataset_in_seconds(valid_bboxes_dataset):
 
 @pytest.fixture
 def valid_bboxes_dataset_with_nan(valid_bboxes_dataset):
-    """Return a valid bboxes dataset with NaN values in the position array."""
-    # Set 3 NaN values in the position array for id_0
-    valid_bboxes_dataset.position.loc[
-        {"individual": "id_0", "time": [3, 7, 8]}
-    ] = np.nan
+    """Return a valid bboxes dataset with NaN values for some detections.
+    A missing detection is represented by NaN in the ``position``, ``shape``
+    and ``confidence`` arrays simultaneously, mirroring how real bounding box
+    data (e.g. from VIA-tracks) encodes frames where an individual is absent.
+    Here, individual ``id_0`` is missing at frames 3, 7 and 8.
+    """
+    nan_selection = {"individual": "id_0", "time": [3, 7, 8]}
+    valid_bboxes_dataset.position.loc[nan_selection] = np.nan
+    valid_bboxes_dataset.shape.loc[nan_selection] = np.nan
+    valid_bboxes_dataset.confidence.loc[nan_selection] = np.nan
     return valid_bboxes_dataset
 
 

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -147,6 +147,8 @@ def valid_bboxes_dataset_with_nan(valid_bboxes_dataset):
     Here, individual ``id_0`` is missing at frames 3, 7 and 8.
     """
     nan_selection = {"individual": "id_0", "time": [3, 7, 8]}
+
+
 for var in valid_bboxes_dataset.data_vars:
     valid_bboxes_dataset[var].loc[nan_selection] = np.nan
     return valid_bboxes_dataset


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
The fixture `valid_bboxes_dataset_with_nan` creates an unrealistic dataset for `bbox`, because it only introduces `NaN` to the position array, while `shape` and `confidence` remain valid. But as discussed in #1011, in bbox datasets, when a detection is missing it is represented by `NaN` values across all three arrays. 

**What does this PR do?**
Updates the  `valid_bboxes_dataset_with_nan` so that missing detections are represented in `position`, `shape` and `confidence`. 


## References

Related to #1011, this issue was identified while adding tests for `napari_layers_to_ds()` in the draft-PR. 

## How has this PR been tested?

Run all the tests locally with `pytest` and everything passed. 

## Is this a breaking change?

No. This just affects a text fixture. 

## Does this PR require an update to the documentation?

I don't think so. 

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
