### PR TITLE
Log warning when saving dataset with individual-wise conf to NWB format

### DIFF
--- a/movement/io/nwb.py
+++ b/movement/io/nwb.py
@@ -567,6 +567,12 @@ def _ds_to_pose_and_skeletons(
         if ds.time_unit == "seconds"
         else ds.time.values / getattr(ds, "fps", 1.0)
     )
+    if "keypoint" not in ds.confidence.dims:
+        logger.warning(
+            "Dataset contains individual-wise confidence scores. "
+            "NWB only supports keypoint-wise confidence scores, "
+            "so confidence values will be expanded to all keypoints."
+        )
     pose_estimation_series = [
         ndx_pose.PoseEstimationSeries(
             data=ds.sel(keypoint=keypoint).position.values,

--- a/tests/test_unit/test_io/test_nwb.py
+++ b/tests/test_unit/test_io/test_nwb.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest.mock import patch
 
 import ndx_pose
+import numpy as np
 import pytest
 from pynwb.file import Subject
 
@@ -43,6 +44,24 @@ def test_ds_to_pose_and_skeletons_invalid(valid_poses_dataset):
         match=".*must contain only one individual.*",
     ):
         _ds_to_pose_and_skeletons(valid_poses_dataset)
+
+
+def test_ds_to_pose_and_skeletons_with_individual_confidence(
+    valid_poses_dataset_with_individual_wise_confidence, caplog
+):
+    """Test that a dataset with individual-wise confidence scores has
+    its confidence values expanded (repeated) across all keypoints when
+    converted to PoseEstimation objects, and that a warning is logged.
+    """
+    ds = valid_poses_dataset_with_individual_wise_confidence.sel(
+        individual="id_0"
+    )
+    pose_estimation, _ = _ds_to_pose_and_skeletons(
+        ds, subject=Subject(subject_id="id_0")
+    )
+    assert "only supports keypoint-wise confidence scores" in caplog.text
+    for series in pose_estimation.pose_estimation_series.values():
+        np.testing.assert_array_equal(series.confidence, ds.confidence.values)
 
 
 def test_write_processing_module(nwbfile_object):

--- a/tests/test_unit/test_io/test_save_poses.py
+++ b/tests/test_unit/test_io/test_save_poses.py
@@ -125,16 +125,20 @@ def test_to_dlc_style_df(ds, expected_exception):
 )
 @pytest.mark.parametrize("split_individuals", [True, False])
 def test_to_dlc_style_df_with_individual_confidence(
-    valid_poses_dataset_with_individual_wise_confidence, split_individuals
+    valid_poses_dataset_with_individual_wise_confidence,
+    split_individuals,
+    caplog,
 ):
     """Test that datasets with individual-wise confidence scores can
     be converted to DLC-style DataFrame(s), for single- and
     multi-individual datasets, and both ``split_individuals`` settings.
     The individual-wise confidence values should be expanded (repeated)
-    across all keypoints in the output DataFrame(s).
+    across all keypoints in the output DataFrame(s), and a warning
+    should be logged.
     """
     ds = valid_poses_dataset_with_individual_wise_confidence
     df = save_poses.to_dlc_style_df(ds, split_individuals=split_individuals)
+    assert "only supports keypoint-wise confidence scores" in caplog.text
     bodyparts = ds.coords["keypoint"].data.tolist()
     assert isinstance(df, dict if split_individuals else pd.DataFrame)
     for ind in ds.individual.values:
@@ -335,15 +339,16 @@ def test_to_lp_file_invalid_dataset(
     indirect=True,
 )
 def test_to_lp_file_with_individual_confidence(
-    valid_poses_dataset_with_individual_wise_confidence, tmp_path
+    valid_poses_dataset_with_individual_wise_confidence, tmp_path, caplog
 ):
     """Test that datasets with individual-wise confidence scores can
     be exported to LightningPose format, for single- and multi-individual
     datasets settings. The exported LightningPose file should be created
-    successfully.
+    successfully, and a warning should be logged.
     """
     ds = valid_poses_dataset_with_individual_wise_confidence
     save_poses.to_lp_file(ds, tmp_path / "test.csv")
+    assert "only supports keypoint-wise confidence scores" in caplog.text
     for ind in ds.individual.values:
         assert (tmp_path / f"test_{ind}.csv").is_file()
 


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Since PR #1017, saving datasets with individual-wise confidence values to DLC/LP formats (which support keypoint-wise conf values) will result in a `logger.warning` as we expand the conf values to each keypoint. 
In #1003 we also note that [`save_poses.to_nwb_file`](https://movement.neuroinformatics.dev/latest/api/movement.io.save_poses.to_nwb_file.html) conveniently (but silently) does the same "expansion". 

**What does this PR do?**
This PR adds a similar `logger.warning` when saving poses to NWB format (which also only supports keypoint-wise conf/scores).

## References
#1017 #1003

## How has this PR been tested?
Tests have been added to ensure the warnings are logged.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
