### PR TITLE
Improve look of contributor cards

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -88,11 +88,6 @@ a[class^="sphx-glr-backref-module-movement"] {
 .contributors-table .sd-card {
   border-radius: 8px;
   overflow: hidden;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-.contributors-table .sd-card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15) !important;
 }
 .contributors-table .sd-card-img-top {
   width: 80px;

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -78,3 +78,37 @@ a[class^="sphx-glr-backref-module-movement"] {
   color: var(--pst-color-success);
   content: "\f004";  /* fa-heart (Font Awesome 6 Free Solid) */
 }
+/* Contributor avatar grid */
+.contributors-table .sd-card,
+.contributors-table .sd-card-body {
+  background: var(--pst-color-on-background) !important;
+  border: none !important;
+  box-shadow: none !important;
+  text-align: center;
+}
+.contributors-table .sd-card {
+  border-radius: 8px;
+  overflow: hidden;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.contributors-table .sd-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15) !important;
+}
+.contributors-table .sd-card-img-top {
+  width: 80px;
+  height: 80px;
+  border-radius: 50% !important;
+  object-fit: cover;
+  margin: 0.75rem auto 0;
+  display: block;
+}
+.contributors-table .sd-card-body {
+  padding: 0.4rem 0.25rem 0.4rem;
+}
+.contributors-table .sd-card-title {
+  font-size: 0.8rem !important;
+  font-weight: 500 !important;
+  line-height: 1.3;
+  margin-bottom: 0 !important;
+}

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -98,7 +98,7 @@ a[class^="sphx-glr-backref-module-movement"] {
   display: block;
 }
 .contributors-table .sd-card-body {
-  padding: 0.4rem 0.25rem 0.4rem;
+  padding: 0.4rem 0.25rem;
 }
 .contributors-table .sd-card-title {
   font-size: 0.8rem !important;

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -78,12 +78,11 @@ a[class^="sphx-glr-backref-module-movement"] {
   color: var(--pst-color-success);
   content: "\f004";  /* fa-heart (Font Awesome 6 Free Solid) */
 }
+
 /* Contributor avatar grid */
 .contributors-table .sd-card,
 .contributors-table .sd-card-body {
   background: var(--pst-color-on-background) !important;
-  border: none !important;
-  box-shadow: none !important;
   text-align: center;
 }
 .contributors-table .sd-card {

--- a/docs/source/_static/js/contributors.js
+++ b/docs/source/_static/js/contributors.js
@@ -30,9 +30,9 @@ document.addEventListener('DOMContentLoaded', () => {
         cardTitle.textContent = name ? name.textContent : img.alt;
         cardBody.appendChild(cardTitle);
 
-        // Image at the bottom of the card
+        // Image at the top of the card
         const cardImg = document.createElement('img');
-        cardImg.className = 'sd-card-img-bottom';
+        cardImg.className = 'sd-card-img-top';
         cardImg.src = img.src;
         cardImg.alt = img.alt;
 
@@ -44,8 +44,8 @@ document.addEventListener('DOMContentLoaded', () => {
         linkSpan.textContent = link.href;
         stretchedLink.appendChild(linkSpan);
 
-        card.appendChild(cardBody);
         card.appendChild(cardImg);
+        card.appendChild(cardBody);
         card.appendChild(stretchedLink);
         col.appendChild(card);
         gridRow.appendChild(col);


### PR DESCRIPTION
## Description
**What is this PR**
- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
The contributor cards on the People page were displayed with images at the bottom and lacked consistent styling. This PR improves the look to match BrainGlobe's contributor card style as requested in #984.

**What does this PR do?**
- Changes `sd-card-img-bottom` to `sd-card-img-top` in contributors.js so avatars appear above names
- Reorders card.appendChild() to match the img-top position
- Adds CSS styles in custom.css for circular avatars, rounded card corners and a subtle hover lift effect

## References
Fixes #984
Related to discussion with @niksirbi and @lochhh in #984

## How has this PR been tested?
- Built docs locally using `make clean html`
- Visually verified the people page in browser
- Confirmed hover effect works
- Pre-commit hooks pass

## Is this a breaking change?
No — only CSS and JS presentation changes. No existing functionality is affected.

## Does this PR require an update to the documentation?
No — this PR itself updates the documentation styling.

## Checklist:
- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with pre-commit