### PR TITLE
Save widget for napari plugin

### DIFF
--- a/docs/make_api.py
+++ b/docs/make_api.py
@@ -26,6 +26,7 @@ EXCLUDE_MODULES = {
     "movement.cli_entrypoint",
     "movement.napari.loader_widgets",
     "movement.napari.regions_widget",
+    "movement.napari.save_widget",
     "movement.napari.meta_widget",
 }
 

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -49,6 +49,16 @@ SUPPORTED_DATA_FILES = {
     **SUPPORTED_NETCDF_FILES,
 }
 
+# Metadata keys stored on napari Points layers created by this widget.
+# Set here (where the layer is created) and read back in save_widget.py
+# (where the layer is saved).
+# - PROPERTIES_KEY stores the full properties dataframe (including
+#   NaN rows dropped from the layer) needed to reconstruct the dataset.
+# - ATTRS_KEY stores the original dataset attributes (e.g.
+#   source_software, fps) to preserve them on save.
+PROPERTIES_KEY: str = "movement_properties_with_nans"
+ATTRS_KEY: str = "movement_attrs"
+
 
 class DataLoader(QWidget):
     """Widget for loading movement datasets from file."""
@@ -224,6 +234,7 @@ class DataLoader(QWidget):
 
         # Convert to napari arrays
         self.data, self.data_bboxes, self.properties = ds_to_napari_layers(ds)
+        self.ds_attrs = ds.attrs
 
         # Find rows that do not contain NaN values
         self.data_not_nan = ~np.any(np.isnan(self.data), axis=1)
@@ -337,12 +348,14 @@ class DataLoader(QWidget):
             :, ~self.properties.columns.str.endswith("_factorized")
         ]
 
-        # Add data as a points layer with metadata
-        # (max_frame_idx is used to set the frame slider range)
         self.points_layer = self.viewer.add_points(
             self.data[self.data_not_nan, 1:],
             properties=points_properties.iloc[self.data_not_nan, :],
-            metadata={"max_frame_idx": max(self.data[:, 1])},
+            metadata={
+                "max_frame_idx": max(self.data[:, 1]),
+                PROPERTIES_KEY: self.properties,
+                ATTRS_KEY: self.ds_attrs,
+            },
             **points_style.as_kwargs(),
         )
         self.points_layer.events.data.connect(self._on_points_data_changed)

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -49,15 +49,16 @@ SUPPORTED_DATA_FILES = {
     **SUPPORTED_NETCDF_FILES,
 }
 
-# Metadata keys stored on napari Points layers created by this widget.
-# Set here (where the layer is created) and read back in save_widget.py
-# (where the layer is saved).
-# - PROPERTIES_KEY stores the full properties dataframe (including
-#   NaN rows dropped from the layer) needed to reconstruct the dataset.
-# - ATTRS_KEY stores the original dataset attributes (e.g.
-#   source_software, fps) to preserve them on save.
-PROPERTIES_KEY: str = "movement_properties_with_nans"
-ATTRS_KEY: str = "movement_attrs"
+# Metadata keys stored on the movement Points layer.
+# Set in _add_points_layer (where the layer is created);
+# read in save_widget.py (where the layer is saved).
+# - POINTS_LAYER_KEY marks the layer as movement-created.
+# - POINTS_PROPERTIES_KEY holds the full properties df, incl. the NaN rows
+#   dropped from the live layer, needed to reconstruct the dataset.
+# - DATASET_ATTRS_KEY holds the source dataset's attrs (source_software, fps…).
+POINTS_LAYER_KEY: str = "movement_points_layer"
+POINTS_PROPERTIES_KEY: str = "movement_points_properties"
+DATASET_ATTRS_KEY: str = "movement_dataset_attrs"
 
 
 class DataLoader(QWidget):
@@ -353,8 +354,9 @@ class DataLoader(QWidget):
             properties=points_properties.iloc[self.data_not_nan, :],
             metadata={
                 "max_frame_idx": max(self.data[:, 1]),
-                PROPERTIES_KEY: self.properties,
-                ATTRS_KEY: self.ds_attrs,
+                POINTS_LAYER_KEY: True,
+                POINTS_PROPERTIES_KEY: self.properties,
+                DATASET_ATTRS_KEY: self.ds_attrs,
             },
             **points_style.as_kwargs(),
         )

--- a/movement/napari/meta_widget.py
+++ b/movement/napari/meta_widget.py
@@ -5,6 +5,7 @@ from qt_niu.collapsible_widget import CollapsibleWidgetContainer
 
 from movement.napari.loader_widgets import DataLoader
 from movement.napari.regions_widget import RegionsWidget
+from movement.napari.save_widget import DataSaver
 
 
 class MovementMetaWidget(CollapsibleWidgetContainer):
@@ -30,6 +31,13 @@ class MovementMetaWidget(CollapsibleWidgetContainer):
             RegionsWidget(napari_viewer, parent=self),
             collapsible=True,
             widget_title="Define regions of interest",
+        )
+
+        # Add the Save widget
+        self.add_widget(
+            DataSaver(napari_viewer, parent=self),
+            collapsible=True,
+            widget_title="Save tracked data",
         )
 
         loader_collapsible = self.collapsible_widgets[0]

--- a/movement/napari/save_widget.py
+++ b/movement/napari/save_widget.py
@@ -40,7 +40,7 @@ class DataSaver(QWidget):
         file_path, _ = QFileDialog.getSaveFileName(
             self,
             caption="Save dataset as",
-            filter="movement native format (*.nc)",
+            filter="movement (netCDF) format (*.nc)",
         )
         # A blank string is returned if the user cancels the dialog
         if not file_path:

--- a/movement/napari/save_widget.py
+++ b/movement/napari/save_widget.py
@@ -1,0 +1,84 @@
+"""Widget for saving movement datasets from napari layers."""
+
+from napari.layers import Points
+from napari.utils.notifications import show_error, show_info
+from napari.viewer import Viewer
+from qtpy.QtWidgets import QFileDialog, QFormLayout, QPushButton, QWidget
+
+from movement.napari.convert import napari_layers_to_ds
+from movement.napari.loader_widgets import (
+    ATTRS_KEY,
+    PROPERTIES_KEY,
+)
+from movement.utils.logging import logger
+from movement.validators.files import validate_file_path
+
+
+class DataSaver(QWidget):
+    """Widget for saving a tracked data layer to the native file format."""
+
+    def __init__(self, napari_viewer: Viewer, parent=None):
+        """Initialize the data saver widget."""
+        super().__init__(parent=parent)
+        self.viewer = napari_viewer
+        self.setLayout(QFormLayout())
+        self._create_save_button()
+
+    def _create_save_button(self):
+        """Create a button to save the selected points layer to file."""
+        self.save_button = QPushButton("Save")
+        self.save_button.setObjectName("save_button")
+        self.save_button.clicked.connect(self._on_save_clicked)
+        self.layout().addRow(self.save_button)
+
+    def _on_save_clicked(self):
+        """Reconstruct a dataset from the selected layer and save it."""
+        layer = self._get_points_layer_to_save()
+        if layer is None:
+            return
+
+        file_path, _ = QFileDialog.getSaveFileName(
+            self,
+            caption="Save dataset as",
+            filter="movement native format (*.nc)",
+        )
+        # A blank string is returned if the user cancels the dialog
+        if not file_path:
+            return
+        if not file_path.lower().endswith(".nc"):
+            file_path += ".nc"
+
+        try:
+            valid_path = validate_file_path(
+                file_path, permission="w", suffixes={".nc"}
+            )
+            ds = napari_layers_to_ds(
+                points_as_napari=layer.data,
+                properties=layer.properties,
+                properties_with_nans=layer.metadata[PROPERTIES_KEY],
+                attrs=layer.metadata[ATTRS_KEY],
+            )
+            ds.to_netcdf(valid_path)
+        except Exception as e:
+            show_error(f"Failed to save dataset to '{file_path}': {e}")
+            return
+
+        logger.info(f"Saved dataset to '{valid_path}'.")
+        show_info(f"Saved dataset to '{valid_path}'.")
+
+    def _get_points_layer_to_save(self) -> Points | None:
+        """Return the points layer to save, or None if selection is invalid."""
+        layer = self.viewer.layers.selection.active
+        if not isinstance(layer, Points):
+            show_error(
+                "Please select a tracked data points layer in the "
+                "layers list before saving."
+            )
+            return None
+        if PROPERTIES_KEY not in layer.metadata:
+            show_error(
+                f"The layer '{layer.name}' was not loaded via the "
+                "movement plugin and cannot be saved."
+            )
+            return None
+        return layer

--- a/movement/napari/save_widget.py
+++ b/movement/napari/save_widget.py
@@ -13,6 +13,11 @@ from movement.napari.loader_widgets import (
 from movement.utils.logging import logger
 from movement.validators.files import validate_file_path
 
+DISABLED_TOOLTIP = "Select a points layer containing tracked data"
+ENABLED_TOOLTIP = (
+    "Save currently selected points layer to a movement (netCDF) file"
+)
+
 
 class DataSaver(QWidget):
     """Widget for saving a tracked data layer to the native file format."""
@@ -23,13 +28,39 @@ class DataSaver(QWidget):
         self.viewer = napari_viewer
         self.setLayout(QFormLayout())
         self._create_save_button()
+        self.viewer.layers.selection.events.changed.connect(
+            self._on_napari_layer_selection_changed
+        )
+        self._update_save_button_state()
 
     def _create_save_button(self):
         """Create a button to save the selected points layer to file."""
         self.save_button = QPushButton("Save")
         self.save_button.setObjectName("save_button")
+        self.save_button.setEnabled(False)
+        self.save_button.setToolTip(DISABLED_TOOLTIP)
         self.save_button.clicked.connect(self._on_save_clicked)
         self.layout().addRow(self.save_button)
+
+    def _on_napari_layer_selection_changed(self, event=None):
+        """Update the save button's enabled state and tooltip."""
+        self._update_save_button_state()
+
+    def _update_save_button_state(self):
+        """Enable the save button only when a valid points layer is active."""
+        layer = self.viewer.layers.selection.active
+        is_valid = self._is_valid_points_layer(layer)
+        self.save_button.setEnabled(is_valid)
+        self.save_button.setToolTip(
+            ENABLED_TOOLTIP if is_valid else DISABLED_TOOLTIP
+        )
+
+    def closeEvent(self, event):
+        """Disconnect signals when the widget is closed."""
+        self.viewer.layers.selection.events.changed.disconnect(
+            self._on_napari_layer_selection_changed
+        )
+        super().closeEvent(event)
 
     def _on_save_clicked(self):
         """Reconstruct a dataset from the selected layer and save it."""
@@ -82,3 +113,7 @@ class DataSaver(QWidget):
             )
             return None
         return layer
+
+    def _is_valid_points_layer(self, layer) -> bool:
+        """Return True if the layer is a points layer with tracked data."""
+        return isinstance(layer, Points) and PROPERTIES_KEY in layer.metadata

--- a/movement/napari/save_widget.py
+++ b/movement/napari/save_widget.py
@@ -7,8 +7,9 @@ from qtpy.QtWidgets import QFileDialog, QFormLayout, QPushButton, QWidget
 
 from movement.napari.convert import napari_layers_to_ds
 from movement.napari.loader_widgets import (
-    ATTRS_KEY,
-    PROPERTIES_KEY,
+    DATASET_ATTRS_KEY,
+    POINTS_LAYER_KEY,
+    POINTS_PROPERTIES_KEY,
 )
 from movement.utils.logging import logger
 from movement.validators.files import validate_file_path
@@ -86,8 +87,8 @@ class DataSaver(QWidget):
             ds = napari_layers_to_ds(
                 points_as_napari=layer.data,
                 properties=layer.properties,
-                properties_with_nans=layer.metadata[PROPERTIES_KEY],
-                attrs=layer.metadata[ATTRS_KEY],
+                properties_with_nans=layer.metadata[POINTS_PROPERTIES_KEY],
+                attrs=layer.metadata[DATASET_ATTRS_KEY],
             )
             ds.to_netcdf(valid_path)
         except Exception as e:
@@ -106,7 +107,7 @@ class DataSaver(QWidget):
                 "layers list before saving."
             )
             return None
-        if PROPERTIES_KEY not in layer.metadata:
+        if not layer.metadata.get(POINTS_LAYER_KEY, False):
             show_error(
                 f"The layer '{layer.name}' was not loaded via the "
                 "movement plugin and cannot be saved."
@@ -116,4 +117,6 @@ class DataSaver(QWidget):
 
     def _is_valid_points_layer(self, layer) -> bool:
         """Return True if the layer is a points layer with tracked data."""
-        return isinstance(layer, Points) and PROPERTIES_KEY in layer.metadata
+        return isinstance(layer, Points) and layer.metadata.get(
+            POINTS_LAYER_KEY, False
+        )

--- a/movement/napari/save_widget.py
+++ b/movement/napari/save_widget.py
@@ -65,9 +65,10 @@ class DataSaver(QWidget):
 
     def _on_save_clicked(self):
         """Reconstruct a dataset from the selected layer and save it."""
-        layer = self._get_points_layer_to_save()
-        if layer is None:
-            return
+        # The button is only enabled for a valid movement points layer
+        # (see _update_save_button_state), so the active layer is safe
+        # to use.
+        layer = self.viewer.layers.selection.active
 
         file_path, _ = QFileDialog.getSaveFileName(
             self,
@@ -97,23 +98,6 @@ class DataSaver(QWidget):
 
         logger.info(f"Saved dataset to '{valid_path}'.")
         show_info(f"Saved dataset to '{valid_path}'.")
-
-    def _get_points_layer_to_save(self) -> Points | None:
-        """Return the points layer to save, or None if selection is invalid."""
-        layer = self.viewer.layers.selection.active
-        if not isinstance(layer, Points):
-            show_error(
-                "Please select a tracked data points layer in the "
-                "layers list before saving."
-            )
-            return None
-        if not layer.metadata.get(POINTS_LAYER_KEY, False):
-            show_error(
-                f"The layer '{layer.name}' was not loaded via the "
-                "movement plugin and cannot be saved."
-            )
-            return None
-        return layer
 
     def _is_valid_points_layer(self, layer) -> bool:
         """Return True if the layer is a points layer with tracked data."""

--- a/tests/test_unit/test_napari_plugin/test_meta_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_meta_widget.py
@@ -8,7 +8,7 @@ def test_meta_widget_instantiation(make_napari_viewer_proxy):
     viewer = make_napari_viewer_proxy()
     meta_widget = MovementMetaWidget(viewer)
 
-    assert len(meta_widget.collapsible_widgets) == 2
+    assert len(meta_widget.collapsible_widgets) == 3
 
     first_widget = meta_widget.collapsible_widgets[0]
     assert first_widget._text == "Load tracked data"
@@ -17,3 +17,7 @@ def test_meta_widget_instantiation(make_napari_viewer_proxy):
     second_widget = meta_widget.collapsible_widgets[1]
     assert second_widget._text == "Define regions of interest"
     assert not second_widget.isExpanded()
+
+    third_widget = meta_widget.collapsible_widgets[2]
+    assert third_widget._text == "Save tracked data"
+    assert not third_widget.isExpanded()

--- a/tests/test_unit/test_napari_plugin/test_save_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_save_widget.py
@@ -1,0 +1,127 @@
+"""Unit tests for the save widget in the napari plugin."""
+
+import numpy as np
+import xarray as xr
+from qtpy.QtWidgets import QPushButton
+
+from movement.napari.save_widget import DataSaver
+
+
+def test_data_saver_widget_instantiation(make_napari_viewer_proxy):
+    """Test that the save widget is properly instantiated."""
+    data_saver_widget = DataSaver(make_napari_viewer_proxy())
+
+    assert data_saver_widget.layout().rowCount() == 1
+    assert isinstance(data_saver_widget.save_button, QPushButton)
+    assert data_saver_widget.save_button.objectName() == "save_button"
+
+
+def test_save_clicked_without_points_layer_selected(
+    make_napari_viewer_proxy, mocker
+):
+    """Test that clicking 'Save' without a valid layer selected shows
+    an error and never opens the file dialog.
+    """
+    viewer = make_napari_viewer_proxy()
+    data_saver_widget = DataSaver(viewer)
+
+    mock_show_error = mocker.patch("movement.napari.save_widget.show_error")
+    mock_file_dialog = mocker.patch(
+        "movement.napari.save_widget.QFileDialog.getSaveFileName"
+    )
+
+    data_saver_widget._on_save_clicked()
+
+    mock_show_error.assert_called_once()
+    mock_file_dialog.assert_not_called()
+
+
+def test_save_clicked_with_non_movement_points_layer(
+    make_napari_viewer_proxy, mocker
+):
+    """Test that a Points layer without movement metadata is rejected."""
+    viewer = make_napari_viewer_proxy()
+    data_saver_widget = DataSaver(viewer)
+
+    layer = viewer.add_points(name="not from movement")
+    viewer.layers.selection.active = layer
+
+    mock_show_error = mocker.patch("movement.napari.save_widget.show_error")
+    mock_file_dialog = mocker.patch(
+        "movement.napari.save_widget.QFileDialog.getSaveFileName"
+    )
+
+    data_saver_widget._on_save_clicked()
+
+    mock_show_error.assert_called_once()
+    mock_file_dialog.assert_not_called()
+
+
+def test_save_clicked_with_non_points_layer_selected(
+    make_napari_viewer_proxy, mocker
+):
+    """Test that a non-Points layer selection is rejected."""
+    viewer = make_napari_viewer_proxy()
+    data_saver_widget = DataSaver(viewer)
+
+    layer = viewer.add_image(np.zeros((10, 10)), name="an image")
+    viewer.layers.selection.active = layer
+
+    mock_show_error = mocker.patch("movement.napari.save_widget.show_error")
+
+    data_saver_widget._on_save_clicked()
+
+    mock_show_error.assert_called_once()
+
+
+def test_save_clicked_cancelled_dialog(make_napari_viewer_proxy, mocker):
+    """Test that cancelling the file dialog does not attempt to save."""
+    viewer = make_napari_viewer_proxy()
+    data_saver_widget = DataSaver(viewer)
+
+    layer = viewer.add_points(
+        name="points",
+        metadata={
+            "movement_properties_with_nans": None,
+            "movement_attrs": {},
+        },
+    )
+    viewer.layers.selection.active = layer
+
+    mocker.patch(
+        "movement.napari.save_widget.QFileDialog.getSaveFileName",
+        return_value=("", None),
+    )
+    mock_to_netcdf = mocker.patch.object(xr.Dataset, "to_netcdf")
+
+    data_saver_widget._on_save_clicked()
+
+    mock_to_netcdf.assert_not_called()
+
+
+def test_save_round_trip(
+    tmp_path,
+    valid_poses_path_and_ds,
+    loaded_data_loader,
+    mocker,
+):
+    """Test that saving a loaded dataset via the save widget reconstructs
+    the original dataset in the netCDF file written to disk.
+    """
+    filepath, ds_loaded = valid_poses_path_and_ds
+    loader = loaded_data_loader(filepath, ds_loaded)
+
+    data_saver_widget = DataSaver(loader.viewer)
+    loader.viewer.layers.selection.active = loader.points_layer
+
+    out_path = tmp_path / "roundtrip.nc"
+    mocker.patch(
+        "movement.napari.save_widget.QFileDialog.getSaveFileName",
+        return_value=(str(out_path), None),
+    )
+
+    data_saver_widget._on_save_clicked()
+
+    assert out_path.exists()
+    saved_ds = xr.open_dataset(out_path)
+    xr.testing.assert_equal(saved_ds, ds_loaded)

--- a/tests/test_unit/test_napari_plugin/test_save_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_save_widget.py
@@ -1,7 +1,9 @@
 """Unit tests for the save widget in the napari plugin."""
 
 import numpy as np
+import pytest
 import xarray as xr
+from qtpy.QtGui import QCloseEvent
 from qtpy.QtWidgets import QPushButton
 
 from movement.napari.loader_widgets import (
@@ -178,7 +180,15 @@ def test_save_clicked_cancelled_dialog(make_napari_viewer_proxy, mocker):
     mock_to_netcdf.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "dialog_name",
+    [
+        pytest.param("roundtrip.nc", id="with_suffix"),
+        pytest.param("roundtrip", id="without_suffix"),
+    ],
+)
 def test_save_round_trip(
+    dialog_name,
     tmp_path,
     valid_poses_path_and_ds,
     loaded_data_loader,
@@ -186,7 +196,37 @@ def test_save_round_trip(
 ):
     """Test that saving a loaded dataset via the save widget reconstructs
     the original dataset in the netCDF file written to disk.
+
+    The ``dialog_name`` without a ".nc" suffix also covers the branch
+    that appends it automatically.
     """
+    filepath, ds_loaded = valid_poses_path_and_ds
+    loader = loaded_data_loader(filepath, ds_loaded)
+
+    data_saver_widget = DataSaver(loader.viewer)
+    loader.viewer.layers.selection.active = loader.points_layer
+
+    out_path = tmp_path / "roundtrip.nc"
+    mocker.patch(
+        "movement.napari.save_widget.QFileDialog.getSaveFileName",
+        return_value=(str(tmp_path / dialog_name), None),
+    )
+
+    data_saver_widget._on_save_clicked()
+
+    assert out_path.exists()
+    saved_ds = xr.open_dataset(out_path)
+    xr.testing.assert_equal(saved_ds, ds_loaded)
+    assert saved_ds.attrs == loader.ds_attrs
+
+
+def test_save_failure_shows_error(
+    tmp_path,
+    valid_poses_path_and_ds,
+    loaded_data_loader,
+    mocker,
+):
+    """Test that a failure during saving shows an error notification."""
     filepath, ds_loaded = valid_poses_path_and_ds
     loader = loaded_data_loader(filepath, ds_loaded)
 
@@ -198,10 +238,35 @@ def test_save_round_trip(
         "movement.napari.save_widget.QFileDialog.getSaveFileName",
         return_value=(str(out_path), None),
     )
+    mocker.patch.object(
+        xr.Dataset, "to_netcdf", side_effect=OSError("disk full")
+    )
+    mock_show_error = mocker.patch("movement.napari.save_widget.show_error")
 
     data_saver_widget._on_save_clicked()
 
-    assert out_path.exists()
-    saved_ds = xr.open_dataset(out_path)
-    xr.testing.assert_equal(saved_ds, ds_loaded)
-    assert saved_ds.attrs == loader.ds_attrs
+    mock_show_error.assert_called_once()
+    assert not out_path.exists()
+
+
+def test_close_event_disconnects_selection_signal(make_napari_viewer_proxy):
+    """Test that closing the widget disconnects the layer selection
+    callback, so it no longer reacts to further selection changes.
+    """
+    viewer = make_napari_viewer_proxy()
+    data_saver_widget = DataSaver(viewer)
+
+    data_saver_widget.closeEvent(QCloseEvent())
+
+    layer = viewer.add_points(
+        name="points",
+        metadata={
+            POINTS_LAYER_KEY: True,
+            POINTS_PROPERTIES_KEY: None,
+            DATASET_ATTRS_KEY: {},
+        },
+    )
+    viewer.layers.selection.active = layer
+
+    assert not data_saver_widget.save_button.isEnabled()
+    assert data_saver_widget.save_button.toolTip() == DISABLED_TOOLTIP

--- a/tests/test_unit/test_napari_plugin/test_save_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_save_widget.py
@@ -4,7 +4,16 @@ import numpy as np
 import xarray as xr
 from qtpy.QtWidgets import QPushButton
 
-from movement.napari.save_widget import DataSaver
+from movement.napari.loader_widgets import (
+    DATASET_ATTRS_KEY,
+    POINTS_LAYER_KEY,
+    POINTS_PROPERTIES_KEY,
+)
+from movement.napari.save_widget import (
+    DISABLED_TOOLTIP,
+    ENABLED_TOOLTIP,
+    DataSaver,
+)
 
 
 def test_data_saver_widget_instantiation(make_napari_viewer_proxy):
@@ -14,6 +23,43 @@ def test_data_saver_widget_instantiation(make_napari_viewer_proxy):
     assert data_saver_widget.layout().rowCount() == 1
     assert isinstance(data_saver_widget.save_button, QPushButton)
     assert data_saver_widget.save_button.objectName() == "save_button"
+    assert not data_saver_widget.save_button.isEnabled()
+    assert data_saver_widget.save_button.toolTip() == DISABLED_TOOLTIP
+
+
+def test_save_button_enabled_for_valid_points_layer(make_napari_viewer_proxy):
+    """Test that selecting a valid movement points layer enables the save
+    button and updates its tooltip.
+    """
+    viewer = make_napari_viewer_proxy()
+    data_saver_widget = DataSaver(viewer)
+
+    layer = viewer.add_points(
+        name="points",
+        metadata={
+            POINTS_LAYER_KEY: True,
+            POINTS_PROPERTIES_KEY: None,
+            DATASET_ATTRS_KEY: {},
+        },
+    )
+    viewer.layers.selection.active = layer
+
+    assert data_saver_widget.save_button.isEnabled()
+    assert data_saver_widget.save_button.toolTip() == ENABLED_TOOLTIP
+
+
+def test_save_button_disabled_for_invalid_layer(make_napari_viewer_proxy):
+    """Test that selecting a layer without movement metadata keeps the
+    save button disabled with the default tooltip.
+    """
+    viewer = make_napari_viewer_proxy()
+    data_saver_widget = DataSaver(viewer)
+
+    layer = viewer.add_points(name="not from movement")
+    viewer.layers.selection.active = layer
+
+    assert not data_saver_widget.save_button.isEnabled()
+    assert data_saver_widget.save_button.toolTip() == DISABLED_TOOLTIP
 
 
 def test_save_clicked_without_points_layer_selected(
@@ -57,6 +103,38 @@ def test_save_clicked_with_non_movement_points_layer(
     mock_file_dialog.assert_not_called()
 
 
+def test_save_clicked_with_properties_but_no_layer_key(
+    make_napari_viewer_proxy, mocker
+):
+    """Test that a Points layer with a properties key but without the
+    explicit POINTS_LAYER_KEY marker is still rejected.
+
+    Guards against relying on the mere presence of
+    ``POINTS_PROPERTIES_KEY`` (even if its value is falsy/None) as a
+    stand-in for "this layer was created by movement".
+    """
+    viewer = make_napari_viewer_proxy()
+    data_saver_widget = DataSaver(viewer)
+
+    layer = viewer.add_points(
+        name="not from movement",
+        metadata={POINTS_PROPERTIES_KEY: None},
+    )
+    viewer.layers.selection.active = layer
+
+    assert not data_saver_widget.save_button.isEnabled()
+
+    mock_show_error = mocker.patch("movement.napari.save_widget.show_error")
+    mock_file_dialog = mocker.patch(
+        "movement.napari.save_widget.QFileDialog.getSaveFileName"
+    )
+
+    data_saver_widget._on_save_clicked()
+
+    mock_show_error.assert_called_once()
+    mock_file_dialog.assert_not_called()
+
+
 def test_save_clicked_with_non_points_layer_selected(
     make_napari_viewer_proxy, mocker
 ):
@@ -82,8 +160,9 @@ def test_save_clicked_cancelled_dialog(make_napari_viewer_proxy, mocker):
     layer = viewer.add_points(
         name="points",
         metadata={
-            "movement_properties_with_nans": None,
-            "movement_attrs": {},
+            POINTS_LAYER_KEY: True,
+            POINTS_PROPERTIES_KEY: None,
+            DATASET_ATTRS_KEY: {},
         },
     )
     viewer.layers.selection.active = layer
@@ -125,3 +204,4 @@ def test_save_round_trip(
     assert out_path.exists()
     saved_ds = xr.open_dataset(out_path)
     xr.testing.assert_equal(saved_ds, ds_loaded)
+    assert saved_ds.attrs == loader.ds_attrs

--- a/tests/test_unit/test_napari_plugin/test_save_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_save_widget.py
@@ -50,108 +50,68 @@ def test_save_button_enabled_for_valid_points_layer(make_napari_viewer_proxy):
     assert data_saver_widget.save_button.toolTip() == ENABLED_TOOLTIP
 
 
-def test_save_button_disabled_for_invalid_layer(make_napari_viewer_proxy):
-    """Test that selecting a layer without movement metadata keeps the
-    save button disabled with the default tooltip.
+@pytest.mark.parametrize(
+    "make_layer",
+    [
+        pytest.param(
+            lambda v: v.add_points(name="not from movement"),
+            id="points_without_metadata",
+        ),
+        pytest.param(
+            lambda v: v.add_points(
+                name="not from movement",
+                metadata={POINTS_PROPERTIES_KEY: None},
+            ),
+            id="points_with_properties_but_no_layer_key",
+        ),
+        pytest.param(
+            lambda v: v.add_image(np.zeros((10, 10)), name="an image"),
+            id="non_points_layer",
+        ),
+    ],
+)
+def test_save_button_disabled_for_invalid_layer(
+    make_layer, make_napari_viewer_proxy
+):
+    """Test that selecting a layer that is not a movement points layer
+    keeps the save button disabled with the default tooltip.
+
+    The ``points_with_properties_but_no_layer_key`` case guards against
+    treating the mere presence of ``POINTS_PROPERTIES_KEY`` (even if
+    falsy/None) as a stand-in for "this layer was created by movement".
     """
     viewer = make_napari_viewer_proxy()
     data_saver_widget = DataSaver(viewer)
 
-    layer = viewer.add_points(name="not from movement")
-    viewer.layers.selection.active = layer
+    viewer.layers.selection.active = make_layer(viewer)
 
     assert not data_saver_widget.save_button.isEnabled()
     assert data_saver_widget.save_button.toolTip() == DISABLED_TOOLTIP
 
 
-def test_save_clicked_without_points_layer_selected(
-    make_napari_viewer_proxy, mocker
-):
-    """Test that clicking 'Save' without a valid layer selected shows
-    an error and never opens the file dialog.
+def test_disabled_button_click_does_not_save(make_napari_viewer_proxy, mocker):
+    """Test that clicking the disabled save button (no valid layer
+    selected) never opens the file dialog.
+
+    This guards the invariant that the button's enabled state is the
+    sole gate on saving, so ``_on_save_clicked`` can safely assume the
+    active layer is a valid movement points layer.
     """
     viewer = make_napari_viewer_proxy()
     data_saver_widget = DataSaver(viewer)
 
-    mock_show_error = mocker.patch("movement.napari.save_widget.show_error")
+    viewer.layers.selection.active = viewer.add_image(
+        np.zeros((10, 10)), name="an image"
+    )
+
     mock_file_dialog = mocker.patch(
         "movement.napari.save_widget.QFileDialog.getSaveFileName"
     )
 
-    data_saver_widget._on_save_clicked()
+    # click() is a no-op on a disabled button, so the slot must not run
+    data_saver_widget.save_button.click()
 
-    mock_show_error.assert_called_once()
     mock_file_dialog.assert_not_called()
-
-
-def test_save_clicked_with_non_movement_points_layer(
-    make_napari_viewer_proxy, mocker
-):
-    """Test that a Points layer without movement metadata is rejected."""
-    viewer = make_napari_viewer_proxy()
-    data_saver_widget = DataSaver(viewer)
-
-    layer = viewer.add_points(name="not from movement")
-    viewer.layers.selection.active = layer
-
-    mock_show_error = mocker.patch("movement.napari.save_widget.show_error")
-    mock_file_dialog = mocker.patch(
-        "movement.napari.save_widget.QFileDialog.getSaveFileName"
-    )
-
-    data_saver_widget._on_save_clicked()
-
-    mock_show_error.assert_called_once()
-    mock_file_dialog.assert_not_called()
-
-
-def test_save_clicked_with_properties_but_no_layer_key(
-    make_napari_viewer_proxy, mocker
-):
-    """Test that a Points layer with a properties key but without the
-    explicit POINTS_LAYER_KEY marker is still rejected.
-
-    Guards against relying on the mere presence of
-    ``POINTS_PROPERTIES_KEY`` (even if its value is falsy/None) as a
-    stand-in for "this layer was created by movement".
-    """
-    viewer = make_napari_viewer_proxy()
-    data_saver_widget = DataSaver(viewer)
-
-    layer = viewer.add_points(
-        name="not from movement",
-        metadata={POINTS_PROPERTIES_KEY: None},
-    )
-    viewer.layers.selection.active = layer
-
-    assert not data_saver_widget.save_button.isEnabled()
-
-    mock_show_error = mocker.patch("movement.napari.save_widget.show_error")
-    mock_file_dialog = mocker.patch(
-        "movement.napari.save_widget.QFileDialog.getSaveFileName"
-    )
-
-    data_saver_widget._on_save_clicked()
-
-    mock_show_error.assert_called_once()
-    mock_file_dialog.assert_not_called()
-
-
-def test_save_clicked_with_non_points_layer_selected(
-    make_napari_viewer_proxy, mocker
-):
-    """Test that a non-Points layer selection is rejected."""
-    viewer = make_napari_viewer_proxy()
-    data_saver_widget = DataSaver(viewer)
-
-    layer = viewer.add_image(np.zeros((10, 10)), name="an image")
-    viewer.layers.selection.active = layer
-
-    mock_show_error = mocker.patch("movement.napari.save_widget.show_error")
-
-    data_saver_widget._on_save_clicked()
-
-    mock_show_error.assert_called_once()
 
 
 def test_save_clicked_cancelled_dialog(make_napari_viewer_proxy, mocker):


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [X] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

This PR is part of #993 (particularly addresses #997). Users can load their data into napari and use napari's native tools to dragg points and manually correct some predictions, or removed inaccurate detections. We have been working on the conversion of napari point layers back to `movement` dataset (#1011). However, we need to include a `Save` widget that calls this conversion function and saves it back to `movement` native format. This PR coverts the missing "Save" step. 

**What does this PR do?**

1. Adds a `DataSaver` widget (`movement/napari/save_widget.py`) with a single `Save` button. On click, it: 
     - Validates that the active layer is `PointsLayer` created by the `movement` `DataLoader` (this is the layer we want to save)
     - Calls `napari_layers_to_ds()` to reconstruct the `movement` `ds` from the napari Points layer. 
     - Writes the converted `ds` via `ds.to_netcdf()`, which is movement's native format. 
2. Writes `DataSaver` into `MovementMetaWidget` (`meta_widget.py`) as a new collapsible `Save tracked data` section. 
3. Adds two metadata keys in the `movement/napari/loader_widgets.py` called `PROPERTIES_KEY` and `ATTRS_KEY`, which carry the unfiltered properties, before the `DataLoader` filters out `NaN` when loading the data into napari layers. 
4. Adds `test/test_unit/test_napari_plugin/test_save_widget.py` to test the functionality  of the widget. The tests cover: 
    - widget instantation
    - three guard clauses 
    - a cancelled-dialog case 
    - a full load > save > reload roundtrip test 

<img width="1523" height="956" alt="Screenshot From 2026-07-20 16-30-35" src="https://github.com/user-attachments/assets/9e966b55-6e11-4142-99df-4be08d9f813d" />


## References

This PR focuses on Issue #997 (part of #993). 
It builds on top of: 
- #1011 : introduces `napari_layers_to_ds()`, the conversion function. 
- #1024 : ensures that moved (dragged) points have their confidence changed to `NaN`
- #1025 : ensures deleted keypoints are correctly set to `NaN` during reconstruction, or dropped in case all the predictions are removed. 

This PR is pending #1041 which adds an `edited` boolean property to flag the manually corrected (dragged) points. This widget will include edited properties once merged. 

## How has this PR been tested?

1. Unit tests: 
     - widget instantiates with a single `Save` button. 
     - clicking `Save` with no layer selected shows an error and never opens the file dialog
     - clicking `Save` on any other layers (not Point Layers) rejects the saving with an error. 
     - Cancelling the dialog does not save anything 
     - A round trip: load, save, reload the `.nc` file. 
3. GUI manually tested via `movement launch`. I loaded a sample dataset. I checked that the GUI includes the `Save` button. I dragged some points. I saved the file as `movement`'s native format. Then I reloaded the saved format and checked that the `confidence` were reloaded as `NaN`, as the expected behavior. 


## Is this a breaking change?

No, it's an additional tool. Doesn't break anything already implemented. 

## Does this PR require an update to the documentation?

Documentation is not updated. In a future PR we will add detailed documentation to help users understand how to use the "Save" widget. 

## Checklist:

- [X] The code has been tested locally
- [X] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
