### PR TITLE
Set confidence of edited points in napari to NaN

### DIFF
--- a/movement/napari/convert.py
+++ b/movement/napari/convert.py
@@ -223,7 +223,7 @@ def napari_layers_to_ds(
     using the full coordinate structure from ``properties_with_nans``
 
     """
-    properties_df = pd.DataFrame.from_dict(properties)
+    properties_df = pd.DataFrame.from_dict(properties)  # without nans
     fps = attrs.get("fps") if attrs is not None else None
 
     if "keypoint" in properties_df.columns:
@@ -234,10 +234,12 @@ def napari_layers_to_ds(
         individual_coords = (
             properties_with_nans["individual"].unique().tolist()
         )
+
         # Build position dataframe from napari's live point layer data
         position_df = pd.DataFrame(
             points_as_napari, columns=["frame", "y", "x"]
         )
+
         # Use the frame coordinate from the live napari layer as the
         # source of truth for time. This avoids relying on
         # properties_df["time"], which may become stale when users add
@@ -249,6 +251,19 @@ def napari_layers_to_ds(
 
         position_df["keypoint"] = properties_df["keypoint"].to_numpy()
         position_df["individual"] = properties_df["individual"].to_numpy()
+        position_df["confidence"] = properties_df["confidence"].to_numpy()
+
+        confidence_da = (
+            position_df.set_index(["time", "keypoint", "individual"])[
+                "confidence"
+            ]
+            .to_xarray()
+            .reindex(
+                time=time_coords,
+                keypoint=keypoint_coords,
+                individual=individual_coords,
+            )
+        )
 
         position_df = position_df.melt(
             id_vars=["time", "frame", "keypoint", "individual"],
@@ -264,18 +279,6 @@ def napari_layers_to_ds(
             .reindex(
                 time=time_coords,
                 space=space_coords,
-                keypoint=keypoint_coords,
-                individual=individual_coords,
-            )
-        )
-
-        confidence_da = (
-            properties_with_nans.set_index(["time", "keypoint", "individual"])[
-                "confidence"
-            ]
-            .to_xarray()
-            .reindex(
-                time=time_coords,
                 keypoint=keypoint_coords,
                 individual=individual_coords,
             )

--- a/movement/napari/convert.py
+++ b/movement/napari/convert.py
@@ -223,7 +223,9 @@ def napari_layers_to_ds(
     using the full coordinate structure from ``properties_with_nans``
 
     """
-    properties_df = pd.DataFrame.from_dict(properties)  # live data without nans
+    properties_df = pd.DataFrame.from_dict(
+        properties
+    )  # live data without nans
     fps = attrs.get("fps") if attrs is not None else None
 
     if "keypoint" in properties_df.columns:

--- a/movement/napari/convert.py
+++ b/movement/napari/convert.py
@@ -223,7 +223,7 @@ def napari_layers_to_ds(
     using the full coordinate structure from ``properties_with_nans``
 
     """
-    properties_df = pd.DataFrame.from_dict(properties)  # without nans
+    properties_df = pd.DataFrame.from_dict(properties)  # live data without nans
     fps = attrs.get("fps") if attrs is not None else None
 
     if "keypoint" in properties_df.columns:

--- a/movement/napari/convert.py
+++ b/movement/napari/convert.py
@@ -253,10 +253,8 @@ def napari_layers_to_ds(
 
         position_df["keypoint"] = properties_df["keypoint"].to_numpy()
         position_df["individual"] = properties_df["individual"].to_numpy()
-        position_df["confidence"] = properties_df["confidence"].to_numpy()
-
         confidence_da = (
-            position_df.set_index(["time", "keypoint", "individual"])[
+            properties_df.set_index(["time", "keypoint", "individual"])[
                 "confidence"
             ]
             .to_xarray()

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -352,9 +352,9 @@ class DataLoader(QWidget):
     def _on_points_data_changed(self, event):
         """Set confidence to NaN for moved (dragged) points.
 
-        Connected to ``points_layer.events.data``. Fires whenever points are
-        added, removed, or moved. Only acts on ``ActionType.CHANGED`` (drag),
-        since moved points no longer have a valid confidence score.
+        Connected to ``points_layer.events.data``. Fires on 
+        ``ActionType.CHANGED`` (i.e., when the data array values 
+        change) and sets the confidence score of moved points to NaN.
         """
         layer = event.source
         if not isinstance(layer, Points):

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -7,7 +7,7 @@ import pandas as pd
 import xarray as xr
 from napari.components.dims import RangeTuple
 from napari.layers import Image, Points, Shapes, Tracks
-from napari.layers.base._base_constants import ActionType
+from napari.layers.base import ActionType
 from napari.settings import get_settings
 from napari.utils.notifications import show_error, show_warning
 from napari.viewer import Viewer

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -7,6 +7,7 @@ import pandas as pd
 import xarray as xr
 from napari.components.dims import RangeTuple
 from napari.layers import Image, Points, Shapes, Tracks
+from napari.layers.base._base_constants import ActionType
 from napari.settings import get_settings
 from napari.utils.notifications import show_error, show_warning
 from napari.viewer import Viewer
@@ -344,8 +345,27 @@ class DataLoader(QWidget):
             metadata={"max_frame_idx": max(self.data[:, 1])},
             **points_style.as_kwargs(),
         )
+        self.points_layer.events.data.connect(self._on_points_data_changed)
 
         logger.info("Added tracked dataset as a napari Points layer.")
+
+    def _on_points_data_changed(self, event):
+        """Set confidence to NaN for moved (dragged) points.
+
+        Connected to ``points_layer.events.data``. Fires whenever points are
+        added, removed, or moved. Only acts on ``ActionType.CHANGED`` (drag),
+        since moved points no longer have a valid confidence score.
+        """
+        layer = event.source
+        if event.action != ActionType.CHANGED:
+            return
+        moved_indices = list(event.data_indices)
+        feats = layer.features
+        feats.loc[moved_indices, "confidence"] = float("nan")
+        layer.features = feats
+
+        full_indices = np.where(self.data_not_nan)[0][moved_indices]
+        self.properties.loc[full_indices, "confidence"] = np.nan
 
     def _add_tracks_layer(self):
         """Add the tracked data to the viewer as a Tracks layer."""

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -352,8 +352,8 @@ class DataLoader(QWidget):
     def _on_points_data_changed(self, event):
         """Set confidence to NaN for moved (dragged) points.
 
-        Connected to ``points_layer.events.data``. Fires on 
-        ``ActionType.CHANGED`` (i.e., when the data array values 
+        Connected to ``points_layer.events.data``. Fires on
+        ``ActionType.CHANGED`` (i.e., when the data array values
         change) and sets the confidence score of moved points to NaN.
         """
         layer = event.source

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -357,15 +357,15 @@ class DataLoader(QWidget):
         since moved points no longer have a valid confidence score.
         """
         layer = event.source
+        if not isinstance(layer, Points):
+            return
         if event.action != ActionType.CHANGED:
             return
         moved_indices = list(event.data_indices)
-        feats = layer.features
-        feats.loc[moved_indices, "confidence"] = float("nan")
-        layer.features = feats
-
-        full_indices = np.where(self.data_not_nan)[0][moved_indices]
-        self.properties.loc[full_indices, "confidence"] = np.nan
+        props = layer.properties
+        props["confidence"] = props["confidence"].copy()
+        props["confidence"][moved_indices] = float("nan")
+        layer.properties = props
 
     def _add_tracks_layer(self):
         """Add the tracked data to the viewer as a Tracks layer."""

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -305,7 +305,12 @@ def test_valid_poses_roundtrip_napari_layer_to_dataset(ds_dataset, request):
         napari_points, properties, properties_with_nan, attrs=ds.attrs
     )
 
-    xr.testing.assert_equal(reconstructed_ds, ds)
+    # Missing points (NaN position) are not visible in napari, so their
+    # confidence cannot be preserved — expect NaN for those.
+    position_is_nan = ds["position"].isnull().all("space")
+    expected_ds = ds.copy(deep=True)
+    expected_ds["confidence"] = ds["confidence"].where(~position_is_nan)
+    xr.testing.assert_equal(reconstructed_ds, expected_ds)
 
 
 @pytest.mark.parametrize(
@@ -355,8 +360,14 @@ def test_napari_layers_to_ds(
         attrs=ds_expected.attrs,
     )
 
-    # Assert that the input dataset and the converted one are equal
-    xr.testing.assert_equal(ds, ds_expected)
+    # Missing points (NaN position) are not visible in napari, so their
+    # confidence cannot be preserved — expect NaN for those.
+    position_is_nan = ds_expected["position"].isnull().all("space")
+    expected_ds = ds_expected.copy(deep=True)
+    expected_ds["confidence"] = ds_expected["confidence"].where(
+        ~position_is_nan
+    )
+    xr.testing.assert_equal(ds, expected_ds)
 
 
 def test_napari_layers_to_ds_bboxes_not_implemented():
@@ -372,14 +383,25 @@ def test_napari_layers_to_ds_bboxes_not_implemented():
         )
 
 
+@pytest.mark.parametrize(
+    "action_type",
+    [
+        ActionType.ADDED,
+        ActionType.REMOVED,
+        ActionType.ADDING,
+        ActionType.REMOVING,
+        ActionType.CHANGING,
+    ],
+)
 def test_on_points_data_changed_ignores_non_move_events(
-    valid_poses_path_and_ds, loaded_data_loader
+    action_type, valid_poses_path_and_ds, loaded_data_loader
 ):
-    """Test that the callback does nothing for add/remove events.
+    """Test that the callback leaves confidence untouched for non-drag events.
 
     Verifies that :meth:`DataLoader._on_points_data_changed` only acts on
-    ``ActionType.CHANGED`` (drag) and leaves confidence untouched for any
-    other action type.
+    ``ActionType.CHANGED`` (completed drag) and ignores all other action types,
+    including ``ADDING``, ``ADDED``, ``REMOVING``, ``REMOVED``, and
+    ``CHANGING`` (in-progress drag).
     """
     filepath, ds_expected = valid_poses_path_and_ds
     loader = loaded_data_loader(filepath, ds_expected)
@@ -388,7 +410,7 @@ def test_on_points_data_changed_ignores_non_move_events(
 
     mock_event = Mock()
     mock_event.source = loader.points_layer
-    mock_event.action = ActionType.ADDED
+    mock_event.action = action_type
 
     loader._on_points_data_changed(mock_event)
 
@@ -473,6 +495,12 @@ def test_edited_pose_napari_layers(
         attrs=ds_expected.attrs,
     )
     expected_ds = ds_expected.copy(deep=True)
+    # NaN-position points are hidden in napari, so their confidence can't be
+    # preserved — the reconstructed dataset will have NaN confidence for them.
+    position_is_nan = ds_expected["position"].isnull().all("space")
+    expected_ds["confidence"] = expected_ds["confidence"].where(
+        ~position_is_nan
+    )
     expected_ds.position.loc[
         {
             "time": frame,

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -309,7 +309,9 @@ def test_valid_poses_roundtrip_napari_layer_to_dataset(ds_dataset, request):
     # confidence cannot be preserved — expect NaN for those.
     position_is_nan = ds["position"].isnull().all("space")
     expected_ds = ds.copy(deep=True)
-    expected_ds["confidence"] = ds["confidence"].where(~position_is_nan) # where condition is False, sets value to NaN
+    expected_ds["confidence"] = ds["confidence"].where(
+        ~position_is_nan
+    )  # where condition is False, sets value to NaN
     xr.testing.assert_equal(reconstructed_ds, expected_ds)
 
 

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -372,6 +372,32 @@ def test_napari_layers_to_ds_bboxes_not_implemented():
         )
 
 
+def test_on_points_data_changed_ignores_non_move_events(
+    valid_poses_path_and_ds, loaded_data_loader
+):
+    """Test that the callback does nothing for add/remove events.
+
+    Verifies that :meth:`DataLoader._on_points_data_changed` only acts on
+    ``ActionType.CHANGED`` (drag) and leaves confidence untouched for any
+    other action type.
+    """
+    filepath, ds_expected = valid_poses_path_and_ds
+    loader = loaded_data_loader(filepath, ds_expected)
+
+    original_confidence = loader.points_layer.features["confidence"].copy()
+
+    mock_event = Mock()
+    mock_event.source = loader.points_layer
+    mock_event.action = ActionType.ADDED
+
+    loader._on_points_data_changed(mock_event)
+
+    pd.testing.assert_series_equal(
+        loader.points_layer.features["confidence"],
+        original_confidence,
+    )
+
+
 @pytest.mark.parametrize(
     "nan_location",
     [

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -404,7 +404,7 @@ def test_on_points_data_changed_ignores_tracks_layer(
     original_tracks_confidence = tracks_layer.properties["confidence"].copy()
 
     mock_event = Mock()
-    mock_event.source = tracks_layer 
+    mock_event.source = tracks_layer
     mock_event.action = ActionType.CHANGED
     # assumes index 0's confidence is non-NaN in the fixture;
     # this is true for valid_poses_path_and_ds which has all

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -271,7 +271,7 @@ def test_invalid_poses_to_napari_layers(ds_name, expected_exception, request):
 # -------------------- Valid napari layers test --------------------
 
 
-def _set_confidence_to_nan(ds):
+def _nan_confidence_at_nan_pos(ds):
     """Return the dataset expected after a napari layer round-trip.
 
     Points with a NaN position are hidden in napari, so their confidence
@@ -280,7 +280,12 @@ def _set_confidence_to_nan(ds):
     """
     position_is_nan = ds["position"].isnull().all("space")
     expected_ds = ds.copy(deep=True)
-    expected_ds["confidence"] = ds["confidence"].where(~position_is_nan)
+    expected_ds["confidence"] = xr.where(
+        position_is_nan,
+        np.nan,
+        expected_ds["confidence"],
+    )
+
     return expected_ds
 
 
@@ -318,7 +323,10 @@ def test_valid_poses_roundtrip_napari_layer_to_dataset(ds_dataset, request):
         napari_points, properties, properties_with_nan, attrs=ds.attrs
     )
 
-    xr.testing.assert_equal(reconstructed_ds, _set_confidence_to_nan(ds))
+    xr.testing.assert_equal(
+        reconstructed_ds,
+        _nan_confidence_at_nan_pos(ds),
+    )
 
 
 @pytest.mark.parametrize(
@@ -368,7 +376,7 @@ def test_napari_layers_to_ds(
         attrs=ds_loaded.attrs,
     )
 
-    xr.testing.assert_equal(ds, _set_confidence_to_nan(ds_loaded))
+    xr.testing.assert_equal(ds, _nan_confidence_at_nan_pos(ds_loaded))
 
 
 def test_napari_layers_to_ds_bboxes_not_implemented():
@@ -458,7 +466,11 @@ def test_edited_pose_napari_layers(
         properties_with_nans=loader.properties,
         attrs=ds_loaded.attrs,
     )
-    expected_ds = _set_confidence_to_nan(ds_loaded)
+
+    # after loading in napari and exporting:
+    # confidence is nan where position is nan
+    expected_ds = _nan_confidence_at_nan_pos(ds_loaded)
+    # edited point values
     expected_ds.position.loc[
         {
             "time": frame,

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-from napari.layers.base._base_constants import ActionType
+from napari.layers.base import ActionType
 from pandas.testing import assert_frame_equal
 
 from movement.napari.convert import ds_to_napari_layers, napari_layers_to_ds

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -421,15 +421,9 @@ def test_edited_pose_napari_layers(
         & (loader.points_layer.properties["keypoint"] == keypoint)
         & (loader.points_layer.properties["individual"] == individual)
     )
-    conf_mask = (
-        (loader.properties["time"] == frame)
-        & (loader.properties["keypoint"] == keypoint)
-        & (loader.properties["individual"] == individual)
-    )
     # we need two masks because they are applied to different sized-objects
     loader.points_layer.data[edit_mask, 1] = 100  # y
     loader.points_layer.data[edit_mask, 2] = 200  # x
-    loader.properties.loc[conf_mask, "confidence"] = 1.0
 
     ds = napari_layers_to_ds(
         points_as_napari=loader.points_layer.data,

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -385,30 +385,37 @@ def test_napari_layers_to_ds_bboxes_not_implemented():
         )
 
 
-def test_on_points_data_changed_ignores_non_points_source(
+def test_on_points_data_changed_ignores_tracks_layer(
     valid_poses_path_and_ds, loaded_data_loader
 ):
-    """Test that the callback does nothing when the event source is
-    not a Points layer.
+    """Test that the callback does not modify a layer's properties
+    when the data change occurs on a non-Points layer.
 
-    Verifies that :meth:`DataLoader._on_points_data_changed` returns early
-    without modifying confidence when ``event.source`` is not a
-    :class:`napari.layers.Points` instance.
+    Verifies that `DataLoader._on_points_data_changed` returns early
+    without modifying confidence when `event.source` is not a
+    `napari.layers.Points` instance.
     """
     filepath, ds_expected = valid_poses_path_and_ds
     loader = loaded_data_loader(filepath, ds_expected)
 
-    original_confidence = loader.points_layer.features["confidence"].copy()
+    tracks_layer = next(
+        layer for layer in loader.viewer.layers if isinstance(layer, Tracks)
+    )
+    original_tracks_confidence = tracks_layer.properties["confidence"].copy()
 
     mock_event = Mock()
-    mock_event.source = Mock()  # not a Points layer
+    mock_event.source = tracks_layer 
     mock_event.action = ActionType.CHANGED
+    # assumes index 0's confidence is non-NaN in the fixture;
+    # this is true for valid_poses_path_and_ds which has all
+    # confidence values non-nan
+    mock_event.data_indices = (0,)
 
     loader._on_points_data_changed(mock_event)
 
-    pd.testing.assert_series_equal(
-        loader.points_layer.features["confidence"],
-        original_confidence,
+    np.testing.assert_array_equal(
+        tracks_layer.properties["confidence"],
+        original_tracks_confidence,
     )
 
 

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -271,6 +271,19 @@ def test_invalid_poses_to_napari_layers(ds_name, expected_exception, request):
 # -------------------- Valid napari layers test --------------------
 
 
+def _set_confidence_to_nan(ds):
+    """Return the dataset expected after a napari layer round-trip.
+
+    Points with a NaN position are hidden in napari, so their confidence
+    cannot be preserved — the reconstructed dataset has NaN confidence for
+    those points.
+    """
+    position_is_nan = ds["position"].isnull().all("space")
+    expected_ds = ds.copy(deep=True)
+    expected_ds["confidence"] = ds["confidence"].where(~position_is_nan)
+    return expected_ds
+
+
 @pytest.mark.parametrize(
     "ds_dataset",
     [
@@ -305,14 +318,7 @@ def test_valid_poses_roundtrip_napari_layer_to_dataset(ds_dataset, request):
         napari_points, properties, properties_with_nan, attrs=ds.attrs
     )
 
-    # Missing points (NaN position) are not visible in napari, so their
-    # confidence cannot be preserved — expect NaN for those.
-    position_is_nan = ds["position"].isnull().all("space")
-    expected_ds = ds.copy(deep=True)
-    expected_ds["confidence"] = ds["confidence"].where(
-        ~position_is_nan
-    )  # where condition is False, sets value to NaN
-    xr.testing.assert_equal(reconstructed_ds, expected_ds)
+    xr.testing.assert_equal(reconstructed_ds, _set_confidence_to_nan(ds))
 
 
 @pytest.mark.parametrize(
@@ -362,12 +368,7 @@ def test_napari_layers_to_ds(
         attrs=ds_loaded.attrs,
     )
 
-    # Missing points (NaN position) are not visible in napari, so their
-    # confidence cannot be preserved — expect NaN for those.
-    position_is_nan = ds_loaded["position"].isnull().all("space")
-    expected_ds = ds_loaded.copy(deep=True)
-    expected_ds["confidence"] = ds_loaded["confidence"].where(~position_is_nan)
-    xr.testing.assert_equal(ds, expected_ds)
+    xr.testing.assert_equal(ds, _set_confidence_to_nan(ds_loaded))
 
 
 def test_napari_layers_to_ds_bboxes_not_implemented():
@@ -381,77 +382,6 @@ def test_napari_layers_to_ds_bboxes_not_implemented():
             properties={"individual": np.array([])},
             properties_with_nans=pd.DataFrame(),
         )
-
-
-def test_on_points_data_changed_ignores_tracks_layer(
-    valid_poses_path_and_ds, loaded_data_loader
-):
-    """Test that the callback does not modify a layer's properties
-    when the data change occurs on a non-Points layer.
-
-    Verifies that `DataLoader._on_points_data_changed` returns early
-    without modifying confidence when `event.source` is not a
-    `napari.layers.Points` instance.
-    """
-    filepath, ds_loaded = valid_poses_path_and_ds
-    loader = loaded_data_loader(filepath, ds_loaded)
-
-    tracks_layer = next(
-        layer for layer in loader.viewer.layers if isinstance(layer, Tracks)
-    )
-    original_tracks_confidence = tracks_layer.properties["confidence"].copy()
-
-    mock_event = Mock()
-    mock_event.source = tracks_layer
-    mock_event.action = ActionType.CHANGED
-    # assumes index 0's confidence is non-NaN in the fixture;
-    # this is true for valid_poses_path_and_ds which has all
-    # confidence values non-nan
-    mock_event.data_indices = (0,)
-
-    loader._on_points_data_changed(mock_event)
-
-    np.testing.assert_array_equal(
-        tracks_layer.properties["confidence"],
-        original_tracks_confidence,
-    )
-
-
-@pytest.mark.parametrize(
-    "action_type",
-    [
-        ActionType.ADDED,
-        ActionType.REMOVED,
-        ActionType.ADDING,
-        ActionType.REMOVING,
-        ActionType.CHANGING,
-    ],
-)
-def test_on_points_data_changed_ignores_non_move_events(
-    action_type, valid_poses_path_and_ds, loaded_data_loader
-):
-    """Test that the callback leaves confidence untouched for non-drag events.
-
-    Verifies that :meth:`DataLoader._on_points_data_changed` only acts on
-    ``ActionType.CHANGED`` (completed drag) and ignores all other action types,
-    including ``ADDING``, ``ADDED``, ``REMOVING``, ``REMOVED``, and
-    ``CHANGING`` (in-progress drag).
-    """
-    filepath, ds_loaded = valid_poses_path_and_ds
-    loader = loaded_data_loader(filepath, ds_loaded)
-
-    original_confidence = loader.points_layer.features["confidence"].copy()
-
-    mock_event = Mock()
-    mock_event.source = loader.points_layer
-    mock_event.action = action_type
-mock_event.data_indices = (0,)
-    loader._on_points_data_changed(mock_event)
-
-    pd.testing.assert_series_equal(
-        loader.points_layer.features["confidence"],
-        original_confidence,
-    )
 
 
 @pytest.mark.parametrize(
@@ -528,13 +458,7 @@ def test_edited_pose_napari_layers(
         properties_with_nans=loader.properties,
         attrs=ds_loaded.attrs,
     )
-    expected_ds = ds_loaded.copy(deep=True)
-    # NaN-position points are hidden in napari, so their confidence can't be
-    # preserved — the reconstructed dataset will have NaN confidence for them.
-    position_is_nan = ds_loaded["position"].isnull().all("space")
-    expected_ds["confidence"] = expected_ds["confidence"].where(
-        ~position_is_nan
-    )
+    expected_ds = _set_confidence_to_nan(ds_loaded)
     expected_ds.position.loc[
         {
             "time": frame,

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -1,9 +1,12 @@
 """Test suite for the movement.napari.convert module."""
 
+from unittest.mock import Mock
+
 import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
+from napari.layers.base._base_constants import ActionType
 from pandas.testing import assert_frame_equal
 
 from movement.napari.convert import ds_to_napari_layers, napari_layers_to_ds
@@ -396,14 +399,13 @@ def test_edited_pose_napari_layers(
     valid_poses_path_and_ds_with_localised_nans,
     loaded_data_loader,
 ):
-    """Test that edits to the napari Points layer are preserved on conversion.
+    """Test that :func:`napari_layers_to_ds` correctly converts edited layers,
+    and sets the new confidence value to ``NaN`` after the edit.
 
-    Simulates a user editing the x, y coordinates of a specific keypoint
-    (``centroid`` of ``id_0`` at frame 2) in the napari Points layer, and
-    setting its confidence score to 1.0 in the properties DataFrame.
-    Verifies that :func:`napari_layers_to_ds` reconstructs a dataset that
-    reflects both edits. The test is parametrized over datasets with and
-    without NaN position values to ensure robustness.
+    Simulates a user dragging the ``centroid`` of ``id_0`` at frame 2 to new
+    ``x``, ``y`` coordinates. Verifies that :func:`napari_layers_to_ds`
+    reconstructs a dataset where the edited point has the new position and
+    ``NaN`` confidence.
     """
     if nan_location is None:
         filepath, ds_expected = valid_poses_path_and_ds
@@ -416,14 +418,27 @@ def test_edited_pose_napari_layers(
     frame = 2  # safe: not NaN in any parametrize case
     keypoint = "centroid"
     individual = "id_0"
-    edit_mask = (
-        (loader.points_layer.properties["time"] == frame)
-        & (loader.points_layer.properties["keypoint"] == keypoint)
-        & (loader.points_layer.properties["individual"] == individual)
+
+    # Find the integer index of the point to edit in the live points layer
+    live_props = loader.points_layer.properties
+    edit_idx = int(
+        np.flatnonzero(
+            (live_props["time"] == frame)
+            & (live_props["keypoint"] == keypoint)
+            & (live_props["individual"] == individual)
+        )[0]
     )
-    # we need two masks because they are applied to different sized-objects
-    loader.points_layer.data[edit_mask, 1] = 100  # y
-    loader.points_layer.data[edit_mask, 2] = 200  # x
+
+    loader.points_layer.data[edit_idx, 1] = 100  # y
+    loader.points_layer.data[edit_idx, 2] = 200  # x
+
+    # Direct mutation does not fire napari events, so we call the callback
+    # manually below with the correct index to replicate what napari does.
+    mock_event = Mock()
+    mock_event.source = loader.points_layer
+    mock_event.action = ActionType.CHANGED
+    mock_event.data_indices = (edit_idx,)
+    loader._on_points_data_changed(mock_event)
 
     ds = napari_layers_to_ds(
         points_as_napari=loader.points_layer.data,
@@ -446,5 +461,5 @@ def test_edited_pose_napari_layers(
             "keypoint": keypoint,
             "individual": individual,
         }
-    ] = 1.0
+    ] = np.nan
     xr.testing.assert_equal(ds, expected_ds)

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -345,30 +345,28 @@ def test_napari_layers_to_ds(
 ):
     # Get sample data filepath and dataset
     if nan_location is None:
-        filepath, ds_expected = valid_poses_path_and_ds
+        filepath, ds_loaded = valid_poses_path_and_ds
     else:
-        filepath, ds_expected = valid_poses_path_and_ds_with_localised_nans(
+        filepath, ds_loaded = valid_poses_path_and_ds_with_localised_nans(
             nan_location
         )
 
     # Get loader widget with sample data loaded
-    loader = loaded_data_loader(filepath, ds_expected)
+    loader = loaded_data_loader(filepath, ds_loaded)
 
     # Convert data in napari point layer to a movement dataset
     ds = napari_layers_to_ds(
         points_as_napari=loader.points_layer.data,
         properties=loader.points_layer.properties,  # dict
         properties_with_nans=loader.properties,
-        attrs=ds_expected.attrs,
+        attrs=ds_loaded.attrs,
     )
 
     # Missing points (NaN position) are not visible in napari, so their
     # confidence cannot be preserved — expect NaN for those.
-    position_is_nan = ds_expected["position"].isnull().all("space")
-    expected_ds = ds_expected.copy(deep=True)
-    expected_ds["confidence"] = ds_expected["confidence"].where(
-        ~position_is_nan
-    )
+    position_is_nan = ds_loaded["position"].isnull().all("space")
+    expected_ds = ds_loaded.copy(deep=True)
+    expected_ds["confidence"] = ds_loaded["confidence"].where(~position_is_nan)
     xr.testing.assert_equal(ds, expected_ds)
 
 
@@ -395,8 +393,8 @@ def test_on_points_data_changed_ignores_tracks_layer(
     without modifying confidence when `event.source` is not a
     `napari.layers.Points` instance.
     """
-    filepath, ds_expected = valid_poses_path_and_ds
-    loader = loaded_data_loader(filepath, ds_expected)
+    filepath, ds_loaded = valid_poses_path_and_ds
+    loader = loaded_data_loader(filepath, ds_loaded)
 
     tracks_layer = next(
         layer for layer in loader.viewer.layers if isinstance(layer, Tracks)
@@ -439,8 +437,8 @@ def test_on_points_data_changed_ignores_non_move_events(
     including ``ADDING``, ``ADDED``, ``REMOVING``, ``REMOVED``, and
     ``CHANGING`` (in-progress drag).
     """
-    filepath, ds_expected = valid_poses_path_and_ds
-    loader = loaded_data_loader(filepath, ds_expected)
+    filepath, ds_loaded = valid_poses_path_and_ds
+    loader = loaded_data_loader(filepath, ds_loaded)
 
     original_confidence = loader.points_layer.features["confidence"].copy()
 
@@ -492,12 +490,12 @@ def test_edited_pose_napari_layers(
     ``NaN`` confidence.
     """
     if nan_location is None:
-        filepath, ds_expected = valid_poses_path_and_ds
+        filepath, ds_loaded = valid_poses_path_and_ds
     else:
-        filepath, ds_expected = valid_poses_path_and_ds_with_localised_nans(
+        filepath, ds_loaded = valid_poses_path_and_ds_with_localised_nans(
             nan_location
         )
-    loader = loaded_data_loader(filepath, ds_expected)
+    loader = loaded_data_loader(filepath, ds_loaded)
 
     frame = 2  # safe: not NaN in any parametrize case
     keypoint = "centroid"
@@ -528,12 +526,12 @@ def test_edited_pose_napari_layers(
         points_as_napari=loader.points_layer.data,
         properties=loader.points_layer.properties,
         properties_with_nans=loader.properties,
-        attrs=ds_expected.attrs,
+        attrs=ds_loaded.attrs,
     )
-    expected_ds = ds_expected.copy(deep=True)
+    expected_ds = ds_loaded.copy(deep=True)
     # NaN-position points are hidden in napari, so their confidence can't be
     # preserved — the reconstructed dataset will have NaN confidence for them.
-    position_is_nan = ds_expected["position"].isnull().all("space")
+    position_is_nan = ds_loaded["position"].isnull().all("space")
     expected_ds["confidence"] = expected_ds["confidence"].where(
         ~position_is_nan
     )

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -309,7 +309,7 @@ def test_valid_poses_roundtrip_napari_layer_to_dataset(ds_dataset, request):
     # confidence cannot be preserved — expect NaN for those.
     position_is_nan = ds["position"].isnull().all("space")
     expected_ds = ds.copy(deep=True)
-    expected_ds["confidence"] = ds["confidence"].where(~position_is_nan)
+    expected_ds["confidence"] = ds["confidence"].where(~position_is_nan) # where condition is False, sets value to NaN
     xr.testing.assert_equal(reconstructed_ds, expected_ds)
 
 

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -383,6 +383,33 @@ def test_napari_layers_to_ds_bboxes_not_implemented():
         )
 
 
+def test_on_points_data_changed_ignores_non_points_source(
+    valid_poses_path_and_ds, loaded_data_loader
+):
+    """Test that the callback does nothing when the event source is
+    not a Points layer.
+
+    Verifies that :meth:`DataLoader._on_points_data_changed` returns early
+    without modifying confidence when ``event.source`` is not a
+    :class:`napari.layers.Points` instance.
+    """
+    filepath, ds_expected = valid_poses_path_and_ds
+    loader = loaded_data_loader(filepath, ds_expected)
+
+    original_confidence = loader.points_layer.features["confidence"].copy()
+
+    mock_event = Mock()
+    mock_event.source = Mock()  # not a Points layer
+    mock_event.action = ActionType.CHANGED
+
+    loader._on_points_data_changed(mock_event)
+
+    pd.testing.assert_series_equal(
+        loader.points_layer.features["confidence"],
+        original_confidence,
+    )
+
+
 @pytest.mark.parametrize(
     "action_type",
     [

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -447,7 +447,7 @@ def test_on_points_data_changed_ignores_non_move_events(
     mock_event = Mock()
     mock_event.source = loader.points_layer
     mock_event.action = action_type
-
+mock_event.data_indices = (0,)
     loader._on_points_data_changed(mock_event)
 
     pd.testing.assert_series_equal(

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -367,3 +367,90 @@ def test_napari_layers_to_ds_bboxes_not_implemented():
             properties={"individual": np.array([])},
             properties_with_nans=pd.DataFrame(),
         )
+
+
+@pytest.mark.parametrize(
+    "nan_location",
+    [
+        None,
+        {
+            "time": "start",
+            "individual": ["id_0", "id_1"],
+            "keypoint": ["centroid", "left", "right"],
+        },
+        {
+            "time": "end",
+            "individual": ["id_0", "id_1"],
+            "keypoint": ["centroid", "left", "right"],
+        },
+        {
+            "time": "middle",
+            "individual": ["id_0"],
+            "keypoint": ["centroid"],
+        },
+    ],
+)
+def test_edited_pose_napari_layers(
+    nan_location,
+    valid_poses_path_and_ds,
+    valid_poses_path_and_ds_with_localised_nans,
+    loaded_data_loader,
+):
+    """Test that edits to the napari Points layer are preserved on conversion.
+
+    Simulates a user editing the x, y coordinates of a specific keypoint
+    (``centroid`` of ``id_0`` at frame 2) in the napari Points layer, and
+    setting its confidence score to 1.0 in the properties DataFrame.
+    Verifies that :func:`napari_layers_to_ds` reconstructs a dataset that
+    reflects both edits. The test is parametrized over datasets with and
+    without NaN position values to ensure robustness.
+    """
+    if nan_location is None:
+        filepath, ds_expected = valid_poses_path_and_ds
+    else:
+        filepath, ds_expected = valid_poses_path_and_ds_with_localised_nans(
+            nan_location
+        )
+    loader = loaded_data_loader(filepath, ds_expected)
+
+    frame = 2  # safe: not NaN in any parametrize case
+    keypoint = "centroid"
+    individual = "id_0"
+    edit_mask = (
+        (loader.points_layer.properties["time"] == frame)
+        & (loader.points_layer.properties["keypoint"] == keypoint)
+        & (loader.points_layer.properties["individual"] == individual)
+    )
+    conf_mask = (
+        (loader.properties["time"] == frame)
+        & (loader.properties["keypoint"] == keypoint)
+        & (loader.properties["individual"] == individual)
+    )
+    # we need two masks because they are applied to different sized-objects
+    loader.points_layer.data[edit_mask, 1] = 100  # y
+    loader.points_layer.data[edit_mask, 2] = 200  # x
+    loader.properties.loc[conf_mask, "confidence"] = 1.0
+
+    ds = napari_layers_to_ds(
+        points_as_napari=loader.points_layer.data,
+        properties=loader.points_layer.properties,
+        properties_with_nans=loader.properties,
+        attrs=ds_expected.attrs,
+    )
+    expected_ds = ds_expected.copy(deep=True)
+    expected_ds.position.loc[
+        {
+            "time": frame,
+            "space": ["x", "y"],
+            "keypoint": keypoint,
+            "individual": individual,
+        }
+    ] = [200, 100]
+    expected_ds["confidence"].loc[
+        {
+            "time": frame,
+            "keypoint": keypoint,
+            "individual": individual,
+        }
+    ] = 1.0
+    xr.testing.assert_equal(ds, expected_ds)

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -7,8 +7,10 @@ instantiated (the methods would have already been connected to signals).
 
 from contextlib import nullcontext as does_not_raise
 from pathlib import Path
+from unittest.mock import Mock
 
 import numpy as np
+import pandas as pd
 import pytest
 from napari.components.dims import RangeTuple
 from napari.layers import (
@@ -20,6 +22,7 @@ from napari.layers import (
     Tracks,
     Vectors,
 )
+from napari.layers.base import ActionType
 from napari.settings import get_settings
 from napari.utils.events import EmitterGroup
 from pytest import DATA_PATHS
@@ -940,3 +943,67 @@ def test_add_points_and_tracks_layer_style(
         np.testing.assert_allclose(
             bboxes_layer_colormap_sorted, text_colormap_sorted, atol=1e-7
         )
+
+
+def test_on_points_data_changed_ignores_non_points_source(
+    valid_poses_path_and_ds, loaded_data_loader
+):
+    """Test that the callback does nothing when the event source is
+    not a Points layer.
+
+    Verifies that :meth:`DataLoader._on_points_data_changed` returns early
+    without modifying confidence when ``event.source`` is not a
+    :class:`napari.layers.Points` instance.
+    """
+    filepath, ds_loaded = valid_poses_path_and_ds
+    loader = loaded_data_loader(filepath, ds_loaded)
+
+    original_confidence = loader.points_layer.features["confidence"].copy()
+
+    mock_event = Mock()
+    mock_event.source = Mock()  # not a Points layer
+    mock_event.action = ActionType.CHANGED
+
+    loader._on_points_data_changed(mock_event)
+
+    pd.testing.assert_series_equal(
+        loader.points_layer.features["confidence"],
+        original_confidence,
+    )
+
+
+@pytest.mark.parametrize(
+    "action_type",
+    [
+        ActionType.ADDED,
+        ActionType.REMOVED,
+        ActionType.ADDING,
+        ActionType.REMOVING,
+        ActionType.CHANGING,
+    ],
+)
+def test_on_points_data_changed_ignores_non_move_events(
+    action_type, valid_poses_path_and_ds, loaded_data_loader
+):
+    """Test that the callback leaves confidence untouched for non-drag events.
+
+    Verifies that :meth:`DataLoader._on_points_data_changed` only acts on
+    ``ActionType.CHANGED`` (completed drag) and ignores all other action types,
+    including ``ADDING``, ``ADDED``, ``REMOVING``, ``REMOVED``, and
+    ``CHANGING`` (in-progress drag).
+    """
+    filepath, ds_loaded = valid_poses_path_and_ds
+    loader = loaded_data_loader(filepath, ds_loaded)
+
+    original_confidence = loader.points_layer.features["confidence"].copy()
+
+    mock_event = Mock()
+    mock_event.source = loader.points_layer
+    mock_event.action = action_type
+
+    loader._on_points_data_changed(mock_event)
+
+    pd.testing.assert_series_equal(
+        loader.points_layer.features["confidence"],
+        original_confidence,
+    )

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -945,30 +945,40 @@ def test_add_points_and_tracks_layer_style(
         )
 
 
-def test_on_points_data_changed_ignores_non_points_source(
+def test_on_points_data_changed_ignores_tracks_layer(
     valid_poses_path_and_ds, loaded_data_loader
 ):
-    """Test that the callback does nothing when the event source is
-    not a Points layer.
+    """Test that the callback does not modify a layer's properties
+    when the data change occurs on a non-Points layer.
 
-    Verifies that :meth:`DataLoader._on_points_data_changed` returns early
-    without modifying confidence when ``event.source`` is not a
-    :class:`napari.layers.Points` instance.
+    Verifies that `DataLoader._on_points_data_changed` returns early
+    without modifying confidence when `event.source` is not a
+    `napari.layers.Points` instance.
     """
-    filepath, ds_loaded = valid_poses_path_and_ds
-    loader = loaded_data_loader(filepath, ds_loaded)
+    filepath, ds = valid_poses_path_and_ds
+    loader = loaded_data_loader(filepath, ds)
 
-    original_confidence = loader.points_layer.features["confidence"].copy()
+    # Get tracks layer data and confidence
+    tracks_layer = next(
+        layer for layer in loader.viewer.layers if isinstance(layer, Tracks)
+    )
+    original_tracks_confidence = tracks_layer.properties["confidence"].copy()
 
+    # Mock a change in the tracks layer;
+    # assumes index 0's confidence is non-NaN in the fixture;
+    # this is true for valid_poses_path_and_ds which has all
+    # confidence values non-nan
     mock_event = Mock()
-    mock_event.source = Mock()  # not a Points layer
+    mock_event.source = tracks_layer
     mock_event.action = ActionType.CHANGED
+    mock_event.data_indices = (0,)
 
     loader._on_points_data_changed(mock_event)
 
-    pd.testing.assert_series_equal(
-        loader.points_layer.features["confidence"],
-        original_confidence,
+    # Check tracks layer properties are unchanged
+    np.testing.assert_array_equal(
+        tracks_layer.properties["confidence"],
+        original_tracks_confidence,
     )
 
 
@@ -1000,6 +1010,7 @@ def test_on_points_data_changed_ignores_non_move_events(
     mock_event = Mock()
     mock_event.source = loader.points_layer
     mock_event.action = action_type
+    mock_event.data_indices = (0,)
 
     loader._on_points_data_changed(mock_event)
 


### PR DESCRIPTION
## Description

This PR adds a unit test verifying that edits made to pose data in napari Point layer are correctly preserved when converting back to ``movement`` dataset using ``napari_layers_to_ds()``.

The test simulates editing coordinates of one visible point (no ``NaN``) in the napari Points layer and updating its confidence value in the associated properties. It then reconstructs the dataset and checks that both edits are present in the output from ``napari_layers_to_ds()``. 

A key detail is that the test uses two boolean masks that express the same logical selection: the ``centroid`` keypoint, of ``id_0`` at frame ``2``. These masks are defined separately because they are applied to different objects. ``loader.points_layer.properties`` corresponds to the filtered napari Points layer, and excludes rows with ``NaN``. While ``loader.properties`` keeps the full original set of rows, including ``NaN`` positions. So these objects have different lengths, so we cannot really use the same mask here. From what I understand. Give me your opinion on this. We need to use ``loader.properties`` (with NaN) because ``napari_layers_to_ds`` reads confidence from ``properties_with_nans``. Modifying ``loader.points_layer.properties["confidence"]`` would have no effect on the reconstruction dataset. 

Although the mask is "duplicated", this can ensure that the test reflects the actual ``DataLoader`` widget behavior. 

Alternatively, we could also consider factoring the repeated condition into a small helper. Something like this: 
```python
def _at(props):
    return (
        (props["time"] == frame)
        & (props["keypoint"] == keypoint)
        & (props["individual"] == individual)
    )
```
And then calling: 
```python
loader.points_layer.data[_at(loader.points_layer.properties), 1] = 100
loader.points_layer.data[_at(loader.points_layer.properties), 2] = 200
loader.properties.loc[_at(loader.properties), "confidence"] = 1.0
```
I think this would reduce the repetition, but need to test this locally. 

What are your thoughts about this? 

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
``napari_layers_to_ds()`` converts napari Point layers back to ``movement`` xarrays. But the ultimate goal of #993 is to be able to edit the trajectories and save them back from napari to ``movement``. Thus this function not only needs to be able to reconstruct the original structure, but also incorporate some edits. 


**What does this PR do?**

We add a simple unit test that simulates user editing point coordinates in napari Point layer and then converts this edit to a ``movement`` ds using ``napari_layers_to_ds()``. 

As we have discussed, the confidence values in properties are set to 1.0 after an edit. This is important because if we edit a point with a low-confidence value, and the confidence is not reassigned, it would be filtered out in subsequent workflows (e.g. interpolate low-confidence predictions). But, since it's going to be manually edited, we expect it to be correct. 

This is something we need to further discuss, but for this test I simply reassigned the confidence to 1.0. 

The test verifies that both the position and confidence edits are present in the reconstructed dataset and that ``napari_layers_to_ds()`` is correctly saving the expected outputs after the edit. 

## References

This is part of 
- #1008 
- follow up to #1011

Related to #993 

## How has this PR been tested?

The new test has been added to the unit test suit and passes locally. 

## Is this a breaking change?

No. 

## Does this PR require an update to the documentation?

No. 

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)

