### PR TITLE
fix: handle individual-wise confidence in ValidPosesInputs.to_dataset

### DIFF
--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -420,12 +420,18 @@ class ValidPosesInputs(_BaseDatasetInputs):
             time_unit = "frames"
         dataset_attrs["time_unit"] = time_unit
         DIM_NAMES = self.DIM_NAMES
+        # Point-wise confidence is 3D (time, keypoint, individual); individual-wise
+        # confidence is 2D (time, individual) and skips the keypoint dimension.
+        if self.confidence_array.ndim == 2:
+            confidence_dims = DIM_NAMES[:1] + DIM_NAMES[3:]
+        else:
+            confidence_dims = DIM_NAMES[:1] + DIM_NAMES[2:]
         # Convert data to an xarray.Dataset
         return xr.Dataset(
             data_vars={
                 "position": xr.DataArray(self.position_array, dims=DIM_NAMES),
                 "confidence": xr.DataArray(
-                    self.confidence_array, dims=DIM_NAMES[:1] + DIM_NAMES[2:]
+                    self.confidence_array, dims=confidence_dims
                 ),
             },
             coords={

--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -420,8 +420,9 @@ class ValidPosesInputs(_BaseDatasetInputs):
             time_unit = "frames"
         dataset_attrs["time_unit"] = time_unit
         DIM_NAMES = self.DIM_NAMES
-        # Point-wise confidence is 3D (time, keypoint, individual); individual-wise
-        # confidence is 2D (time, individual) and skips the keypoint dimension.
+        # Point-wise confidence is 3D (time, keypoint, individual);
+        # individual-wise confidence is 2D (time, individual) and skips
+        # the keypoint dimension.
         if self.confidence_array.ndim == 2:
             confidence_dims = DIM_NAMES[:1] + DIM_NAMES[3:]
         else:

--- a/tests/test_unit/test_validators/test_datasets_validators.py
+++ b/tests/test_unit/test_validators/test_datasets_validators.py
@@ -366,6 +366,21 @@ class TestValidPosesInputs:
             expected_ds.time.attrs["units"] = "seconds"
             xr.testing.assert_equal(ds, expected_ds)
 
+    def test_to_dataset_individual_wise_confidence(self):
+        """to_dataset should handle 2D individual-wise confidence (issue #1038)."""
+        n_frames, n_space, n_keypoints, n_individuals = 5, 2, 3, 2
+        ds = ValidPosesInputs(
+            position_array=np.zeros(
+                (n_frames, n_space, n_keypoints, n_individuals)
+            ),
+            confidence_array=np.zeros((n_frames, n_individuals)),
+            individual_names=[f"id_{i}" for i in range(n_individuals)],
+            keypoint_names=[f"kp_{i}" for i in range(n_keypoints)],
+            source_software=None,
+        ).to_dataset()
+        assert ds["confidence"].dims == ("time", "individual")
+        assert ds["confidence"].shape == (n_frames, n_individuals)
+
     @pytest.mark.parametrize(
         "confidence_array, expected_context",
         [


### PR DESCRIPTION
Closes #1038.

`ValidPosesInputs.to_dataset()` hardcoded 3 confidence dims `(time, keypoint, individual)`, so a 2D individual-wise confidence array `(n_frames, n_individuals)` raised `ValueError: different number of dimensions on data and dims: 2 vs 3`. Pick the dims from the array's ndim. Adds a to_dataset test for the individual-wise case (existing to_dataset test only covered point-wise).