### PR TITLE
Adding edited properties to napari layers when a keypoint is dragged. 

### DIFF
--- a/movement/napari/convert.py
+++ b/movement/napari/convert.py
@@ -67,8 +67,9 @@ def ds_to_napari_layers(
         (track_id, frame, y, x). Returns None when the input dataset doesn't
         have a "shape" variable.
     properties : pandas.DataFrame
-        DataFrame with properties (individual, keypoint, time, confidence,
-        edited) for use with napari layers.
+        DataFrame with properties (individual, keypoint, time, confidence)
+        for use with napari layers. An ``edited`` column is also included
+        if the input dataset has an ``edited`` variable.
 
     See Also
     --------

--- a/movement/napari/convert.py
+++ b/movement/napari/convert.py
@@ -278,6 +278,7 @@ def napari_layers_to_ds(
                 individual=individual_coords,
             )
         )
+        edited_da = None
         if "edited" in properties_df.columns:
             edited_da = (
                 properties_df.set_index(["time", "keypoint", "individual"])[
@@ -291,8 +292,6 @@ def napari_layers_to_ds(
                     fill_value=False,
                 )
             )
-        else:
-            edited_da = xr.full_like(confidence_da, False, dtype=bool)
 
         position_df = position_df.melt(
             id_vars=["time", "frame", "keypoint", "individual"],
@@ -313,12 +312,15 @@ def napari_layers_to_ds(
             )
         )
 
+        data_vars = {
+            "position": position_da,
+            "confidence": confidence_da,
+        }
+        if edited_da is not None:
+            data_vars["edited"] = edited_da
+
         ds = xr.Dataset(
-            data_vars={
-                "position": position_da,
-                "confidence": confidence_da,
-                "edited": edited_da,
-            },
+            data_vars=data_vars,
             coords={
                 "time": time_coords,
                 "space": space_coords,
@@ -328,9 +330,10 @@ def napari_layers_to_ds(
             attrs=attrs if attrs is not None else {},
         )
         # Drop keypoints/individuals with no data left; never `time`.
-        # `edited` is excluded from the check: it's boolean (fill
-        # value False), so it's never "null" and would otherwise
-        # prevent any keypoint/individual from ever being dropped.
+        # `edited` (if present) is excluded from the check: it's
+        # boolean (fill value False), so it's never "null" and would
+        # otherwise prevent any keypoint/individual from ever being
+        # dropped.
         dropna_subset = ["position", "confidence"]
         ds = ds.dropna(dim="keypoint", how="all", subset=dropna_subset).dropna(
             dim="individual", how="all", subset=dropna_subset

--- a/movement/napari/convert.py
+++ b/movement/napari/convert.py
@@ -278,18 +278,21 @@ def napari_layers_to_ds(
                 individual=individual_coords,
             )
         )
-        edited_da = (
-            properties_df.set_index(["time", "keypoint", "individual"])[
-                "edited"
-            ]
-            .to_xarray()
-            .reindex(
-                time=time_coords,
-                keypoint=keypoint_coords,
-                individual=individual_coords,
-                fill_value=False,
+        if "edited" in properties_df.columns:
+            edited_da = (
+                properties_df.set_index(["time", "keypoint", "individual"])[
+                    "edited"
+                ]
+                .to_xarray()
+                .reindex(
+                    time=time_coords,
+                    keypoint=keypoint_coords,
+                    individual=individual_coords,
+                    fill_value=False,
+                )
             )
-        )
+        else:
+            edited_da = xr.full_like(confidence_da, False, dtype=bool)
 
         position_df = position_df.melt(
             id_vars=["time", "frame", "keypoint", "individual"],

--- a/movement/napari/convert.py
+++ b/movement/napari/convert.py
@@ -285,14 +285,13 @@ def napari_layers_to_ds(
                     "edited"
                 ]
                 .to_xarray()
-                .fillna(False)
-                .astype(bool)
                 .reindex(
                     time=time_coords,
                     keypoint=keypoint_coords,
                     individual=individual_coords,
-                    fill_value=False,
                 )
+                .fillna(False)
+                .astype(bool)
             )
 
         position_df = position_df.melt(

--- a/movement/napari/convert.py
+++ b/movement/napari/convert.py
@@ -18,6 +18,9 @@ def _construct_properties_dataframe(ds: xr.Dataset) -> pd.DataFrame:
     if "keypoint" in ds.coords:
         data["keypoint"] = ds.coords["keypoint"].values
         desired_order.insert(1, "keypoint")
+    if "edited" in ds:
+        data["edited"] = ds["edited"].values.flatten()
+        desired_order.append("edited")
 
     # sort
     return pd.DataFrame(data).reindex(columns=desired_order)
@@ -64,8 +67,8 @@ def ds_to_napari_layers(
         (track_id, frame, y, x). Returns None when the input dataset doesn't
         have a "shape" variable.
     properties : pandas.DataFrame
-        DataFrame with properties (individual, keypoint, time, confidence)
-        for use with napari layers.
+        DataFrame with properties (individual, keypoint, time, confidence,
+        edited) for use with napari layers.
 
     See Also
     --------
@@ -172,8 +175,8 @@ def napari_layers_to_ds(
     properties
         Live napari Point properties data. It is in-sync with the
         Points layer data. It is a dictionary with keys
-        ``individual``, ``keypoint``, ``time`` and ``confidence``,
-        each mapping to a list of values, and each value
+        ``individual``, ``keypoint``, ``time``, ``confidence`` and
+        ``edited``, each mapping to a list of values, and each value
         corresponding to a point.
     properties_with_nans:
         Properties DataFrame derived from the original loaded dataset
@@ -275,6 +278,18 @@ def napari_layers_to_ds(
                 individual=individual_coords,
             )
         )
+        edited_da = (
+            properties_df.set_index(["time", "keypoint", "individual"])[
+                "edited"
+            ]
+            .to_xarray()
+            .reindex(
+                time=time_coords,
+                keypoint=keypoint_coords,
+                individual=individual_coords,
+                fill_value=False,
+            )
+        )
 
         position_df = position_df.melt(
             id_vars=["time", "frame", "keypoint", "individual"],
@@ -299,6 +314,7 @@ def napari_layers_to_ds(
             data_vars={
                 "position": position_da,
                 "confidence": confidence_da,
+                "edited": edited_da,
             },
             coords={
                 "time": time_coords,
@@ -309,8 +325,12 @@ def napari_layers_to_ds(
             attrs=attrs if attrs is not None else {},
         )
         # Drop keypoints/individuals with no data left; never `time`.
-        ds = ds.dropna(dim="keypoint", how="all").dropna(
-            dim="individual", how="all"
+        # `edited` is excluded from the check: it's boolean (fill
+        # value False), so it's never "null" and would otherwise
+        # prevent any keypoint/individual from ever being dropped.
+        dropna_subset = ["position", "confidence"]
+        ds = ds.dropna(dim="keypoint", how="all", subset=dropna_subset).dropna(
+            dim="individual", how="all", subset=dropna_subset
         )
         if ds.sizes["keypoint"] == 0 or ds.sizes["individual"] == 0:
             raise logger.error(

--- a/movement/napari/convert.py
+++ b/movement/napari/convert.py
@@ -176,9 +176,9 @@ def napari_layers_to_ds(
     properties
         Live napari Point properties data. It is in-sync with the
         Points layer data. It is a dictionary with keys
-        ``individual``, ``keypoint``, ``time``, ``confidence`` and
-        ``edited``, each mapping to a list of values, and each value
-        corresponding to a point.
+        ``individual``, ``keypoint``, ``time`` and ``confidence``
+        (plus ``edited`` once any point has been dragged), each mapping
+        to a list of values, and each value corresponding to a point.
     properties_with_nans:
         Properties DataFrame derived from the original loaded dataset
         including any NaN position data.

--- a/movement/napari/convert.py
+++ b/movement/napari/convert.py
@@ -285,6 +285,8 @@ def napari_layers_to_ds(
                     "edited"
                 ]
                 .to_xarray()
+                .fillna(False)
+                .astype(bool)
                 .reindex(
                     time=time_coords,
                     keypoint=keypoint_coords,

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -350,11 +350,12 @@ class DataLoader(QWidget):
         logger.info("Added tracked dataset as a napari Points layer.")
 
     def _on_points_data_changed(self, event):
-        """Set confidence to NaN for moved (dragged) points.
+        """Set confidence to NaN and flag as edited for moved points.
 
         Connected to ``points_layer.events.data``. Fires on
         ``ActionType.CHANGED`` (i.e., when the data array values
-        change) and sets the confidence score of moved points to NaN.
+        change) and sets the confidence score of moved (dragged)
+        points to NaN, and marks them as edited.
         """
         layer = event.source
         if not isinstance(layer, Points):
@@ -365,6 +366,11 @@ class DataLoader(QWidget):
         props = layer.properties
         props["confidence"] = props["confidence"].copy()
         props["confidence"][moved_indices] = float("nan")
+        if "edited" in props:
+            props["edited"] = props["edited"].copy()
+        else:
+            props["edited"] = np.full(len(props["confidence"]), False)
+        props["edited"][moved_indices] = True
         layer.properties = props
 
     def _add_tracks_layer(self):

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -330,28 +330,31 @@ def test_valid_poses_roundtrip_napari_layer_to_dataset(ds_dataset, request):
     )
 
 
-@pytest.mark.parametrize(
-    "nan_location",
-    [
-        None,
-        # no NaNs
-        {
-            "time": "start",
-            "individual": ["id_0", "id_1"],
-            "keypoint": ["centroid", "left", "right"],
-        },  # all individuals are nan at the start
-        {
-            "time": "end",
-            "individual": ["id_0", "id_1"],
-            "keypoint": ["centroid", "left", "right"],
-        },  # all individuals are nan at the end
-        {
-            "time": "middle",
-            "individual": ["id_0"],
-            "keypoint": ["centroid"],
-        },  # a single keypoint of an individual is nan mid-sequence
-    ],
-)
+# NaN scenarios shared by the napari-layer round-trip tests below.
+# Each entry is passed to ``valid_poses_path_and_ds_with_localised_nans``
+# (or is ``None`` for the no-NaN case) to place missing data at a known
+# location.
+NAN_LOCATIONS = [
+    None,  # no NaNs
+    {
+        "time": "start",
+        "individual": ["id_0", "id_1"],
+        "keypoint": ["centroid", "left", "right"],
+    },  # all individuals are nan at the start
+    {
+        "time": "end",
+        "individual": ["id_0", "id_1"],
+        "keypoint": ["centroid", "left", "right"],
+    },  # all individuals are nan at the end
+    {
+        "time": "middle",
+        "individual": ["id_0"],
+        "keypoint": ["centroid"],
+    },  # a single keypoint of an individual is nan mid-sequence
+]
+
+
+@pytest.mark.parametrize("nan_location", NAN_LOCATIONS)
 def test_napari_layers_to_ds(
     nan_location,
     valid_poses_path_and_ds,
@@ -413,27 +416,7 @@ def _move_point(loader, frame, keypoint, individual, new_y, new_x):
     loader._on_points_data_changed(mock_event)
 
 
-@pytest.mark.parametrize(
-    "nan_location",
-    [
-        None,
-        {
-            "time": "start",
-            "individual": ["id_0", "id_1"],
-            "keypoint": ["centroid", "left", "right"],
-        },
-        {
-            "time": "end",
-            "individual": ["id_0", "id_1"],
-            "keypoint": ["centroid", "left", "right"],
-        },
-        {
-            "time": "middle",
-            "individual": ["id_0"],
-            "keypoint": ["centroid"],
-        },
-    ],
-)
+@pytest.mark.parametrize("nan_location", NAN_LOCATIONS)
 def test_edited_pose_napari_layers(
     nan_location,
     valid_poses_path_and_ds,
@@ -497,27 +480,7 @@ def test_edited_pose_napari_layers(
     xr.testing.assert_equal(ds, expected_ds)
 
 
-@pytest.mark.parametrize(
-    "nan_location",
-    [
-        None,
-        {
-            "time": "start",
-            "individual": ["id_0", "id_1"],
-            "keypoint": ["centroid", "left", "right"],
-        },
-        {
-            "time": "end",
-            "individual": ["id_0", "id_1"],
-            "keypoint": ["centroid", "left", "right"],
-        },
-        {
-            "time": "middle",
-            "individual": ["id_0"],
-            "keypoint": ["centroid"],
-        },
-    ],
-)
+@pytest.mark.parametrize("nan_location", NAN_LOCATIONS)
 def test_edited_property_round_trip(
     nan_location,
     valid_poses_path_and_ds,

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -393,6 +393,26 @@ def test_napari_layers_to_ds_bboxes_not_implemented():
         )
 
 
+def _move_point(loader, frame, keypoint, individual, new_y, new_x):
+    """Simulate a user dragging a single point to a new position."""
+    live_props = loader.points_layer.properties
+    edit_idx = int(
+        np.flatnonzero(
+            (live_props["time"] == frame)
+            & (live_props["keypoint"] == keypoint)
+            & (live_props["individual"] == individual)
+        )[0]
+    )
+    loader.points_layer.data[edit_idx, 1] = new_y
+    loader.points_layer.data[edit_idx, 2] = new_x
+
+    mock_event = Mock()
+    mock_event.source = loader.points_layer
+    mock_event.action = ActionType.CHANGED
+    mock_event.data_indices = (edit_idx,)
+    loader._on_points_data_changed(mock_event)
+
+
 @pytest.mark.parametrize(
     "nan_location",
     [
@@ -439,27 +459,14 @@ def test_edited_pose_napari_layers(
     frame = 2  # safe: not NaN in any parametrize case
     keypoint = "centroid"
     individual = "id_0"
-
-    # Find the integer index of the point to edit in the live points layer
-    live_props = loader.points_layer.properties
-    edit_idx = int(
-        np.flatnonzero(
-            (live_props["time"] == frame)
-            & (live_props["keypoint"] == keypoint)
-            & (live_props["individual"] == individual)
-        )[0]
+    _move_point(
+        loader,
+        frame=frame,
+        keypoint=keypoint,
+        individual=individual,
+        new_y=100,
+        new_x=200,
     )
-
-    loader.points_layer.data[edit_idx, 1] = 100  # y
-    loader.points_layer.data[edit_idx, 2] = 200  # x
-
-    # Direct mutation does not fire napari events, so we call the callback
-    # manually below with the correct index to replicate what napari does.
-    mock_event = Mock()
-    mock_event.source = loader.points_layer
-    mock_event.action = ActionType.CHANGED
-    mock_event.data_indices = (edit_idx,)
-    loader._on_points_data_changed(mock_event)
 
     ds = napari_layers_to_ds(
         points_as_napari=loader.points_layer.data,
@@ -467,27 +474,108 @@ def test_edited_pose_napari_layers(
         properties_with_nans=loader.properties,
         attrs=ds_loaded.attrs,
     )
+    # check if `edited` is boolean
+    assert ds["edited"].dtype == bool
 
     # after loading in napari and exporting:
     # confidence is nan where position is nan
     expected_ds = _nan_confidence_at_nan_pos(ds_loaded)
-    # edited point values
-    expected_ds.position.loc[
-        {
-            "time": frame,
-            "space": ["x", "y"],
-            "keypoint": keypoint,
-            "individual": individual,
-        }
-    ] = [200, 100]
-    expected_ds["confidence"].loc[
-        {
-            "time": frame,
-            "keypoint": keypoint,
-            "individual": individual,
-        }
-    ] = np.nan
+    edited_point = {
+        "time": frame,
+        "keypoint": keypoint,
+        "individual": individual,
+    }
+    expected_ds.position.loc[{**edited_point, "space": ["x", "y"]}] = [
+        200,
+        100,
+    ]
+    expected_ds["confidence"].loc[edited_point] = np.nan
+    expected_ds["edited"] = xr.full_like(
+        expected_ds["confidence"], False, dtype=bool
+    )
+    expected_ds["edited"].loc[edited_point] = True
     xr.testing.assert_equal(ds, expected_ds)
+
+
+@pytest.mark.parametrize(
+    "nan_location",
+    [
+        None,
+        {
+            "time": "start",
+            "individual": ["id_0", "id_1"],
+            "keypoint": ["centroid", "left", "right"],
+        },
+        {
+            "time": "end",
+            "individual": ["id_0", "id_1"],
+            "keypoint": ["centroid", "left", "right"],
+        },
+        {
+            "time": "middle",
+            "individual": ["id_0"],
+            "keypoint": ["centroid"],
+        },
+    ],
+)
+def test_edited_property_round_trip(
+    nan_location,
+    valid_poses_path_and_ds,
+    valid_poses_path_and_ds_with_localised_nans,
+    loaded_data_loader,
+):
+    """Test that an ``edited`` variable survives a full round trip.
+
+    Once a dataset has been reconstructed with an ``edited`` variable
+    (e.g. from a previous napari editing session), it must be possible
+    to load it back into napari via :func:`ds_to_napari_layers`, and
+    to convert it back again via :func:`napari_layers_to_ds`, without
+    losing the ``edited`` flags. This simulates reopening a
+    previously-edited dataset in a new napari session.
+    """
+    if nan_location is None:
+        filepath, ds_loaded = valid_poses_path_and_ds
+    else:
+        filepath, ds_loaded = valid_poses_path_and_ds_with_localised_nans(
+            nan_location
+        )
+    loader = loaded_data_loader(filepath, ds_loaded)
+
+    _move_point(
+        loader,
+        frame=2,  # safe: not NaN in any parametrize case
+        keypoint="centroid",
+        individual="id_0",
+        new_y=100,
+        new_x=200,
+    )
+
+    ds = napari_layers_to_ds(
+        points_as_napari=loader.points_layer.data,
+        properties=loader.points_layer.properties,
+        properties_with_nans=loader.properties,
+        attrs=ds_loaded.attrs,
+    )
+    assert "edited" in ds
+
+    # Load the previously-edited dataset back into napari layers.
+    napari_tracks, _, properties_with_nan = ds_to_napari_layers(ds)
+    assert "edited" in properties_with_nan.columns
+
+    # Simulate the loader widget filtering out NaN position rows, then
+    # convert back to a dataset again.
+    valid_point_mask = ~np.any(np.isnan(napari_tracks[:, 2:4]), axis=1)
+    napari_points = napari_tracks[valid_point_mask, 1:]
+    properties = properties_with_nan.iloc[valid_point_mask].reset_index(
+        drop=True
+    )
+
+    reconstructed_ds = napari_layers_to_ds(
+        napari_points, properties, properties_with_nan, attrs=ds.attrs
+    )
+
+    assert reconstructed_ds["edited"].dtype == bool
+    xr.testing.assert_equal(reconstructed_ds, ds)
 
 
 def _target_points_to_remove(target, ds):
@@ -579,6 +667,9 @@ def test_removed_pose_napari_layers_restores_nans(
         properties_with_nans=loader.properties,
         attrs=ds_expected.attrs,
     )
+    # No point was ever dragged, so the live properties never gained an
+    # `edited` key: deletion alone does not add the variable.
+    assert "edited" not in ds
 
     # Removed points are restored as NaN; nothing is dropped from the
     # dataset's time/keypoint/individual coordinates.
@@ -644,6 +735,9 @@ def test_removed_pose_napari_layers_drops_empty_coord(
         properties_with_nans=loader.properties,
         attrs=ds_expected.attrs,
     )
+    # No point was ever dragged, so the live properties never gained an
+    # `edited` key: deletion alone does not add the variable.
+    assert "edited" not in ds
 
     removed_labels = target[dropped_dim]
     remaining_labels = [

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -1018,3 +1018,40 @@ def test_on_points_data_changed_ignores_non_move_events(
         loader.points_layer.features["confidence"],
         original_confidence,
     )
+
+
+def test_on_points_data_changed_second_drag_extends_edited(
+    valid_poses_path_and_ds, loaded_data_loader
+):
+    """Test that a second drag reuses and extends the ``edited`` property.
+
+    The first drag creates the ``edited`` array (``else`` branch), while a
+    second drag on different points must copy the existing array and flag
+    the new points too (``if "edited" in props`` branch). The second drag
+    targets multiple points at once, which is how napari reports a
+    multi-point selection being dragged: a single ``CHANGED`` event with
+    several ``data_indices``.
+    """
+    filepath, ds = valid_poses_path_and_ds
+    loader = loaded_data_loader(filepath, ds)
+
+    def drag(indices):
+        mock_event = Mock()
+        mock_event.source = loader.points_layer
+        mock_event.action = ActionType.CHANGED
+        mock_event.data_indices = indices
+        loader._on_points_data_changed(mock_event)
+
+    # First drag creates `edited`
+    drag((0,))
+    assert loader.points_layer.properties["edited"][0]
+
+    # Second, drag hits the "edited already exists" branch
+    drag((1, 2))
+
+    edited = loader.points_layer.properties["edited"]
+    confidence = loader.points_layer.properties["confidence"]
+    assert edited[[0, 1, 2]].all()  # all dragged points flagged
+    assert not edited[3:].any()  # untouched points stay False
+    assert np.isnan(confidence[[0, 1, 2]]).all()  # confidence set to NaN
+    assert not np.isnan(confidence[3:]).any()  # untouched points untouched

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -1023,14 +1023,12 @@ def test_on_points_data_changed_ignores_non_move_events(
 def test_on_points_data_changed_second_drag_extends_edited(
     valid_poses_path_and_ds, loaded_data_loader
 ):
-    """Test that a second drag reuses and extends the ``edited`` property.
+    """Test that a second, multi-point drag extends the ``edited`` property.
 
-    The first drag creates the ``edited`` array (``else`` branch), while a
-    second drag on different points must copy the existing array and flag
-    the new points too (``if "edited" in props`` branch). The second drag
-    targets multiple points at once, which is how napari reports a
-    multi-point selection being dragged: a single ``CHANGED`` event with
-    several ``data_indices``.
+    The first drag creates ``edited`` (the ``else`` branch). The second
+    drag moves two points at once, as napari does for a multi-point
+    selection, hitting the ``if "edited" in props`` branch and covering
+    multi-point drags in the same test.
     """
     filepath, ds = valid_poses_path_and_ds
     loader = loaded_data_loader(filepath, ds)
@@ -1042,11 +1040,12 @@ def test_on_points_data_changed_second_drag_extends_edited(
         mock_event.data_indices = indices
         loader._on_points_data_changed(mock_event)
 
-    # First drag creates `edited`
+    # First drag: creates `edited` (the `else` branch), one point moved
     drag((0,))
     assert loader.points_layer.properties["edited"][0]
 
-    # Second, drag hits the "edited already exists" branch
+    # Second drag: extends `edited` (the `if "edited" in props` branch),
+    # moving two points (1, 2) at once in a single event
     drag((1, 2))
 
     edited = loader.points_layer.properties["edited"]


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [X] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

When a user manually drags a point in the napari Points layer, `movement` already sets that point's confidence to `NaN` (#1024) to flag it as no longer coming from the original pose estimation model.

 However, there was no way to distinguish a point that was manually corrected from one that originally has `NaN` (e.g. during occlusions). 

That is why, to easily track which points were moved, in this PR we propose an `edited` property (bool), which will set as `True` all the points that were dragged by the user in the napari layers. 

**What does this PR do?**

-  Adds an `edited` boolean property, set to `True` for points a user has dragged in the napari Points layer (`_on_points_data_changed` in `loader_widgets.py`). The property is only created the first time a point is edited, so datasets/layers with no edits never carry it.
- `ds_to_napari_layers` includes `edited` in the properties DataFrame when the source dataset has an `edited` variable.
-  `napari_layers_to_ds` reconstructs an `edited` data variable (defaulting missing values to `False`) when converting napari layer data back into a `movement` dataset.

## References
Builds on #1024  and #1025 
It is part of #993 

## How has this PR been tested?

**Manually on the GUI**: 
When we load a dataset into the GUI (see image below), we see columns for keypoints, individuals, time and confidence. So when nothing is touched (dragged) the `edited` properties do not appear.  
<img width="1440" height="900" alt="Screenshot 2026-07-18 at 16 56 45" src="https://github.com/user-attachments/assets/d4a3bdf8-1224-4eec-9597-81d8421d7670" />

However, when we move a point, we see that confidence is set to `NaN` (implemented in #1024) and `edited` properties is set to True (see image below): 
<img width="1440" height="900" alt="Screenshot 2026-07-18 at 16 56 59" src="https://github.com/user-attachments/assets/eeff61d2-eae8-4559-a23c-85bf5f833d5d" />

I have further tested that dragging a second point then updates the `edited` to `True`. 

**Tests**:
Added in `tests/test_unit/test_napari_plugin/test_convert.py`

- I added a helper function called `_move_point` to simulate a user dragging a point and not repeating it across consecutive tests. 
- Edited the current tests on editing/removing keypoints (e.g. `test_edited_pose_napari_layers`, `test_removed_pose_napari_layers_restores_nans`, etc.) to directly test if `napari_layers_to_ds` returns edited properties. It needs to be `True` for edits and `False` for removal. 
- I added a roundtrip test called `test_edited_property_round_trip` to test if a returned ds from `napari_layers_to_ds` includes the edited properties when it is loaded back to napari layers. 

## Is this a breaking change?

No. 

## Does this PR require an update to the documentation?

The documentation has not been updated yet. 

## Checklist:

- [X] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
