### PR TITLE
A single Zenodo link leading to multiple movement posters

### DIFF
--- a/docs/source/community/resources.md
+++ b/docs/source/community/resources.md
@@ -82,7 +82,7 @@ A selection of talks, posters, and blogposts about `movement`.
 
 | Type | Venue | Date | Link |
 |-------|-------|------|------|
-| Poster  | Multiple conferences | Apr 2025 -- Jul 2026| [PDFs on Zenodo](https://doi.org/10.5281/zenodo.17924159) |
+| Poster  | Multiple conferences | Apr 2025 onwards | [PDFs on Zenodo](https://doi.org/10.5281/zenodo.17924159) |
 | Talk  | [TheBehaviourForum](https://www.thebehaviourforum.org) Virtual Workshop | Apr 2026 | [Video on YouTube](https://www.youtube.com/watch?v=RUDhXB1ZZIg) |
 | Talk  | [FOSDEM 2026](https://fosdem.org/2026/schedule/) | Jan 2026 | [Video on fosdem.org](https://fosdem.org/2026/schedule/event/9VLSXV-movement-tracks-python/) |
 | Talk  | [CBIAS 2025](https://www.crick.ac.uk/whats-on/crick-bioimage-analysis-symposium-2025) | Nov 2025 | [Slides](https://neuroinformatics.dev/slides-movement-cbias2025/) |

--- a/docs/source/community/resources.md
+++ b/docs/source/community/resources.md
@@ -82,11 +82,11 @@ A selection of talks, posters, and blogposts about `movement`.
 
 | Type | Venue | Date | Link |
 |-------|-------|------|------|
+| Poster  | Multiple conferences | Apr 2025 -- Jul 2026| [PDFs on Zenodo](https://doi.org/10.5281/zenodo.17924159) |
 | Talk  | [TheBehaviourForum](https://www.thebehaviourforum.org) Virtual Workshop | Apr 2026 | [Video on YouTube](https://www.youtube.com/watch?v=RUDhXB1ZZIg) |
 | Talk  | [FOSDEM 2026](https://fosdem.org/2026/schedule/) | Jan 2026 | [Video on fosdem.org](https://fosdem.org/2026/schedule/event/9VLSXV-movement-tracks-python/) |
 | Talk  | [CBIAS 2025](https://www.crick.ac.uk/whats-on/crick-bioimage-analysis-symposium-2025) | Nov 2025 | [Slides](https://neuroinformatics.dev/slides-movement-cbias2025/) |
 | Blogpost  | [UCL-ARC Showcase](https://www.ucl.ac.uk/advanced-research-computing/arc-showcase) | May 2025 | [URL](https://www.ucl.ac.uk/advanced-research-computing/case-studies/2025/may/movement-python-package-simplifies-analysis-animals-motion) |
-| Poster  | [ASAB Spring 2025](https://asabspring2025.github.io) | Apr 2025 | [PDF on Zenodo](https://doi.org/10.5281/zenodo.17924159) |
 | Talk  | [ABIDE](https://abide.ics.ulisboa.pt/en/) Seminar | Feb 2025 | [Video on YouTube](https://www.youtube.com/watch?v=GXBQsqqZZTg) |
 
 


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other: website

**Why is this PR needed?**

We keep track of posters/presentation in https://movement.neuroinformatics.dev/latest/community/resources.html.

I wanted to add the latest up-to-date poster (presented at FENS 2026).

**What does this PR do?**

We already had a link to the ASAB-spring 2025 poster (archived on Zenodo). I could have replaced that table row, or added a separate Zenodo archive and link for FENS.
I thought neither is a scalable strategy, as it would require to update the resources table for every new poster (and lead to a proliferation of Zenodo records).

Instead, I opted for making a new version of the existing Zenodo record, this one containing both posters.

The doi linked via the resource table will always resolve to the latest version of the Zenodo record, which contains all publicly shared posters to date. As long as we keep updating the Zenodo record with new poster we want to share, no further changes will be necessary to the resources table.

The only downside is that there is no single 'venue' or 'date' that corresponds to the 'Poster' entry. I went with 'Multiple conferences' and 'Apr 2025 onwards'. It may read slightly weird, but I think it's worth it (because it obviates the need to update the table for each new poster). Let me know if you have a better suggestion.

<img width="771" height="438" alt="image" src="https://github.com/user-attachments/assets/b3a9b3ff-f377-4b96-ad9e-1a52ad02d83f" />


## References

N/A

## How has this PR been tested?

Local docs build.

## Is this a breaking change?

No. The old ASAB poster is still accessible on Zenodo.

## Does this PR require an update to the documentation?

N/A.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
