### PR TITLE
Add maximum expected displacement (Emax) as a path metric

### DIFF
--- a/movement/kinematics/__init__.py
+++ b/movement/kinematics/__init__.py
@@ -3,27 +3,27 @@
 from movement.kinematics.distances import compute_pairwise_distances
 from movement.kinematics.kinematics import (
     compute_acceleration,
-    compute_forward_displacement,
     compute_backward_displacement,
+    compute_forward_displacement,
     compute_speed,
     compute_time_derivative,
     compute_velocity,
 )
+from movement.kinematics.kinetic_energy import compute_kinetic_energy
 from movement.kinematics.orientation import (
     compute_forward_vector,
     compute_forward_vector_angle,
     compute_head_direction_vector,
 )
-from movement.kinematics.kinetic_energy import compute_kinetic_energy
 from movement.kinematics.path import (
     compute_directional_change,
     compute_path_deviation,
+    compute_path_emax,
     compute_path_length,
     compute_path_sinuosity,
     compute_path_straightness,
     compute_turning_angle,
 )
-
 
 __all__ = [
     "compute_forward_displacement",
@@ -35,6 +35,7 @@ __all__ = [
     "compute_path_straightness",
     "compute_directional_change",
     "compute_path_deviation",
+    "compute_path_emax",
     "compute_time_derivative",
     "compute_path_sinuosity",
     "compute_pairwise_distances",

--- a/movement/kinematics/__init__.py
+++ b/movement/kinematics/__init__.py
@@ -17,8 +17,8 @@ from movement.kinematics.orientation import (
 )
 from movement.kinematics.path import (
     compute_directional_change,
+    compute_maximum_expected_displacement,
     compute_path_deviation,
-    compute_path_emax,
     compute_path_length,
     compute_path_sinuosity,
     compute_path_straightness,
@@ -35,7 +35,7 @@ __all__ = [
     "compute_path_straightness",
     "compute_directional_change",
     "compute_path_deviation",
-    "compute_path_emax",
+    "compute_maximum_expected_displacement",
     "compute_time_derivative",
     "compute_path_sinuosity",
     "compute_pairwise_distances",

--- a/movement/kinematics/__init__.py
+++ b/movement/kinematics/__init__.py
@@ -17,8 +17,8 @@ from movement.kinematics.orientation import (
 )
 from movement.kinematics.path import (
     compute_directional_change,
-    compute_maximum_expected_displacement,
     compute_path_deviation,
+    compute_path_emax,
     compute_path_length,
     compute_path_sinuosity,
     compute_path_straightness,
@@ -35,7 +35,7 @@ __all__ = [
     "compute_path_straightness",
     "compute_directional_change",
     "compute_path_deviation",
-    "compute_maximum_expected_displacement",
+    "compute_path_emax",
     "compute_time_derivative",
     "compute_path_sinuosity",
     "compute_pairwise_distances",

--- a/movement/kinematics/path.py
+++ b/movement/kinematics/path.py
@@ -7,7 +7,7 @@ keypoint representing the individual's overall position (e.g., centroid).
 """
 
 import warnings
-from typing import Literal
+from typing import Literal, cast
 
 import numpy as np
 import xarray as xr
@@ -505,6 +505,144 @@ def compute_directional_change(
     dc.name = "directional_change"
     dc.attrs["long_name"] = "Directional Change"
     return dc
+
+
+def compute_path_emax(
+    data: xr.DataArray,
+    in_spatial_units: bool = True,
+) -> xr.DataArray:
+    r"""Compute the maximum expected displacement (:math:`E_{\max}`).
+
+    :math:`E_{\max}` is a straightness measure that captures the
+    directional persistence of a path. Intuitively, it is the maximum
+    expected displacement of an animal navigating *without* an external
+    directional reference (e.g. a compass or a landmark), given the
+    observed distribution of its turning angles and step lengths [1]_.
+    Larger values indicate straighter, more persistent paths; values
+    close to zero indicate sinuous paths.
+
+    Two variants are available. The dimensionless variant
+    :math:`E_{\max}^{(a)}` depends only on the turning angles:
+
+    .. math::
+        E_{\max}^{(a)} = \frac{\bar{c}}{1 - \bar{c}}, \qquad
+        \bar{c} = \overline{\cos\theta}
+
+    where :math:`\theta` are the turning angles and :math:`\bar{c}` is
+    their mean cosine. The variant :math:`E_{\max}^{(b)}` scales this by
+    the mean step length :math:`\bar{p}` to express the result in the
+    same spatial units as the input:
+
+    .. math::
+        E_{\max}^{(b)} = \bar{p} \, E_{\max}^{(a)}
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        The input data containing position information, with ``time``
+        and ``space`` (in Cartesian coordinates) as required dimensions.
+        The ``space`` dimension must contain exactly the coordinates
+        ``["x", "y"]`` (2D data only).
+    in_spatial_units : bool, optional
+        If ``True`` (the default), return the dimensioned variant
+        :math:`E_{\max}^{(b)}`, expressed in the same spatial units as
+        ``data``. If ``False``, return the dimensionless variant
+        :math:`E_{\max}^{(a)}`.
+
+    Returns
+    -------
+    xarray.DataArray
+        The maximum expected displacement, with dimensions matching
+        those of the input data, except ``time`` and ``space`` are
+        removed. When ``in_spatial_units`` is ``True`` the values are in
+        the same spatial units as ``data``; otherwise they are
+        dimensionless.
+
+    Notes
+    -----
+    1. **Mean cosine of the turning angles.**
+       :math:`\bar{c} = \overline{\cos\theta}` is the ``time`` average
+       (ignoring ``NaN`` values) of the cosine of the turning angles
+       :math:`\theta` returned by :func:`compute_turning_angle`. Each
+       :math:`\theta` is the signed rotation from the backward
+       displacement step arriving at ``t-1`` to the step arriving at
+       ``t``, computed via
+       :func:`movement.utils.vector.compute_signed_angle_2d`. The first
+       two time steps have no defined turning angle and so do not
+       contribute.
+    2. **Radians only.** The turning angles must be in radians for
+       :math:`\cos\theta` to be meaningful, so the ``in_degrees`` flag of
+       :func:`compute_turning_angle` is deliberately *not* exposed here;
+       passing angles in degrees would silently corrupt the result.
+    3. **Range.** :math:`E_{\max}^{(a)} \in [-0.5, \infty)`. Negative
+       values arise for highly sinuous paths, where the mean cosine
+       :math:`\bar{c}` is itself negative.
+    4. **Straight paths.** As a path approaches a perfectly straight
+       line, :math:`\bar{c} \to 1`, so :math:`1 - \bar{c} \to 0` and
+       :math:`E_{\max} \to +\infty`. An infinite result is therefore the
+       correct, expected output for a straight path.
+    5. **Missing values.** Turning angles and step lengths that are
+       ``NaN`` (e.g. from missing positions or stationary steps) are
+       ignored when averaging. If every turning angle is ``NaN`` (e.g. a
+       stationary track), the result is ``NaN``.
+
+    References
+    ----------
+    .. [1] Cheung, A., Zhang, S., Stricker, C. & Srinivasan, M. V.
+       (2007). Animal navigation: the difficulty of moving in a straight
+       line. *Biological Cybernetics* 97(1), 47-61.
+       https://doi.org/10.1007/s00422-007-0158-0
+    .. [2] McLean, D. J. & Skowron Volponi, M. A. (2018). trajr: An R
+       package for characterisation of animal trajectories. *Ethology*
+       124(6), 440-448. https://doi.org/10.1111/eth.12739
+
+    See Also
+    --------
+    compute_turning_angle :
+        The underlying function used to compute the turning angles.
+    compute_path_straightness :
+        A related, path-length-based measure of straightness.
+
+    Examples
+    --------
+    >>> from movement.kinematics import compute_path_emax
+
+    Compute E_max from the centroid trajectory of a poses dataset ``ds``:
+
+    >>> centroid = ds.position.mean(dim="keypoint")
+    >>> emax = compute_path_emax(centroid)
+
+    Return the dimensionless variant instead:
+
+    >>> emax_a = compute_path_emax(centroid, in_spatial_units=False)
+
+    Compute over a specific time window:
+
+    >>> emax = compute_path_emax(centroid.sel(time=slice(0, 100)))
+
+    """
+    data = _validate_time_points(data, "maximum expected displacement")
+
+    theta = compute_turning_angle(data)
+    mean_cosine = cast("xr.DataArray", np.cos(theta)).mean(
+        dim="time", skipna=True
+    )
+
+    # mean_cosine -> 1 for a perfectly straight path, giving E_max -> +inf.
+    # Guard the division so the zero denominator does not emit a warning.
+    one_minus_c = 1 - mean_cosine
+    emax = xr.where(
+        one_minus_c == 0,
+        np.inf,
+        mean_cosine / one_minus_c.where(one_minus_c != 0),
+    )
+
+    if in_spatial_units:
+        emax = emax * _segment_lengths(data).mean(dim="time", skipna=True)
+
+    emax.name = "path_emax"
+    emax.attrs["long_name"] = "Maximum Expected Displacement"
+    return emax
 
 
 def compute_path_deviation(

--- a/movement/kinematics/path.py
+++ b/movement/kinematics/path.py
@@ -153,6 +153,10 @@ def compute_path_straightness(
     --------
     compute_path_length : The underlying function used to
         compute the path length :math:`L`.
+    compute_maximum_expected_displacement :
+        An alternative straightness measure derived from the
+        turning-angle distribution which, unlike the :math:`D/L`
+        ratio, does not depend on the number of steps in the path.
 
     Examples
     --------
@@ -470,6 +474,8 @@ def compute_directional_change(
     --------
     compute_turning_angle :
         The underlying function used to compute turning angles.
+    compute_maximum_expected_displacement :
+        A related path-straightness measure based on turning angles.
 
     Examples
     --------
@@ -568,18 +574,16 @@ def compute_maximum_expected_displacement(
        :func:`movement.utils.vector.compute_signed_angle_2d`. The first
        two time steps have no defined turning angle and so do not
        contribute.
-    2. **Radians only.** The turning angles must be in radians for
-       :math:`\cos\theta` to be meaningful, so the ``in_degrees`` flag of
-       :func:`compute_turning_angle` is deliberately *not* exposed here;
-       passing angles in degrees would silently corrupt the result.
-    3. **Range.** :math:`E_{\max}^{(a)} \in [-0.5, \infty)`. Negative
-       values arise for highly sinuous paths, where the mean cosine
+    2. **Range.** :math:`E_{\max}^{(a)} \in [-0.5, \infty)`. While
+       highly sinuous paths actually have values approaching 0,
+       negative values specifically arise for trajectories with a
+       systematic backward-turning bias where the mean cosine
        :math:`\bar{c}` is itself negative.
-    4. **Straight paths.** As a path approaches a perfectly straight
+    3. **Straight paths.** As a path approaches a perfectly straight
        line, :math:`\bar{c} \to 1`, so :math:`1 - \bar{c} \to 0` and
        :math:`E_{\max} \to +\infty`. An infinite result is therefore the
        correct, expected output for a straight path.
-    5. **Missing values.** Turning angles and step lengths that are
+    4. **Missing values.** Turning angles and step lengths that are
        ``NaN`` (e.g. from missing positions or stationary steps) are
        ignored when averaging. If every turning angle is ``NaN`` (e.g. a
        stationary track), the result is ``NaN``.

--- a/movement/kinematics/path.py
+++ b/movement/kinematics/path.py
@@ -507,7 +507,7 @@ def compute_directional_change(
     return dc
 
 
-def compute_path_emax(
+def compute_maximum_expected_displacement(
     data: xr.DataArray,
     in_spatial_units: bool = True,
 ) -> xr.DataArray:
@@ -600,20 +600,24 @@ def compute_path_emax(
 
     Examples
     --------
-    >>> from movement.kinematics import compute_path_emax
+    >>> from movement.kinematics import compute_maximum_expected_displacement
 
     Compute E_max from the centroid trajectory of a poses dataset ``ds``:
 
     >>> centroid = ds.position.mean(dim="keypoint")
-    >>> emax = compute_path_emax(centroid)
+    >>> emax = compute_maximum_expected_displacement(centroid)
 
     Return the dimensionless variant instead:
 
-    >>> emax_a = compute_path_emax(centroid, in_spatial_units=False)
+    >>> emax_a = compute_maximum_expected_displacement(
+    ...     centroid, in_spatial_units=False
+    ... )
 
     Compute over a specific time window:
 
-    >>> emax = compute_path_emax(centroid.sel(time=slice(0, 100)))
+    >>> emax = compute_maximum_expected_displacement(
+    ...     centroid.sel(time=slice(0, 100))
+    ... )
 
     """
     data = _validate_time_points(data, "maximum expected displacement")
@@ -635,7 +639,7 @@ def compute_path_emax(
     if in_spatial_units:
         emax = emax * _segment_lengths(data).mean(dim="time", skipna=True)
 
-    emax.name = "path_emax"
+    emax.name = "maximum_expected_displacement"
     emax.attrs["long_name"] = "Maximum Expected Displacement"
     return emax
 

--- a/movement/kinematics/path.py
+++ b/movement/kinematics/path.py
@@ -538,12 +538,10 @@ def compute_path_emax(
 
     Parameters
     ----------
-    data : xarray.DataArray
+    data
         The input data containing position information, with ``time``
         and ``space`` (in Cartesian coordinates) as required dimensions.
-        The ``space`` dimension must contain exactly the coordinates
-        ``["x", "y"]`` (2D data only).
-    in_spatial_units : bool, optional
+    in_spatial_units
         If ``True`` (the default), return the dimensioned variant
         :math:`E_{\max}^{(b)}`, expressed in the same spatial units as
         ``data``. If ``False``, return the dimensionless variant
@@ -592,9 +590,6 @@ def compute_path_emax(
        (2007). Animal navigation: the difficulty of moving in a straight
        line. *Biological Cybernetics* 97(1), 47-61.
        https://doi.org/10.1007/s00422-007-0158-0
-    .. [2] McLean, D. J. & Skowron Volponi, M. A. (2018). trajr: An R
-       package for characterisation of animal trajectories. *Ethology*
-       124(6), 440-448. https://doi.org/10.1111/eth.12739
 
     See Also
     --------

--- a/movement/kinematics/path.py
+++ b/movement/kinematics/path.py
@@ -4,6 +4,16 @@ By 'path' we refer to the spatial trajectory of an individual over the
 time span of the data. While these metrics can be computed based on any
 set of keypoints, they are most meaningful when applied to a single
 keypoint representing the individual's overall position (e.g., centroid).
+
+When adding a new path metric, follow this convention for the
+``nan_warn_threshold`` parameter: expose it only if the metric returns a
+single scalar per path (e.g. ``compute_path_length``,
+``compute_path_straightness``, ``compute_path_sinuosity`` and
+``compute_path_emax``), where a high proportion of missing values can
+silently skew that scalar. Do not expose it if the metric returns a
+time-varying quantity (e.g. ``compute_directional_change`` and
+``compute_path_deviation``), where missing values remain visible per
+time step and propagate on their own.
 """
 
 import warnings
@@ -155,7 +165,7 @@ def compute_path_straightness(
         compute the path length :math:`L`.
     compute_path_sinuosity :
         A related turning-angle-based measure of path tortuosity.
-    compute_maximum_expected_displacement :
+    compute_path_emax :
         An alternative straightness measure derived from the
         turning-angle distribution which, unlike the :math:`D/L`
         ratio, does not depend on the number of steps in the path.
@@ -349,7 +359,7 @@ def compute_path_sinuosity(
     compute_path_length : Total distance travelled along a path.
     compute_path_straightness : Net displacement divided by path length.
     compute_turning_angle : Step-wise turning angle along a path.
-    compute_maximum_expected_displacement : Directional-persistence measure.
+    compute_path_emax : Directional-persistence measure.
 
     Notes
     -----
@@ -477,7 +487,7 @@ def compute_directional_change(
     --------
     compute_turning_angle :
         The underlying function used to compute turning angles.
-    compute_maximum_expected_displacement :
+    compute_path_emax :
         A related path-straightness measure based on turning angles.
 
     Examples
@@ -516,7 +526,7 @@ def compute_directional_change(
     return dc
 
 
-def compute_maximum_expected_displacement(
+def compute_path_emax(
     data: xr.DataArray,
     in_spatial_units: bool = True,
     nan_warn_threshold: float = 0.2,
@@ -610,24 +620,20 @@ def compute_maximum_expected_displacement(
 
     Examples
     --------
-    >>> from movement.kinematics import compute_maximum_expected_displacement
+    >>> from movement.kinematics import compute_path_emax
 
     Compute E_max from the centroid trajectory of a poses dataset ``ds``:
 
     >>> centroid = ds.position.mean(dim="keypoint")
-    >>> emax = compute_maximum_expected_displacement(centroid)
+    >>> emax = compute_path_emax(centroid)
 
     Return the dimensionless variant instead:
 
-    >>> emax_a = compute_maximum_expected_displacement(
-    ...     centroid, in_spatial_units=False
-    ... )
+    >>> emax_a = compute_path_emax(centroid, in_spatial_units=False)
 
     Compute over a specific time window:
 
-    >>> emax = compute_maximum_expected_displacement(
-    ...     centroid.sel(time=slice(0, 100))
-    ... )
+    >>> emax = compute_path_emax(centroid.sel(time=slice(0, 100)))
 
     """
     data = _validate_time_points(

--- a/movement/kinematics/path.py
+++ b/movement/kinematics/path.py
@@ -7,7 +7,7 @@ keypoint representing the individual's overall position (e.g., centroid).
 """
 
 import warnings
-from typing import Literal, cast
+from typing import Literal
 
 import numpy as np
 import xarray as xr
@@ -629,9 +629,7 @@ def compute_maximum_expected_displacement(
     )
 
     theta = compute_turning_angle(data)
-    mean_cosine = cast("xr.DataArray", np.cos(theta)).mean(
-        dim="time", skipna=True
-    )
+    mean_cosine = xr.apply_ufunc(np.cos, theta).mean(dim="time", skipna=True)
 
     emax = mean_cosine / (1 - mean_cosine)
 

--- a/movement/kinematics/path.py
+++ b/movement/kinematics/path.py
@@ -572,11 +572,7 @@ def compute_maximum_expected_displacement(
     1. **Mean cosine of the turning angles.**
        :math:`\bar{c} = \overline{\cos\theta}` is the ``time`` average
        (ignoring ``NaN`` values) of the cosine of the turning angles
-       :math:`\theta` returned by :func:`compute_turning_angle`. Each
-       :math:`\theta` is the signed rotation from the backward
-       displacement step arriving at ``t-1`` to the step arriving at
-       ``t``, computed via
-       :func:`movement.utils.vector.compute_signed_angle_2d`. The first
+       :math:`\theta` returned by :func:`compute_turning_angle`. The first
        two time steps have no defined turning angle and so do not
        contribute.
     2. **Range.** :math:`E_{\max}^{(a)} \in [-0.5, \infty)`. While

--- a/movement/kinematics/path.py
+++ b/movement/kinematics/path.py
@@ -153,6 +153,8 @@ def compute_path_straightness(
     --------
     compute_path_length : The underlying function used to
         compute the path length :math:`L`.
+    compute_path_sinuosity :
+        A related turning-angle-based measure of path tortuosity.
     compute_maximum_expected_displacement :
         An alternative straightness measure derived from the
         turning-angle distribution which, unlike the :math:`D/L`
@@ -347,6 +349,7 @@ def compute_path_sinuosity(
     compute_path_length : Total distance travelled along a path.
     compute_path_straightness : Net displacement divided by path length.
     compute_turning_angle : Step-wise turning angle along a path.
+    compute_maximum_expected_displacement : Directional-persistence measure.
 
     Notes
     -----
@@ -567,6 +570,15 @@ def compute_maximum_expected_displacement(
         the same spatial units as ``data``; otherwise they are
         dimensionless.
 
+    See Also
+    --------
+    compute_turning_angle :
+        The underlying function used to compute the turning angles.
+    compute_path_sinuosity :
+        A related turning-angle-based measure of path tortuosity.
+    compute_path_straightness :
+        A related, path-length-based measure of straightness.
+
     Notes
     -----
     1. **Mean cosine of the turning angles.**
@@ -595,13 +607,6 @@ def compute_maximum_expected_displacement(
        (2007). Animal navigation: the difficulty of moving in a straight
        line. *Biological Cybernetics* 97(1), 47-61.
        https://doi.org/10.1007/s00422-007-0158-0
-
-    See Also
-    --------
-    compute_turning_angle :
-        The underlying function used to compute the turning angles.
-    compute_path_straightness :
-        A related, path-length-based measure of straightness.
 
     Examples
     --------

--- a/movement/kinematics/path.py
+++ b/movement/kinematics/path.py
@@ -624,21 +624,16 @@ def compute_maximum_expected_displacement(
     ... )
 
     """
-    data = _validate_time_points(data, "maximum expected displacement")
+    data = _validate_time_points(
+        data, metric_name="maximum expected displacement", min_points=3
+    )
 
     theta = compute_turning_angle(data)
     mean_cosine = cast("xr.DataArray", np.cos(theta)).mean(
         dim="time", skipna=True
     )
 
-    # mean_cosine -> 1 for a perfectly straight path, giving E_max -> +inf.
-    # Guard the division so the zero denominator does not emit a warning.
-    one_minus_c = 1 - mean_cosine
-    emax = xr.where(
-        one_minus_c == 0,
-        np.inf,
-        mean_cosine / one_minus_c.where(one_minus_c != 0),
-    )
+    emax = mean_cosine / (1 - mean_cosine)
 
     if in_spatial_units:
         emax = emax * _segment_lengths(data).mean(dim="time", skipna=True)

--- a/movement/kinematics/path.py
+++ b/movement/kinematics/path.py
@@ -516,6 +516,7 @@ def compute_directional_change(
 def compute_maximum_expected_displacement(
     data: xr.DataArray,
     in_spatial_units: bool = True,
+    nan_warn_threshold: float = 0.2,
 ) -> xr.DataArray:
     r"""Compute the maximum expected displacement (:math:`E_{\max}`).
 
@@ -552,6 +553,10 @@ def compute_maximum_expected_displacement(
         :math:`E_{\max}^{(b)}`, expressed in the same spatial units as
         ``data``. If ``False``, return the dimensionless variant
         :math:`E_{\max}^{(a)}`.
+    nan_warn_threshold
+        If any point track in the data has at least (:math:`\ge`)
+        this proportion of values missing, a warning will be emitted.
+        Defaults to 0.2 (20%).
 
     Returns
     -------
@@ -627,6 +632,8 @@ def compute_maximum_expected_displacement(
     data = _validate_time_points(
         data, metric_name="maximum expected displacement", min_points=3
     )
+
+    _warn_about_nan_proportion(data, nan_warn_threshold)
 
     theta = compute_turning_angle(data)
     mean_cosine = xr.apply_ufunc(np.cos, theta).mean(dim="time", skipna=True)

--- a/tests/test_unit/test_kinematics/test_path.py
+++ b/tests/test_unit/test_kinematics/test_path.py
@@ -7,8 +7,8 @@ import xarray as xr
 
 from movement.kinematics import (
     compute_directional_change,
+    compute_maximum_expected_displacement,
     compute_path_deviation,
-    compute_path_emax,
     compute_path_length,
     compute_path_sinuosity,
     compute_path_straightness,
@@ -281,7 +281,7 @@ def regular_triangle_path():
         pytest.param(compute_directional_change, id="directional-change"),
         pytest.param(compute_path_deviation, id="deviation"),
         pytest.param(compute_path_sinuosity, id="sinuosity"),
-        pytest.param(compute_path_emax, id="emax"),
+        pytest.param(compute_maximum_expected_displacement, id="emax"),
     ],
 )
 def test_path_metrics_across_time_ranges(
@@ -1037,7 +1037,7 @@ def test_path_sinuosity_outlier_step():
         ),
     ],
 )
-def test_path_emax_known_values(
+def test_maximum_expected_displacement_known_values(
     request, fixture_name, in_spatial_units, expected_value
 ):
     """Test E_max against paths with a constant turning angle.
@@ -1048,16 +1048,20 @@ def test_path_emax_known_values(
     negative part of the E_max range.
     """
     path = request.getfixturevalue(fixture_name)
-    result = compute_path_emax(path, in_spatial_units=in_spatial_units)
-    assert result.name == "path_emax"
+    result = compute_maximum_expected_displacement(
+        path, in_spatial_units=in_spatial_units
+    )
+    assert result.name == "maximum_expected_displacement"
     assert result.attrs["long_name"] == "Maximum Expected Displacement"
     assert np.isclose(result.item(), expected_value)
 
 
 @pytest.mark.parametrize("in_spatial_units", [False, True])
-def test_path_emax_straight_path_is_inf(straight_paths, in_spatial_units):
+def test_maximum_expected_displacement_straight_path_is_inf(
+    straight_paths, in_spatial_units
+):
     """A perfectly straight path has a mean cosine of 1, so E_max is +inf."""
-    result = compute_path_emax(
+    result = compute_maximum_expected_displacement(
         straight_paths, in_spatial_units=in_spatial_units
     )
     assert np.isinf(result).all()
@@ -1078,7 +1082,9 @@ def test_path_emax_straight_path_is_inf(straight_paths, in_spatial_units):
         ),
     ],
 )
-def test_path_emax_all_nan_output(positions, in_spatial_units):
+def test_maximum_expected_displacement_all_nan_output(
+    positions, in_spatial_units
+):
     """Test cases where E_max should be NaN: a stationary track has no
     valid turning angles, and two time points define no turning angle.
     """
@@ -1090,23 +1096,25 @@ def test_path_emax_all_nan_output(positions, in_spatial_units):
             "space": ["x", "y"],
         },
     )
-    result = compute_path_emax(data, in_spatial_units=in_spatial_units)
+    result = compute_maximum_expected_displacement(
+        data, in_spatial_units=in_spatial_units
+    )
     assert result.isnull().all()
 
 
-def test_path_emax_output_shape(straight_paths):
+def test_maximum_expected_displacement_output_shape(straight_paths):
     """Test that ``time`` and ``space`` are removed and other dimensions
     are preserved.
     """
-    result = compute_path_emax(straight_paths)
+    result = compute_maximum_expected_displacement(straight_paths)
     assert "space" not in result.dims
     assert "time" not in result.dims
     assert "individual" in result.dims
 
 
-def test_path_emax_raises_on_3d(straight_paths_3d):
+def test_maximum_expected_displacement_raises_on_3d(straight_paths_3d):
     """E_max is only defined for 2D data (inherited from turning angle)."""
     with pytest.raises(
         ValueError, match="Dimension 'space' must only contain"
     ):
-        compute_path_emax(straight_paths_3d)
+        compute_maximum_expected_displacement(straight_paths_3d)

--- a/tests/test_unit/test_kinematics/test_path.py
+++ b/tests/test_unit/test_kinematics/test_path.py
@@ -8,6 +8,7 @@ import xarray as xr
 from movement.kinematics import (
     compute_directional_change,
     compute_path_deviation,
+    compute_path_emax,
     compute_path_length,
     compute_path_sinuosity,
     compute_path_straightness,
@@ -190,6 +191,33 @@ def regular_zigzag_path():
 
 
 @pytest.fixture
+def regular_hexagon_path():
+    """Return a path tracing a regular hexagon with step length 2.
+
+    Every step turns by a constant 60 degrees, so the mean cosine of the
+    turning angles is cos(60 deg) = 0.5, giving E_max-a = 0.5 / (1 - 0.5)
+    = 1.0. With a constant step length of 2, E_max-b = 2.0.
+    """
+    r3 = np.sqrt(3)
+    positions = np.array(
+        [
+            [0.0, 0.0],
+            [2.0, 0.0],
+            [3.0, r3],
+            [2.0, 2 * r3],
+            [0.0, 2 * r3],
+            [-1.0, r3],
+            [0.0, 0.0],
+        ]
+    )
+    return xr.DataArray(
+        positions,
+        dims=["time", "space"],
+        coords={"time": np.arange(len(positions)), "space": ["x", "y"]},
+    )
+
+
+@pytest.fixture
 def scaled_zigzag_path(regular_zigzag_path):
     """Return the zigzag path with all positions scaled by a factor of 4.
 
@@ -213,6 +241,33 @@ def zigzag_path_with_nan(regular_zigzag_path):
     return path
 
 
+@pytest.fixture
+def regular_triangle_path():
+    """Return a path tracing a regular triangle with unit step length.
+
+    Every step turns by a constant 120 degrees, so the mean cosine of the
+    turning angles is cos(120 deg) = -0.5, giving E_max-a = -0.5 / 1.5 =
+    -1/3. This exercises the negative part of the E_max range.
+    """
+    r3 = np.sqrt(3)
+    positions = np.array(
+        [
+            [0.0, 0.0],
+            [1.0, 0.0],
+            [0.5, r3 / 2],
+            [0.0, 0.0],
+            [1.0, 0.0],
+            [0.5, r3 / 2],
+            [0.0, 0.0],
+        ]
+    )
+    return xr.DataArray(
+        positions,
+        dims=["time", "space"],
+        coords={"time": np.arange(len(positions)), "space": ["x", "y"]},
+    )
+
+
 # ─────────────────────────────────────────────
 # Cross-metric time-range tests
 # ─────────────────────────────────────────────
@@ -226,6 +281,7 @@ def zigzag_path_with_nan(regular_zigzag_path):
         pytest.param(compute_directional_change, id="directional-change"),
         pytest.param(compute_path_deviation, id="deviation"),
         pytest.param(compute_path_sinuosity, id="sinuosity"),
+        pytest.param(compute_path_emax, id="emax"),
     ],
 )
 def test_path_metrics_across_time_ranges(
@@ -960,3 +1016,88 @@ def test_path_sinuosity_outlier_step():
 
     assert not result.isnull().any()
     assert np.isfinite(result.item())
+
+
+# ─────────────────────────────────────────────
+# E_max tests
+# ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "fixture_name, in_spatial_units, expected_value",
+    [
+        pytest.param(
+            "regular_hexagon_path", False, 1.0, id="hexagon-dimensionless"
+        ),
+        pytest.param(
+            "regular_hexagon_path", True, 2.0, id="hexagon-spatial-units"
+        ),
+        pytest.param(
+            "regular_triangle_path", False, -1 / 3, id="triangle-negative"
+        ),
+    ],
+)
+def test_path_emax_known_values(
+    request, fixture_name, in_spatial_units, expected_value
+):
+    """Test E_max against paths with a constant turning angle.
+
+    For a constant turning angle the mean cosine is exactly its cosine,
+    so both E_max variants have closed-form values. The triangle case
+    (120 degree turns) has a negative mean cosine, exercising the
+    negative part of the E_max range.
+    """
+    path = request.getfixturevalue(fixture_name)
+    result = compute_path_emax(path, in_spatial_units=in_spatial_units)
+    assert result.name == "path_emax"
+    assert result.attrs["long_name"] == "Maximum Expected Displacement"
+    assert np.isclose(result.item(), expected_value)
+
+
+@pytest.mark.parametrize("in_spatial_units", [False, True])
+def test_path_emax_straight_path_is_inf(straight_paths, in_spatial_units):
+    """A perfectly straight path has a mean cosine of 1, so E_max is +inf."""
+    result = compute_path_emax(
+        straight_paths, in_spatial_units=in_spatial_units
+    )
+    assert np.isinf(result).all()
+    assert (result > 0).all()
+
+
+@pytest.mark.parametrize("in_spatial_units", [False, True])
+def test_path_emax_stationary_is_nan(stationary_paths, in_spatial_units):
+    """A stationary track has no valid turning angles, so E_max is NaN."""
+    result = compute_path_emax(
+        stationary_paths, in_spatial_units=in_spatial_units
+    )
+    assert result.isnull().all()
+
+
+@pytest.mark.parametrize("in_spatial_units", [False, True])
+def test_path_emax_two_timepoints_is_nan(straight_paths, in_spatial_units):
+    """With only two time points no turning angle is defined, so E_max
+    is NaN.
+    """
+    result = compute_path_emax(
+        straight_paths.isel(time=slice(0, 2)),
+        in_spatial_units=in_spatial_units,
+    )
+    assert result.isnull().all()
+
+
+def test_path_emax_output_shape(straight_paths):
+    """Test that ``time`` and ``space`` are removed and other dimensions
+    are preserved.
+    """
+    result = compute_path_emax(straight_paths)
+    assert "space" not in result.dims
+    assert "time" not in result.dims
+    assert "individual" in result.dims
+
+
+def test_path_emax_raises_on_3d(straight_paths_3d):
+    """E_max is only defined for 2D data (inherited from turning angle)."""
+    with pytest.raises(
+        ValueError, match="Dimension 'space' must only contain"
+    ):
+        compute_path_emax(straight_paths_3d)

--- a/tests/test_unit/test_kinematics/test_path.py
+++ b/tests/test_unit/test_kinematics/test_path.py
@@ -1065,23 +1065,32 @@ def test_path_emax_straight_path_is_inf(straight_paths, in_spatial_units):
 
 
 @pytest.mark.parametrize("in_spatial_units", [False, True])
-def test_path_emax_stationary_is_nan(stationary_paths, in_spatial_units):
-    """A stationary track has no valid turning angles, so E_max is NaN."""
-    result = compute_path_emax(
-        stationary_paths, in_spatial_units=in_spatial_units
-    )
-    assert result.isnull().all()
-
-
-@pytest.mark.parametrize("in_spatial_units", [False, True])
-def test_path_emax_two_timepoints_is_nan(straight_paths, in_spatial_units):
-    """With only two time points no turning angle is defined, so E_max
-    is NaN.
+@pytest.mark.parametrize(
+    "positions",
+    [
+        pytest.param(
+            [[5.0, 5.0], [5.0, 5.0], [5.0, 5.0], [5.0, 5.0]],
+            id="stationary",
+        ),
+        pytest.param(
+            [[0.0, 0.0], [1.0, 0.0]],
+            id="only_two_timepoints",
+        ),
+    ],
+)
+def test_path_emax_all_nan_output(positions, in_spatial_units):
+    """Test cases where E_max should be NaN: a stationary track has no
+    valid turning angles, and two time points define no turning angle.
     """
-    result = compute_path_emax(
-        straight_paths.isel(time=slice(0, 2)),
-        in_spatial_units=in_spatial_units,
+    data = xr.DataArray(
+        np.array(positions),
+        dims=["time", "space"],
+        coords={
+            "time": np.arange(len(positions)),
+            "space": ["x", "y"],
+        },
     )
+    result = compute_path_emax(data, in_spatial_units=in_spatial_units)
     assert result.isnull().all()
 
 

--- a/tests/test_unit/test_kinematics/test_path.py
+++ b/tests/test_unit/test_kinematics/test_path.py
@@ -1076,18 +1076,12 @@ def test_maximum_expected_displacement_straight_path_is_inf(
             [[5.0, 5.0], [5.0, 5.0], [5.0, 5.0], [5.0, 5.0]],
             id="stationary",
         ),
-        pytest.param(
-            [[0.0, 0.0], [1.0, 0.0]],
-            id="only_two_timepoints",
-        ),
     ],
 )
 def test_maximum_expected_displacement_all_nan_output(
     positions, in_spatial_units
 ):
-    """Test cases where E_max should be NaN: a stationary track has no
-    valid turning angles, and two time points define no turning angle.
-    """
+    """A stationary track has no valid turning angles, so E_max is NaN."""
     data = xr.DataArray(
         np.array(positions),
         dims=["time", "space"],
@@ -1100,6 +1094,14 @@ def test_maximum_expected_displacement_all_nan_output(
         data, in_spatial_units=in_spatial_units
     )
     assert result.isnull().all()
+
+
+def test_maximum_expected_displacement_too_few_timepoints(straight_paths):
+    """E_max needs at least 3 time points for one valid turning angle."""
+    # Slice the data to exactly 2 time points (which is only 1 segment)
+    position = straight_paths.isel(time=slice(0, 2))
+    with pytest.raises(ValueError, match="3 time points are required"):
+        compute_maximum_expected_displacement(position)
 
 
 def test_maximum_expected_displacement_output_shape(straight_paths):

--- a/tests/test_unit/test_kinematics/test_path.py
+++ b/tests/test_unit/test_kinematics/test_path.py
@@ -7,8 +7,8 @@ import xarray as xr
 
 from movement.kinematics import (
     compute_directional_change,
-    compute_maximum_expected_displacement,
     compute_path_deviation,
+    compute_path_emax,
     compute_path_length,
     compute_path_sinuosity,
     compute_path_straightness,
@@ -281,7 +281,7 @@ def regular_triangle_path():
         pytest.param(compute_directional_change, id="directional-change"),
         pytest.param(compute_path_deviation, id="deviation"),
         pytest.param(compute_path_sinuosity, id="sinuosity"),
-        pytest.param(compute_maximum_expected_displacement, id="emax"),
+        pytest.param(compute_path_emax, id="emax"),
     ],
 )
 def test_path_metrics_across_time_ranges(
@@ -1037,7 +1037,7 @@ def test_path_sinuosity_outlier_step():
         ),
     ],
 )
-def test_maximum_expected_displacement_known_values(
+def test_path_emax_known_values(
     request, fixture_name, in_spatial_units, expected_value
 ):
     """Test E_max against paths with a constant turning angle.
@@ -1048,20 +1048,16 @@ def test_maximum_expected_displacement_known_values(
     negative part of the E_max range.
     """
     path = request.getfixturevalue(fixture_name)
-    result = compute_maximum_expected_displacement(
-        path, in_spatial_units=in_spatial_units
-    )
+    result = compute_path_emax(path, in_spatial_units=in_spatial_units)
     assert result.name == "maximum_expected_displacement"
     assert result.attrs["long_name"] == "Maximum Expected Displacement"
     assert np.isclose(result.item(), expected_value)
 
 
 @pytest.mark.parametrize("in_spatial_units", [False, True])
-def test_maximum_expected_displacement_straight_path_is_inf(
-    straight_paths, in_spatial_units
-):
+def test_path_emax_straight_path_is_inf(straight_paths, in_spatial_units):
     """A perfectly straight path has a mean cosine of 1, so E_max is +inf."""
-    result = compute_maximum_expected_displacement(
+    result = compute_path_emax(
         straight_paths, in_spatial_units=in_spatial_units
     )
     assert np.isinf(result).all()
@@ -1078,9 +1074,7 @@ def test_maximum_expected_displacement_straight_path_is_inf(
         ),
     ],
 )
-def test_maximum_expected_displacement_all_nan_output(
-    positions, in_spatial_units
-):
+def test_path_emax_all_nan_output(positions, in_spatial_units):
     """A stationary track has no valid turning angles, so E_max is NaN."""
     data = xr.DataArray(
         np.array(positions),
@@ -1090,42 +1084,40 @@ def test_maximum_expected_displacement_all_nan_output(
             "space": ["x", "y"],
         },
     )
-    result = compute_maximum_expected_displacement(
-        data, in_spatial_units=in_spatial_units
-    )
+    result = compute_path_emax(data, in_spatial_units=in_spatial_units)
     assert result.isnull().all()
 
 
-def test_maximum_expected_displacement_nan_warning(straight_paths):
+def test_path_emax_nan_warning(straight_paths):
     """Test that fully missing tracks warn and yield NaN E_max."""
     position = straight_paths.copy()
     position[:] = np.nan
     with pytest.warns(UserWarning, match="The result may be unreliable"):
-        result = compute_maximum_expected_displacement(position)
+        result = compute_path_emax(position)
     assert result.isnull().all()
 
 
-def test_maximum_expected_displacement_too_few_timepoints(straight_paths):
+def test_path_emax_too_few_timepoints(straight_paths):
     """E_max needs at least 3 time points for one valid turning angle."""
     # Slice the data to exactly 2 time points (which is only 1 segment)
     position = straight_paths.isel(time=slice(0, 2))
     with pytest.raises(ValueError, match="3 time points are required"):
-        compute_maximum_expected_displacement(position)
+        compute_path_emax(position)
 
 
-def test_maximum_expected_displacement_output_shape(straight_paths):
+def test_path_emax_output_shape(straight_paths):
     """Test that ``time`` and ``space`` are removed and other dimensions
     are preserved.
     """
-    result = compute_maximum_expected_displacement(straight_paths)
+    result = compute_path_emax(straight_paths)
     assert "space" not in result.dims
     assert "time" not in result.dims
     assert "individual" in result.dims
 
 
-def test_maximum_expected_displacement_raises_on_3d(straight_paths_3d):
+def test_path_emax_raises_on_3d(straight_paths_3d):
     """E_max is only defined for 2D data (inherited from turning angle)."""
     with pytest.raises(
         ValueError, match="Dimension 'space' must only contain"
     ):
-        compute_maximum_expected_displacement(straight_paths_3d)
+        compute_path_emax(straight_paths_3d)

--- a/tests/test_unit/test_kinematics/test_path.py
+++ b/tests/test_unit/test_kinematics/test_path.py
@@ -1096,6 +1096,15 @@ def test_maximum_expected_displacement_all_nan_output(
     assert result.isnull().all()
 
 
+def test_maximum_expected_displacement_nan_warning(straight_paths):
+    """Test that fully missing tracks warn and yield NaN E_max."""
+    position = straight_paths.copy()
+    position[:] = np.nan
+    with pytest.warns(UserWarning, match="The result may be unreliable"):
+        result = compute_maximum_expected_displacement(position)
+    assert result.isnull().all()
+
+
 def test_maximum_expected_displacement_too_few_timepoints(straight_paths):
     """E_max needs at least 3 time points for one valid turning angle."""
     # Slice the data to exactly 2 time points (which is only 1 segment)


### PR DESCRIPTION
Adds `compute_maximum_expected_displacement` (Cheung 2007's E_max) to `movement.kinematics.path`.

## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
E_max is a straightness measure that quantifies how far an animal is expected to travel given its observed distribution of turning angles and step lengths; assuming it navigates without an external directional reference (e.g. no compass, no landmark)



**What does this PR do?**

  - `E_max⁽ᵃ⁾ = c̄ / (1 − c̄)` with `c̄ = nanmean(cos θ)` over turning angles (dimensionless), and `E_max⁽ᵇ⁾ = p̄ ·
  E_max⁽ᵃ⁾` scaled by mean step length (spatial units).
  - `in_spatial_units=True` (default) → spatial variant; `False` → dimensionless. Default follows your steer in #905
  (most users stay within one species/setup).
  - Light-touch per the 2026-06-12 community call: no `min_step_length`, `nan_warn_threshold`, or `nan_policy`.
  `in_degrees` is deliberately **not** exposed — `cos θ` requires radians.

## References
- Closes #905
- Related to #406 
- Link to [Zulip](https://neuroinformatics.zulipchat.com/#narrow/channel/406001-Movement/topic/Potential.20trajectory.20complexity.20metrics/with/596429211)

Cheung, A., Zhang, S., Stricker, C. & Srinivasan, M. V. (2007). Animal navigation: the difficulty of moving in a straight line. *Biological Cybernetics* 97(1), 47-61. https://doi.org/10.1007/s00422-007-0158-0

## How has this PR been tested?
Created new parametrized test functions in `tests/test_unit/test_kinematics/test_path.py`:

## Is this a breaking change?
No

## Does this PR require an update to the documentation?

Added a self contained docstring

### Naming — question + my suggestion
Following #1021 (`directional_change` → `turning_angle_rate`, moving off opaque paper labels), I've named the function
**`compute_maximum_expected_displacement`** rather than `compute_path_emax`. It's self-documenting, matches
`long_name="Maximum Expected Displacement"`, and sits in the same vocabulary as `compute_*_displacement`; `E_max` / 
trajr's `TrajEmax` stay in the docstring first line + Notes for discoverability. The scale toggle is **`in_spatial_units`** (mirrors `in_degrees`), replacing the `emax_b` name you flagged.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
