### PR TITLE
Add `keep_points_with_nan_confidence` kwarg to `filter_by_confidence`

### DIFF
--- a/movement/filtering.py
+++ b/movement/filtering.py
@@ -15,12 +15,15 @@ def filter_by_confidence(
     data: xr.DataArray,
     confidence: xr.DataArray,
     threshold: float = 0.6,
+    keep_points_with_nan_confidence: bool = True,
     print_report: bool = False,
 ) -> xr.DataArray:
     """Drop data points below a certain confidence threshold.
 
     Data points with an associated confidence value below the threshold are
-    converted to NaN.
+    converted to NaN. Data points with a missing (NaN) confidence value are
+    kept by default, but this can be changed via
+    ``keep_points_with_nan_confidence``.
 
     Parameters
     ----------
@@ -31,6 +34,9 @@ def filter_by_confidence(
     threshold
         The confidence threshold below which datapoints are filtered.
         A default value of ``0.6`` is used. See notes for more information.
+    keep_points_with_nan_confidence
+        Whether to keep data points whose confidence value is NaN.
+        Default is ``True``. See notes for more information.
     print_report
         Whether to print a report on the number of NaNs in the dataset
         before and after filtering. Default is ``False``.
@@ -52,8 +58,18 @@ def filter_by_confidence(
     pose estimation frameworks. We advise users to inspect the confidence
     values in their dataset and adjust the threshold accordingly.
 
+    A missing (NaN) confidence value may mean that the point was manually
+    annotated or edited, and therefore has no associated model confidence.
+    For example, this is the case for points proof-read in SLEAP. Such
+    points are the ones we should be most confident about, so they are kept
+    by default. Set ``keep_points_with_nan_confidence=False`` to drop them
+    instead.
+
     """
-    data_filtered = data.where(confidence >= threshold)
+    keep = confidence >= threshold
+    if keep_points_with_nan_confidence:
+        keep = keep | confidence.isnull()
+    data_filtered = data.where(keep)
     if print_report:
         print(report_nan_values(data, "input"))
         print(report_nan_values(data_filtered, "output"))

--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -10,6 +10,7 @@ from movement.filtering import (
     rolling_filter,
     savgol_filter,
 )
+from movement.io import load_poses
 
 # Dataset fixtures
 list_valid_datasets_without_nans = [
@@ -323,3 +324,36 @@ def test_filter_by_confidence_with_nan_confidence(
     assert helpers.count_nans(position_filtered) == (
         valid_input_dataset.sizes["space"] * n_expected_dropped_pts
     )
+
+
+@pytest.mark.parametrize(
+    "keep_points_with_nan_confidence",
+    [
+        pytest.param(True, id="keep proof-read points (default)"),
+        pytest.param(False, id="drop proof-read points"),
+    ],
+)
+def test_filter_by_confidence_on_proofread_data(
+    sleap_analysis_file, keep_points_with_nan_confidence, helpers
+):
+    """Test filtering by confidence on manually proof-read SLEAP data.
+
+    All points in this dataset were proof-read in SLEAP, and therefore
+    have a missing (NaN) confidence value despite holding a valid position.
+    Such points should survive filtering by default.
+    """
+    ds = load_poses.from_sleap_file(sleap_analysis_file)
+    # Verify all points are proof-read, i.e. NaN confidence, valid position
+    assert ds.confidence.isnull().all()
+    assert ds.position.notnull().all()
+
+    position_filtered = filter_by_confidence(
+        ds.position,
+        ds.confidence,
+        keep_points_with_nan_confidence=keep_points_with_nan_confidence,
+    )
+    # All points are kept by default, and dropped otherwise
+    expected_n_nans = (
+        0 if keep_points_with_nan_confidence else ds.position.size
+    )
+    assert helpers.count_nans(position_filtered) == expected_n_nans

--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -1,5 +1,6 @@
 from contextlib import nullcontext as does_not_raise
 
+import numpy as np
 import pytest
 import xarray as xr
 
@@ -279,3 +280,46 @@ def test_filter_by_confidence_on_position(
     n_low_confidence_kpts = 5
     assert isinstance(position_filtered, xr.DataArray)
     assert n_nans == valid_input_dataset.sizes["space"] * n_low_confidence_kpts
+
+
+@pytest.mark.parametrize(
+    "valid_dataset_no_nans",
+    list_valid_datasets_without_nans,
+)
+@pytest.mark.parametrize(
+    "keep_points_with_nan_confidence",
+    [
+        pytest.param(True, id="keep NaN-confidence points (default)"),
+        pytest.param(False, id="drop NaN-confidence points"),
+    ],
+)
+def test_filter_by_confidence_with_nan_confidence(
+    valid_dataset_no_nans, keep_points_with_nan_confidence, helpers, request
+):
+    """Test the handling of NaN confidence values.
+
+    Points with NaN confidence (e.g. manually edited ones) should survive
+    filtering by default, but are dropped if the
+    ``keep_points_with_nan_confidence`` argument is set to ``False``.
+    """
+    valid_input_dataset = request.getfixturevalue(valid_dataset_no_nans)
+    # Set the confidence of individual id_0 at times 0 and 1 to NaN,
+    # on top of the 5 pre-existing low-confidence points
+    confidence = valid_input_dataset.confidence.copy()
+    confidence.loc[{"time": [0, 1], "individual": "id_0"}] = np.nan
+    n_nan_confidence_pts = helpers.count_nans(confidence)
+    position_filtered = filter_by_confidence(
+        valid_input_dataset.position,
+        confidence=confidence,
+        threshold=0.6,
+        keep_points_with_nan_confidence=keep_points_with_nan_confidence,
+    )
+    # Only the low-confidence points are dropped if NaNs are kept,
+    # otherwise the NaN-confidence points are dropped as well
+    n_low_confidence_pts = 5
+    n_expected_dropped_pts = n_low_confidence_pts + (
+        0 if keep_points_with_nan_confidence else n_nan_confidence_pts
+    )
+    assert helpers.count_nans(position_filtered) == (
+        valid_input_dataset.sizes["space"] * n_expected_dropped_pts
+    )

--- a/tests/test_unit/test_filtering.py
+++ b/tests/test_unit/test_filtering.py
@@ -2,7 +2,6 @@ from contextlib import nullcontext as does_not_raise
 
 import numpy as np
 import pytest
-import xarray as xr
 
 from movement.filtering import (
     filter_by_confidence,
@@ -260,69 +259,26 @@ class TestFilteringValidDatasetWithNaNs:
 def test_filter_by_confidence_on_position(
     valid_dataset_no_nans, helpers, request
 ):
-    """Test that points below the default 0.6 confidence threshold
-    are converted to NaN.
-    """
-    # Filter position by confidence
-    valid_input_dataset = request.getfixturevalue(valid_dataset_no_nans)
-    position_filtered = filter_by_confidence(
-        valid_input_dataset.position,
-        confidence=valid_input_dataset.confidence,
-        threshold=0.6,
-        print_report=True,
-    )
-    # Count number of NaNs in the full array
-    n_nans = helpers.count_nans(position_filtered)
-    # expected number of nans for poses:
-    # 5 timepoints * 2 individuals * 2 keypoints
-    # Note: we count the number of nans in the array, so we multiply
-    # the number of low confidence keypoints by the number of
-    # space dimensions
-    n_low_confidence_kpts = 5
-    assert isinstance(position_filtered, xr.DataArray)
-    assert n_nans == valid_input_dataset.sizes["space"] * n_low_confidence_kpts
-
-
-@pytest.mark.parametrize(
-    "valid_dataset_no_nans",
-    list_valid_datasets_without_nans,
-)
-@pytest.mark.parametrize(
-    "keep_points_with_nan_confidence",
-    [
-        pytest.param(True, id="keep NaN-confidence points (default)"),
-        pytest.param(False, id="drop NaN-confidence points"),
-    ],
-)
-def test_filter_by_confidence_with_nan_confidence(
-    valid_dataset_no_nans, keep_points_with_nan_confidence, helpers, request
-):
-    """Test the handling of NaN confidence values.
-
-    Points with NaN confidence (e.g. manually edited ones) should survive
-    filtering by default, but are dropped if the
-    ``keep_points_with_nan_confidence`` argument is set to ``False``.
+    """Test that points below the 0.6 confidence threshold are converted
+    to NaN, whereas points with a NaN confidence value are kept.
     """
     valid_input_dataset = request.getfixturevalue(valid_dataset_no_nans)
     # Set the confidence of individual id_0 at times 0 and 1 to NaN,
     # on top of the 5 pre-existing low-confidence points
     confidence = valid_input_dataset.confidence.copy()
     confidence.loc[{"time": [0, 1], "individual": "id_0"}] = np.nan
-    n_nan_confidence_pts = helpers.count_nans(confidence)
+    # Filter position by confidence
     position_filtered = filter_by_confidence(
         valid_input_dataset.position,
         confidence=confidence,
         threshold=0.6,
-        keep_points_with_nan_confidence=keep_points_with_nan_confidence,
+        print_report=True,
     )
-    # Only the low-confidence points are dropped if NaNs are kept,
-    # otherwise the NaN-confidence points are dropped as well
+    # Only the 5 low-confidence points are dropped, as points with a
+    # NaN confidence value are kept by default.
     n_low_confidence_pts = 5
-    n_expected_dropped_pts = n_low_confidence_pts + (
-        0 if keep_points_with_nan_confidence else n_nan_confidence_pts
-    )
     assert helpers.count_nans(position_filtered) == (
-        valid_input_dataset.sizes["space"] * n_expected_dropped_pts
+        valid_input_dataset.sizes["space"] * n_low_confidence_pts
     )
 
 


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Closes #1026, see that issue for context on why this change is necessary and why it has become timely now.

Specifically, this PR implements the 'short-term' solution mentioned in that issue. The 'long-term' solution is described separately in #1027.

**What does this PR do?**

Adds a new optional keyword argument (kwarg) to the `filter_by_confidence` function:

```rst
  keep_points_with_nan_confidence
      Whether to keep data points whose confidence value is NaN.
      Default is ``True``. See notes for more information.
```

The `True` default means that points proof-read in SLEAP or `movement` (upcoming feature) will not be dropped during filtering. I think this default makes sense, since these are the points we should trust most.

I would like feedback on the name of the new kwarg. I went for long and explicit, but if you can think of an alternative, let me know.

## References

#1026
#1027

## How has this PR been tested?

I added a new test—`test_filter_by_confidence_on_proofread_data`—using an existing SLEAP fixture containing a fully proofread dataset (with nan confidences).

I also modified the existing `test_filter_by_confidence_on_position` test to introduce a single NaN confidence, so I can verify that point is not dropped by default.

All tests pass locally, with 100% coverage.

I also built the docs locally and inspected the API reference for `filter_by_confidence` and the examples in which the function was used.

## Is this a breaking change?

Yes! The default behaviour of `filter_by_confidence` is changed by this PR.

The older behaviour can be still recovered by setting `keep_points_with_nan_confidence=False`.

## Does this PR require an update to the documentation?

I added a new note to the docstring of `filter_by_confidence`.

The API reference has been updated automatically.

I examined whether any examples needed updating, but this was not the case, because no no example was applying `filter_by_confidence` to a dataset with NaN confidence values.

As far as I know the only such datasets among our sample data are `SLEAP_three-mice_Aeon_proofread.analysis.h5/.slp` (fully proofread, all confidence values are NaN) and `SLEAP_three-mice_Aeon_mixed-labels.analysis.h5/.slp` (partly edited, a few confidence values are NaN).

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
