### PR TITLE
Fix `ValidPosesInputs.to_dataset` for datasets with individual-wise confidence arrays

### DIFF
--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -420,12 +420,21 @@ class ValidPosesInputs(_BaseDatasetInputs):
             time_unit = "frames"
         dataset_attrs["time_unit"] = time_unit
         DIM_NAMES = self.DIM_NAMES
+        # confidence_array may be point-wise (all non-space dims) or
+        # individual-wise (non-space and non-keypoint dims)
+        confidence_dims = tuple(d for d in DIM_NAMES if d != "space")
+        # Ignore type error as ValidPosesInputs ensures
+        # `confidence_array` is not None
+        if self.confidence_array.ndim == 2:  # type: ignore[union-attr]
+            confidence_dims = tuple(
+                d for d in confidence_dims if d != "keypoint"
+            )
         # Convert data to an xarray.Dataset
         return xr.Dataset(
             data_vars={
                 "position": xr.DataArray(self.position_array, dims=DIM_NAMES),
                 "confidence": xr.DataArray(
-                    self.confidence_array, dims=DIM_NAMES[:1] + DIM_NAMES[2:]
+                    self.confidence_array, dims=confidence_dims
                 ),
             },
             coords={

--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -402,8 +402,9 @@ class ValidPosesInputs(_BaseDatasetInputs):
             and associated metadata.
 
         """
-        n_frames = self.position_array.shape[0]
-        n_space = self.position_array.shape[1]
+        DIM_NAMES = self.DIM_NAMES
+        n_frames = self.position_array.shape[DIM_NAMES.index("time")]
+        n_space = self.position_array.shape[DIM_NAMES.index("space")]
         dataset_attrs: dict[str, str | float | None] = {
             "source_software": self.source_software,
             "ds_type": "poses",
@@ -419,7 +420,6 @@ class ValidPosesInputs(_BaseDatasetInputs):
             time_coords = np.arange(n_frames, dtype=np.int64)
             time_unit = "frames"
         dataset_attrs["time_unit"] = time_unit
-        DIM_NAMES = self.DIM_NAMES
         # confidence_array may be point-wise (all non-space dims) or
         # individual-wise (non-space and non-keypoint dims)
         confidence_dims = tuple(d for d in DIM_NAMES if d != "space")
@@ -579,7 +579,7 @@ class ValidBboxesInputs(_BaseDatasetInputs):
         # Convert data to an xarray.Dataset
         # with dimensions ('time', 'space', 'individual')
         DIM_NAMES = self.DIM_NAMES
-        n_space = self.position_array.shape[1]
+        n_space = self.position_array.shape[DIM_NAMES.index("space")]
         return xr.Dataset(
             data_vars={
                 "position": xr.DataArray(self.position_array, dims=DIM_NAMES),

--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -73,10 +73,9 @@ class _BaseDatasetInputs(ABC):
         default=None,
         validator=validators.optional(validators.instance_of(np.ndarray)),
     )
-    """Array containing point-wise confidence scores for the position data.
-    The shape of this array is the same as that of ``position_array``, but
-    without the ``space`` dimension. If None (default), the confidence scores
-    will be set to an array of NaNs."""
+    """Array containing confidence scores for the position data. The expected
+    shape depends on the subclass - see its class docstring for details. If
+    None (default), the confidence scores will be set to an array of NaNs."""
 
     individual_names: list[str] | None = field(
         default=None,

--- a/tests/test_unit/test_validators/test_datasets_validators.py
+++ b/tests/test_unit/test_validators/test_datasets_validators.py
@@ -347,8 +347,20 @@ class TestValidPosesInputs:
             assert data.keypoint_names == expected_keypoint_names
 
     @pytest.mark.parametrize("fps", [30, None])
-    def test_to_dataset(self, fps, valid_poses_dataset):
+    @pytest.mark.parametrize(
+        "dataset_fixture",
+        [
+            "valid_poses_dataset",
+            "valid_poses_dataset_with_individual_wise_confidence",
+        ],
+        ids=[
+            "Point-wise confidence array",
+            "Individual-wise confidence array",
+        ],
+    )
+    def test_to_dataset(self, fps, dataset_fixture, request):
         """Test to_dataset creates the expected poses dataset."""
+        valid_poses_dataset = request.getfixturevalue(dataset_fixture)
         ds = ValidPosesInputs(
             position_array=valid_poses_dataset.position.values,
             confidence_array=valid_poses_dataset.confidence.values,


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Closes #1038 

**What does this PR do?**
- replaces hardcoded 3D confidence array dim names to allow both 2D and 3D depending on `confidence_array.ndim`
- looks up indices by `DIM_NAME` when setting `n_space` and `n_frames` instead of hardcoding indices

## References
#1038 #989

## How has this PR been tested?
`to_dataset` test extended to cover valid poses dataset having individual-wise confidence array - uses existing `valid_poses_dataset_with_individual_wise_conf` fixture.

## Does this PR require an update to the documentation?
Updated `confidence_array` docstring of `_BaseDatasetInputs` to point to subclasses for accurate description of expected shape.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
