### PR TITLE
Reconstruction of removed napari pose predictions back to movement ds

### DIFF
--- a/movement/napari/convert.py
+++ b/movement/napari/convert.py
@@ -4,6 +4,8 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from movement.utils.logging import logger
+
 
 def _construct_properties_dataframe(ds: xr.Dataset) -> pd.DataFrame:
     """Construct a properties DataFrame from a ``movement`` dataset."""
@@ -189,6 +191,9 @@ def napari_layers_to_ds(
 
     Raises
     ------
+    ValueError
+        If ``points_as_napari`` is empty, i.e. all points have been
+        removed from the dataset.
     NotImplementedError
         If the napari Points layer data does not represent a pose dataset.
 
@@ -223,6 +228,14 @@ def napari_layers_to_ds(
     using the full coordinate structure from ``properties_with_nans``
 
     """
+    if len(points_as_napari) == 0:
+        raise logger.error(
+            ValueError(
+                "No points found in the napari layer. "
+                "This happens when all points have been removed."
+            )
+        )
+
     properties_df = pd.DataFrame.from_dict(
         properties
     )  # live data without nans

--- a/movement/napari/convert.py
+++ b/movement/napari/convert.py
@@ -227,11 +227,11 @@ def napari_layers_to_ds(
     This function reconstructs the full dataset by restoring missing points
     using the full coordinate structure from ``properties_with_nans``.
 
-    If all data is removed for a keypoint or individual (i.e. it is
-    NaN across every frame, individual/keypoint and space), it is
-    dropped entirely from the returned dataset rather than kept as an
-    all-NaN coordinate. This does not apply to ``time``: a frame with
-    no detections at all still remains in the timeline.
+    If a keypoint or individual has no remaining points in any frame,
+    it is dropped from the returned dataset rather than kept as an
+    all-NaN entry. The ``time`` dimension is never reduced in this
+    way: a frame from which every point has been removed is kept,
+    with NaN values for position and confidence.
 
     """
     properties_df = pd.DataFrame.from_dict(
@@ -308,11 +308,7 @@ def napari_layers_to_ds(
             },
             attrs=attrs if attrs is not None else {},
         )
-        # A keypoint/individual with all data removed (all NaN
-        # across every other dimension) is dropped entirely, rather
-        # than kept as an all-NaN coordinate. `time` is never dropped
-        # this way. A frame with no detections should still exist in
-        # the timeline.
+        # Drop keypoints/individuals with no data left; never `time`.
         ds = ds.dropna(dim="keypoint", how="all").dropna(
             dim="individual", how="all"
         )

--- a/movement/napari/convert.py
+++ b/movement/napari/convert.py
@@ -192,8 +192,8 @@ def napari_layers_to_ds(
     Raises
     ------
     ValueError
-        If ``points_as_napari`` is empty, i.e. all points have been
-        removed from the dataset.
+        If no keypoint or individual has any data left, i.e. all
+        points have been removed from the dataset.
     NotImplementedError
         If the napari Points layer data does not represent a pose dataset.
 
@@ -234,14 +234,6 @@ def napari_layers_to_ds(
     no detections at all still remains in the timeline.
 
     """
-    if len(points_as_napari) == 0:
-        raise logger.error(
-            ValueError(
-                "No points found in the napari layer. "
-                "This happens when all points have been removed."
-            )
-        )
-
     properties_df = pd.DataFrame.from_dict(
         properties
     )  # live data without nans
@@ -321,9 +313,17 @@ def napari_layers_to_ds(
         # than kept as an all-NaN coordinate. `time` is never dropped
         # this way. A frame with no detections should still exist in
         # the timeline.
-        return ds.dropna(dim="keypoint", how="all").dropna(
+        ds = ds.dropna(dim="keypoint", how="all").dropna(
             dim="individual", how="all"
         )
+        if ds.sizes["keypoint"] == 0 or ds.sizes["individual"] == 0:
+            raise logger.error(
+                ValueError(
+                    "No points found in the napari layer. "
+                    "This happens when all points have been removed."
+                )
+            )
+        return ds
 
     raise NotImplementedError(
         "Reconstruction of bounding box datasets from napari layers "

--- a/movement/napari/convert.py
+++ b/movement/napari/convert.py
@@ -225,7 +225,13 @@ def napari_layers_to_ds(
     reconstructing a dataset via :func:`napari_layers_to_ds`, the input arrays
     will have no NaN (i.e. missing) coordinates.
     This function reconstructs the full dataset by restoring missing points
-    using the full coordinate structure from ``properties_with_nans``
+    using the full coordinate structure from ``properties_with_nans``.
+
+    If all data is removed for a keypoint or individual (i.e. it is
+    NaN across every frame, individual/keypoint and space), it is
+    dropped entirely from the returned dataset rather than kept as an
+    all-NaN coordinate. This does not apply to ``time``: a frame with
+    no detections at all still remains in the timeline.
 
     """
     if len(points_as_napari) == 0:
@@ -297,7 +303,7 @@ def napari_layers_to_ds(
             )
         )
 
-        return xr.Dataset(
+        ds = xr.Dataset(
             data_vars={
                 "position": position_da,
                 "confidence": confidence_da,
@@ -309,6 +315,14 @@ def napari_layers_to_ds(
                 "individual": individual_coords,
             },
             attrs=attrs if attrs is not None else {},
+        )
+        # A keypoint/individual with all data removed (all NaN
+        # across every other dimension) is dropped entirely, rather
+        # than kept as an all-NaN coordinate. `time` is never dropped
+        # this way. A frame with no detections should still exist in
+        # the timeline.
+        return ds.dropna(dim="keypoint", how="all").dropna(
+            dim="individual", how="all"
         )
 
     raise NotImplementedError(

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -387,9 +387,9 @@ def test_napari_layers_to_ds_bboxes_not_implemented():
         match="Reconstruction of bounding box datasets",
     ):
         napari_layers_to_ds(
-            points_as_napari=np.empty((1, 3)),
-            properties={"individual": np.array(["id_0"])},
-            properties_with_nans=pd.DataFrame({"individual": ["id_0"]}),
+            points_as_napari=np.empty((0, 3)),
+            properties={"individual": np.array([])},
+            properties_with_nans=pd.DataFrame(),
         )
 
 
@@ -491,47 +491,10 @@ def test_edited_pose_napari_layers(
 
 
 def _target_points_to_remove(target, ds):
-    """Define target points to remove into a concrete coordinate value.
-
-    ``target`` is a dict with keys ``"time"``, ``"individual"`` and
-    ``"keypoint"``, each mapping to either an explicit list of
-    coordinate values to target; or the string ``"all"`` as shorthand
-    for every value along this axis. This function replaces any
-    ``"all"`` entries with the dataset's actual coordinate values (e.g.
-    ``ds.coords["individual"].values``), so that the returned dict can
-    be used directly to build a removal mask (see :func:`_remove_points`)
-    or an xarray ``.loc`` selection.
-
-    Parameters
-    ----------
-    target : dict
-        Removal target with keys ``"time"``, ``"individual"``,
-        ``"keypoint"``; each value is either a list of coordinate
-        values or ``"all"``.
-    ds : xarray.Dataset
-        Dataset to resolve ``"all"`` against, providing the full set
-        of ``time``/``individual``/``keypoint`` coordinate values.
-
-    Returns
-    -------
-    dict
-        Same keys as ``target``, with every ``"all"`` entry replaced
-        by the corresponding coordinate values from ``ds``.
-
-    Examples
-    --------
-    For a dataset with individuals ``["id_0", "id_1"]``, keypoints
-    ``["centroid", "left", "right"]`` and 10 frames (``0`` to ``9``),
-    targeting individual ``"id_0"`` for every keypoint and frame:
-
-    >>> target = {"time": "all", "individual": ["id_0"], "keypoint": "all"}
-    >>> _target_points_to_remove(target, ds)  # doctest: +SKIP
-    {
-        "time": array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
-        "individual": ["id_0"],
-        "keypoint": array(["centroid", "left", "right"]),
-    }
-
+    """Expand the ``"all"`` shorthand in a removal target into the
+    dataset's actual coordinate values for ``time``/``individual``/
+    ``keypoint``, so the result can be used to build a removal mask
+    (see :func:`_remove_points`) or an xarray ``.loc`` selection.
     """
     return {
         key: (ds.coords[key].values if target[key] == "all" else target[key])
@@ -540,37 +503,10 @@ def _target_points_to_remove(target, ds):
 
 
 def _remove_points(loader, target):
-    """Simulate napari deleting the targeted points from the live point layer.
-
-    In napari, deleting points removes the corresponding rows from both
-    the Points layer data and its properties.
-    This function selects every point whose ``time``, ``individual`` and
-    ``keypoint`` all match ``target``(as produced by
-    :func:`_target_points_to_remove`) and drops those rows from both
-    ``loader.points_layer.data`` and ``loader.points_layer.properties``,
-    returning the shrunk arrays.
-
-    Parameters
-    ----------
-    loader : movement.napari.loader_widgets.DataLoader
-        Loader widget with data already loaded, providing the live
-        ``points_layer.data`` and ``points_layer.properties`` to remove
-        points from.
-    target : dict
-        Removal target with keys ``"time"``, ``"individual"``,
-        ``"keypoint"``, each mapping to a list of coordinate values (as
-        returned by :func:`_target_points_to_remove`, with no remaining
-        ``"all"`` entries).
-
-    Returns
-    -------
-    points : numpy.ndarray
-        ``points_as_napari`` array, i.e. ``loader.points_layer.data``
-        with the targeted rows removed.
-    properties : dict
-        ``loader.points_layer.properties`` with the targeted rows
-        removed from every value array.
-
+    """Simulate napari deleting every point matching ``target`` (as
+    produced by :func:`_target_points_to_remove`) from the live Points
+    layer, dropping the matching rows from both ``points_layer.data``
+    and ``points_layer.properties`` and returning the shrunk arrays.
     """
     live_props = loader.points_layer.properties
     remove_mask = (
@@ -585,34 +521,54 @@ def _remove_points(loader, target):
 
 
 @pytest.mark.parametrize(
+    "nan_location",
+    [
+        None,
+        {"time": "middle", "individual": ["id_0"], "keypoint": ["centroid"]},
+    ],
+    ids=["no_pre_existing_nans", "pre_existing_nans"],
+)
+@pytest.mark.parametrize(
     "removal_selector",
     [
+        {"time": [2], "individual": ["id_0"], "keypoint": ["centroid"]},
         {"time": "all", "individual": ["id_0"], "keypoint": ["centroid"]},
         {"time": [3], "individual": "all", "keypoint": "all"},
         {"time": [3, 4, 5], "individual": ["id_0"], "keypoint": "all"},
         {"time": [3, 4, 5], "individual": "all", "keypoint": "all"},
     ],
     ids=[
+        "keypoint_removed_for_one_individual_one_frame",
         "keypoint_removed_for_one_individual_all_frames",
         "single_frame_removed_all_keypoints_all_individuals",
         "frame_range_removed_one_individual_all_keypoints",
         "frame_range_removed_all_individuals_all_keypoints",
     ],
 )
-def test_removed_pose_napari_layers(
+def test_removed_pose_napari_layers_restores_nans(
+    nan_location,
     removal_selector,
     valid_poses_path_and_ds,
+    valid_poses_path_and_ds_with_localised_nans,
     loaded_data_loader,
 ):
-    """Test removal of napari points across a keypoint, individual,
-    or frame range.
+    """Test partial removal of napari points across a keypoint,
+    individual, or frame range.
 
     Simulates a user selecting and deleting many points at once in the
     napari Points layer: every point for a keypoint (for one individual,
     or for all of them), every point for an individual, or every point
     for a range of frames (for one individual, or for all of them).
+    Parametrized over datasets with and without pre-existing NaN
+    positions, to check removal still works when combined with data
+    that's already missing.
     """
-    filepath, ds_expected = valid_poses_path_and_ds
+    if nan_location is None:
+        filepath, ds_expected = valid_poses_path_and_ds
+    else:
+        filepath, ds_expected = valid_poses_path_and_ds_with_localised_nans(
+            nan_location
+        )
     loader = loaded_data_loader(filepath, ds_expected)
     target = _target_points_to_remove(removal_selector, ds_expected)
     points, properties = _remove_points(loader, target)
@@ -738,3 +694,35 @@ def test_removed_pose_napari_layers_empty_ds(
             properties_with_nans=loader.properties,
             attrs=ds_expected.attrs,
         )
+
+
+def test_never_detected_keypoint_dropped_on_round_trip(
+    valid_poses_dataset, tmp_path, loaded_data_loader
+):
+    """Test that a keypoint the tracker never detected is dropped.
+
+    A keypoint that is all-NaN in the source file is filtered out when
+    the napari layers are created, so it is indistinguishable from one
+    the user deleted: both are simply absent from the live Points layer.
+    It is therefore dropped on conversion back to a dataset, even though
+    the user edited nothing. This test documents that behaviour.
+    """
+    ds_in = valid_poses_dataset.copy(deep=True)
+    ds_in.position.loc[{"keypoint": "left"}] = np.nan  # never detected
+    filepath = tmp_path / "ds.csv"
+    save_poses.to_dlc_file(ds_in, filepath, split_individuals=False)
+    loader = loaded_data_loader(filepath, ds_in)
+
+    # The keypoint survives loading; it is lost only on conversion back.
+    assert "left" in loader.properties["keypoint"].unique()
+
+    # No edits: hand the live layers straight back.
+    ds_out = napari_layers_to_ds(
+        points_as_napari=loader.points_layer.data,
+        properties=loader.points_layer.properties,
+        properties_with_nans=loader.properties,
+        attrs=ds_in.attrs,
+    )
+
+    assert "left" not in ds_out.coords["keypoint"]
+    xr.testing.assert_equal(ds_out, ds_in.drop_sel(keypoint="left"))

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -516,13 +516,14 @@ def test_removed_pose_napari_layers(
     valid_poses_path_and_ds_with_localised_nans,
     loaded_data_loader,
 ):
-    """Test :func:`napari_layers_to_ds` correctly converts a layer with
-    removed predictions back to a ``movement`` dataset.
+    """Test that deleted napari points are restored as NaNs on conversion.
 
-    Simulates a user removing the prediction for ``centroid`` of ``id_0``
-    at frame 2 by setting its x, y coordinates and confidence score to NaN.
-    Verifies that :func:`napari_layers_to_ds` reconstructs a dataset that
-    reflects the removal. The test is parametrized over datasets with and
+    Simulates a user deleting the prediction for ``centroid`` of ``id_0``
+    at frame 2 from the napari Points layer. In napari, deleting a point
+    removes the corresponding row from both ``points_layer.data`` and
+    ``points_layer.properties``. Verifies that :func:`napari_layers_to_ds`
+    reconstructs a dataset where the deleted point has NaN x, y coordinates
+    and NaN confidence. The test is parametrized over datasets with and
     without NaN position values to ensure robustness.
     """
     if nan_location is None:
@@ -536,27 +537,39 @@ def test_removed_pose_napari_layers(
     frame = 2  # safe: not NaN in any parametrize case
     keypoint = "centroid"
     individual = "id_0"
-    remove_mask = (
+
+    # In napari, deleting a point removes that row from both the Points
+    # layer data and its properties by index. Replicate that here.
+    mask = (
         (loader.points_layer.properties["time"] == frame)
         & (loader.points_layer.properties["keypoint"] == keypoint)
         & (loader.points_layer.properties["individual"] == individual)
     )
+    remove_idx = int(np.flatnonzero(mask)[0])
+    points = np.delete(
+        loader.points_layer.data, remove_idx, axis=0
+    )  # delete entire row
+    properties = {
+        key: np.delete(value, remove_idx)
+        for key, value in loader.points_layer.properties.items()
+    }
+
     conf_mask = (
         (loader.properties["time"] == frame)
         & (loader.properties["keypoint"] == keypoint)
         & (loader.properties["individual"] == individual)
     )
-    loader.points_layer.data[remove_mask, 1] = np.nan  # y
-    loader.points_layer.data[remove_mask, 2] = np.nan  # x
     loader.properties.loc[conf_mask, "confidence"] = np.nan
 
     ds = napari_layers_to_ds(
-        points_as_napari=loader.points_layer.data,
-        properties=loader.points_layer.properties,
+        points_as_napari=points,
+        properties=properties,
         properties_with_nans=loader.properties,
         attrs=ds_expected.attrs,
     )
+
     expected_ds = ds_expected.copy(deep=True)
+
     expected_ds.position.loc[
         {
             "time": frame,
@@ -565,6 +578,7 @@ def test_removed_pose_napari_layers(
             "individual": individual,
         }
     ] = [np.nan, np.nan]
+
     expected_ds["confidence"].loc[
         {
             "time": frame,
@@ -572,4 +586,5 @@ def test_removed_pose_napari_layers(
             "individual": individual,
         }
     ] = np.nan
+
     xr.testing.assert_equal(ds, expected_ds)

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -9,6 +9,7 @@ import xarray as xr
 from napari.layers.base import ActionType
 from pandas.testing import assert_frame_equal
 
+from movement.io import save_poses
 from movement.napari.convert import ds_to_napari_layers, napari_layers_to_ds
 
 
@@ -386,9 +387,9 @@ def test_napari_layers_to_ds_bboxes_not_implemented():
         match="Reconstruction of bounding box datasets",
     ):
         napari_layers_to_ds(
-            points_as_napari=np.empty((0, 3)),
-            properties={"individual": np.array([])},
-            properties_with_nans=pd.DataFrame(),
+            points_as_napari=np.empty((1, 3)),
+            properties={"individual": np.array(["id_0"])},
+            properties_with_nans=pd.DataFrame({"individual": ["id_0"]}),
         )
 
 
@@ -489,77 +490,132 @@ def test_edited_pose_napari_layers(
     xr.testing.assert_equal(ds, expected_ds)
 
 
+def _target_points_to_remove(target, ds):
+    """Define target points to remove into a concrete coordinate value.
+
+    ``target`` is a dict with keys ``"time"``, ``"individual"`` and
+    ``"keypoint"``, each mapping to either an explicit list of
+    coordinate values to target; or the string ``"all"`` as shorthand
+    for every value along this axis. This function replaces any
+    ``"all"`` entries with the dataset's actual coordinate values (e.g.
+    ``ds.coords["individual"].values``), so that the returned dict can
+    be used directly to build a removal mask (see :func:`_remove_points`)
+    or an xarray ``.loc`` selection.
+
+    Parameters
+    ----------
+    target : dict
+        Removal target with keys ``"time"``, ``"individual"``,
+        ``"keypoint"``; each value is either a list of coordinate
+        values or ``"all"``.
+    ds : xarray.Dataset
+        Dataset to resolve ``"all"`` against, providing the full set
+        of ``time``/``individual``/``keypoint`` coordinate values.
+
+    Returns
+    -------
+    dict
+        Same keys as ``target``, with every ``"all"`` entry replaced
+        by the corresponding coordinate values from ``ds``.
+
+    Examples
+    --------
+    For a dataset with individuals ``["id_0", "id_1"]``, keypoints
+    ``["centroid", "left", "right"]`` and 10 frames (``0`` to ``9``),
+    targeting individual ``"id_0"`` for every keypoint and frame:
+
+    >>> target = {"time": "all", "individual": ["id_0"], "keypoint": "all"}
+    >>> _target_points_to_remove(target, ds)  # doctest: +SKIP
+    {
+        "time": array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+        "individual": ["id_0"],
+        "keypoint": array(["centroid", "left", "right"]),
+    }
+
+    """
+    return {
+        key: (ds.coords[key].values if target[key] == "all" else target[key])
+        for key in ("time", "individual", "keypoint")
+    }
+
+
+def _remove_points(loader, target):
+    """Simulate napari deleting the targeted points from the live point layer.
+
+    In napari, deleting points removes the corresponding rows from both
+    the Points layer data and its properties.
+    This function selects every point whose ``time``, ``individual`` and
+    ``keypoint`` all match ``target``(as produced by
+    :func:`_target_points_to_remove`) and drops those rows from both
+    ``loader.points_layer.data`` and ``loader.points_layer.properties``,
+    returning the shrunk arrays.
+
+    Parameters
+    ----------
+    loader : movement.napari.loader_widgets.DataLoader
+        Loader widget with data already loaded, providing the live
+        ``points_layer.data`` and ``points_layer.properties`` to remove
+        points from.
+    target : dict
+        Removal target with keys ``"time"``, ``"individual"``,
+        ``"keypoint"``, each mapping to a list of coordinate values (as
+        returned by :func:`_target_points_to_remove`, with no remaining
+        ``"all"`` entries).
+
+    Returns
+    -------
+    points : numpy.ndarray
+        ``points_as_napari`` array, i.e. ``loader.points_layer.data``
+        with the targeted rows removed.
+    properties : dict
+        ``loader.points_layer.properties`` with the targeted rows
+        removed from every value array.
+
+    """
+    live_props = loader.points_layer.properties
+    remove_mask = (
+        np.isin(live_props["time"], target["time"])
+        & np.isin(live_props["individual"], target["individual"])
+        & np.isin(live_props["keypoint"], target["keypoint"])
+    )
+    keep_mask = ~remove_mask
+    points = loader.points_layer.data[keep_mask]
+    properties = {key: value[keep_mask] for key, value in live_props.items()}
+    return points, properties
+
+
 @pytest.mark.parametrize(
-    "nan_location",
+    "removal_selector",
     [
-        None,
-        {
-            "time": "start",
-            "individual": ["id_0", "id_1"],
-            "keypoint": ["centroid", "left", "right"],
-        },
-        {
-            "time": "end",
-            "individual": ["id_0", "id_1"],
-            "keypoint": ["centroid", "left", "right"],
-        },
-        {
-            "time": "middle",
-            "individual": ["id_0"],
-            "keypoint": ["centroid"],
-        },
+        {"time": "all", "individual": ["id_0"], "keypoint": ["centroid"]},
+        {"time": [3], "individual": "all", "keypoint": "all"},
+        {"time": [3, 4, 5], "individual": ["id_0"], "keypoint": "all"},
+        {"time": [3, 4, 5], "individual": "all", "keypoint": "all"},
+    ],
+    ids=[
+        "keypoint_removed_for_one_individual_all_frames",
+        "single_frame_removed_all_keypoints_all_individuals",
+        "frame_range_removed_one_individual_all_keypoints",
+        "frame_range_removed_all_individuals_all_keypoints",
     ],
 )
 def test_removed_pose_napari_layers(
-    nan_location,
+    removal_selector,
     valid_poses_path_and_ds,
-    valid_poses_path_and_ds_with_localised_nans,
     loaded_data_loader,
 ):
-    """Test that deleted napari points are restored as NaNs on conversion.
+    """Test removal of napari points across a keypoint, individual,
+    or frame range.
 
-    Simulates a user deleting the prediction for ``centroid`` of ``id_0``
-    at frame 2 from the napari Points layer. In napari, deleting a point
-    removes the corresponding row from both ``points_layer.data`` and
-    ``points_layer.properties``. Verifies that :func:`napari_layers_to_ds`
-    reconstructs a dataset where the deleted point has NaN x, y coordinates
-    and NaN confidence. The test is parametrized over datasets with and
-    without NaN position values to ensure robustness.
+    Simulates a user selecting and deleting many points at once in the
+    napari Points layer: every point for a keypoint (for one individual,
+    or for all of them), every point for an individual, or every point
+    for a range of frames (for one individual, or for all of them).
     """
-    if nan_location is None:
-        filepath, ds_expected = valid_poses_path_and_ds
-    else:
-        filepath, ds_expected = valid_poses_path_and_ds_with_localised_nans(
-            nan_location
-        )
+    filepath, ds_expected = valid_poses_path_and_ds
     loader = loaded_data_loader(filepath, ds_expected)
-
-    frame = 2  # safe: not NaN in any parametrize case
-    keypoint = "centroid"
-    individual = "id_0"
-
-    # In napari, deleting a point removes that row from both the Points
-    # layer data and its properties by index. Replicate that here.
-    mask = (
-        (loader.points_layer.properties["time"] == frame)
-        & (loader.points_layer.properties["keypoint"] == keypoint)
-        & (loader.points_layer.properties["individual"] == individual)
-    )
-    remove_idx = int(np.flatnonzero(mask)[0])
-    points = np.delete(
-        loader.points_layer.data, remove_idx, axis=0
-    )  # delete entire row
-    properties = {
-        key: np.delete(value, remove_idx)
-        for key, value in loader.points_layer.properties.items()
-    }
-
-    conf_mask = (
-        (loader.properties["time"] == frame)
-        & (loader.properties["keypoint"] == keypoint)
-        & (loader.properties["individual"] == individual)
-    )
-    loader.properties.loc[conf_mask, "confidence"] = np.nan
+    target = _target_points_to_remove(removal_selector, ds_expected)
+    points, properties = _remove_points(loader, target)
 
     ds = napari_layers_to_ds(
         points_as_napari=points,
@@ -568,23 +624,117 @@ def test_removed_pose_napari_layers(
         attrs=ds_expected.attrs,
     )
 
-    expected_ds = ds_expected.copy(deep=True)
-
+    # Removed points are restored as NaN; nothing is dropped from the
+    # dataset's time/keypoint/individual coordinates.
+    expected_ds = _nan_confidence_at_nan_pos(ds_expected)
     expected_ds.position.loc[
         {
-            "time": frame,
+            "time": target["time"],
             "space": ["x", "y"],
-            "keypoint": keypoint,
-            "individual": individual,
+            "keypoint": target["keypoint"],
+            "individual": target["individual"],
         }
-    ] = [np.nan, np.nan]
-
+    ] = np.nan
     expected_ds["confidence"].loc[
         {
-            "time": frame,
-            "keypoint": keypoint,
-            "individual": individual,
+            "time": target["time"],
+            "keypoint": target["keypoint"],
+            "individual": target["individual"],
         }
     ] = np.nan
 
     xr.testing.assert_equal(ds, expected_ds)
+
+
+@pytest.mark.parametrize(
+    "removal_selector, dropped_dim",
+    [
+        (
+            {"time": "all", "individual": "all", "keypoint": ["centroid"]},
+            "keypoint",
+        ),
+        (
+            {"time": "all", "individual": ["id_0"], "keypoint": "all"},
+            "individual",
+        ),
+    ],
+    ids=[
+        "keypoint_removed_for_all_individuals_all_frames",
+        "individual_removed_all_keypoints_all_frames",
+    ],
+)
+def test_removed_pose_napari_layers_drops_empty_coord(
+    removal_selector,
+    dropped_dim,
+    valid_poses_path_and_ds,
+    loaded_data_loader,
+):
+    """Test that a keypoint/individual with no data left anywhere is
+    dropped entirely from the reconstructed dataset.
+
+    Unlike a partial removal (some, but not all, individuals/frames for
+    a keypoint), removing a keypoint or individual entirely leaves it
+    with no data anywhere -- ``napari_layers_to_ds`` drops it from the
+    dataset rather than keeping it as an all-NaN coordinate.
+    """
+    filepath, ds_expected = valid_poses_path_and_ds
+    loader = loaded_data_loader(filepath, ds_expected)
+    target = _target_points_to_remove(removal_selector, ds_expected)
+    points, properties = _remove_points(loader, target)
+
+    ds = napari_layers_to_ds(
+        points_as_napari=points,
+        properties=properties,
+        properties_with_nans=loader.properties,
+        attrs=ds_expected.attrs,
+    )
+
+    removed_labels = target[dropped_dim]
+    remaining_labels = [
+        label
+        for label in ds_expected.coords[dropped_dim].values
+        if label not in removed_labels
+    ]
+    assert list(ds.coords[dropped_dim].values) == remaining_labels
+
+    expected_ds = ds_expected.sel({dropped_dim: remaining_labels})
+    xr.testing.assert_equal(ds, expected_ds)
+
+
+@pytest.mark.parametrize(
+    "valid_poses_dataset",
+    ["multi_individual_array", "single_individual_array"],
+    indirect=True,
+    ids=["two_individual_dataset", "single_individual_dataset"],
+)
+def test_removed_pose_napari_layers_empty_ds(
+    valid_poses_dataset,
+    tmp_path,
+    loaded_data_loader,
+):
+    """Test that removing every point in the dataset raises a ValueError.
+
+    Covers deleting all individuals (and therefore every point) from a
+    2-individual dataset, and deleting the only individual from a
+    1-individual dataset. Either way, nothing is left to reconstruct, so
+    :func:`napari_layers_to_ds` should raise rather than silently return
+    an empty dataset.
+    """
+    ds_expected = valid_poses_dataset
+    filepath = tmp_path / "ds.csv"
+    save_poses.to_dlc_file(ds_expected, filepath, split_individuals=False)
+    loader = loaded_data_loader(filepath, ds_expected)
+    target = _target_points_to_remove(
+        {"time": "all", "individual": "all", "keypoint": "all"}, ds_expected
+    )
+    points, properties = _remove_points(loader, target)
+
+    with pytest.raises(
+        ValueError, match="No points found in the napari layer"
+    ):
+        napari_layers_to_ds(
+            points_as_napari=points,
+            properties=properties,
+            properties_with_nans=loader.properties,
+            attrs=ds_expected.attrs,
+        )

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -487,3 +487,89 @@ def test_edited_pose_napari_layers(
         }
     ] = np.nan
     xr.testing.assert_equal(ds, expected_ds)
+
+
+@pytest.mark.parametrize(
+    "nan_location",
+    [
+        None,
+        {
+            "time": "start",
+            "individual": ["id_0", "id_1"],
+            "keypoint": ["centroid", "left", "right"],
+        },
+        {
+            "time": "end",
+            "individual": ["id_0", "id_1"],
+            "keypoint": ["centroid", "left", "right"],
+        },
+        {
+            "time": "middle",
+            "individual": ["id_0"],
+            "keypoint": ["centroid"],
+        },
+    ],
+)
+def test_removed_pose_napari_layers(
+    nan_location,
+    valid_poses_path_and_ds,
+    valid_poses_path_and_ds_with_localised_nans,
+    loaded_data_loader,
+):
+    """Test :func:`napari_layers_to_ds` correctly converts a layer with
+    removed predictions back to a ``movement`` dataset.
+
+    Simulates a user removing the prediction for ``centroid`` of ``id_0``
+    at frame 2 by setting its x, y coordinates and confidence score to NaN.
+    Verifies that :func:`napari_layers_to_ds` reconstructs a dataset that
+    reflects the removal. The test is parametrized over datasets with and
+    without NaN position values to ensure robustness.
+    """
+    if nan_location is None:
+        filepath, ds_expected = valid_poses_path_and_ds
+    else:
+        filepath, ds_expected = valid_poses_path_and_ds_with_localised_nans(
+            nan_location
+        )
+    loader = loaded_data_loader(filepath, ds_expected)
+
+    frame = 2  # safe: not NaN in any parametrize case
+    keypoint = "centroid"
+    individual = "id_0"
+    remove_mask = (
+        (loader.points_layer.properties["time"] == frame)
+        & (loader.points_layer.properties["keypoint"] == keypoint)
+        & (loader.points_layer.properties["individual"] == individual)
+    )
+    conf_mask = (
+        (loader.properties["time"] == frame)
+        & (loader.properties["keypoint"] == keypoint)
+        & (loader.properties["individual"] == individual)
+    )
+    loader.points_layer.data[remove_mask, 1] = np.nan  # y
+    loader.points_layer.data[remove_mask, 2] = np.nan  # x
+    loader.properties.loc[conf_mask, "confidence"] = np.nan
+
+    ds = napari_layers_to_ds(
+        points_as_napari=loader.points_layer.data,
+        properties=loader.points_layer.properties,
+        properties_with_nans=loader.properties,
+        attrs=ds_expected.attrs,
+    )
+    expected_ds = ds_expected.copy(deep=True)
+    expected_ds.position.loc[
+        {
+            "time": frame,
+            "space": ["x", "y"],
+            "keypoint": keypoint,
+            "individual": individual,
+        }
+    ] = [np.nan, np.nan]
+    expected_ds["confidence"].loc[
+        {
+            "time": frame,
+            "keypoint": keypoint,
+            "individual": individual,
+        }
+    ] = np.nan
+    xr.testing.assert_equal(ds, expected_ds)


### PR DESCRIPTION
## Description

This PR extends `napari_layers_to_ds` to correctly handle deletion of pose predictions in napari, and adds test coverage for the different ways that can happen.

As @sfmig highlighted in #1011 ([here](https://github.com/neuroinformatics-unit/movement/pull/1011#:~:text=dataset%2E-,In,this,-%2E)), when you remove a point in napari, that prediction is not set to  a ``NaN`` value. Instead, the entire row is removed, both from the points layers and its properties.


This PR extends `napari_layers_to_ds` so that a keypoint or individual with no data left anywhere is dropped entirely from the reconstructed dataset, rather than kept as an all-NaN coordinate, and raises a ValueError if every point has been removed. It also adds unit tests covering these deletion scenarios.

With the following implementation, we extend `napari_layers_to_ds` to (1) restore removed points from napari layers back to `movement` ds as `NaNs`;  (2) drop entirely an individual or keypoint from the reconstructed dataset when it has been completely removed from the napari layers; (3) raises `ValueError` when all predictions have been removed; (4) adds unit test to check the utility of this function in the multiple deleting scenarios. 

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Same reasoning as in #1024. We want ``napari_layers_to_ds()`` to reconstruct the napari layers back to ``movement`` dataset. Removing predictions is a type of edit to be implemented. 

**What does this PR do?**

In `movement/napari/convert.py`:

- After reconstructing the dataset, `napari_layers_to_ds` now drops any keypoint with  or individual with no data left anywhere (all `NaN` across every other dimension), rather than keeping it as an all-NaN coordinate. `time` is never dropped this way. A frame with no detections still stays in the timeline.
```python
# Drop keypoints/individuals with no data left; never `time`.
        ds = ds.dropna(dim="keypoint", how="all").dropna(
            dim="individual", how="all"
        )
```
- If the edit leaves no keypoints or no individuals at all (i.e. every point was removed), the function raises `ValueError` instead of silently returning an empty dataset.
```python
if ds.sizes["keypoint"] == 0 or ds.sizes["individual"] == 0:
            raise logger.error(
                ValueError(
                    "No points found in the napari layer. "
                    "This happens when all points have been removed."
                )
            )
        return ds
```

In `tests/test_unit/test_napari_plugin/test_convert.py`:

- Added `_target_points_to_remove` and `_remove_points` test helpers to simulate napari point deletion for keypoint/individual/frame selections.
- `test_removed_pose_napari_layers_restores_nans`: tests if partial removal (a keypoint, an individual, a single frame, or a frame range) always leaves something behind, so the affected points come back as NaN and nothing is dropped. Parametrized over datasets with and without pre-existing `NaN`.
- `test_removed_pose_napari_layers_drops_empty_coord`: if we fully remove a keypoint or an individual, does `napari_layers_to_ds` drop it entirely from the reconstructed dataset.
- `test_removed_pose_napari_layers_empty_ds`: tests if removing every point on the dataset raises `ValueError`.
- `test_never_detected_keypoint_dropped_on_round_trip`: test if a keypoint that was never detected by the tracker (all-NaN in the source file) is indistinguishable from a user-deleted one once loaded into napari, so it's dropped on conversion too, even with no user edits at all.

## References

Part of #1008. Follow-up to #1011. Related to #993.

## How has this PR been tested?

The new test has been added to the unit test suit and passes locally.

The implementation has also been verified interactively in napari to confirm that deleting a point removes the corresponding row from Points layer and the associated properties (confidence). 

## Is this a breaking change?

No. 

## Does this PR require an update to the documentation?

No. 

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
