### PR TITLE
Add frame_array support to ValidPosesInputs

### DIFF
--- a/movement/io/load_bboxes.py
+++ b/movement/io/load_bboxes.py
@@ -71,11 +71,10 @@ def from_numpy(
 
     Examples
     --------
-    Create random position data for two bounding boxes, ``id_0`` and ``id_1``,
-    with the same width (40 pixels) and height (30 pixels). These are tracked
-    in 2D space for 100 frames, which are numbered from the start frame 1200
-    to the end frame 1299. The confidence score for all bounding boxes is set
-    to 0.5.
+    Create random position and shape data for two bounding boxes, tracked
+    in 2D space for 100 frames. Confidence scores are omitted, so they
+    default to NaN, and individuals are auto-named ("id_0", "id_1"). Time
+    coordinates default to consecutive 0-based frame numbers.
 
     >>> import numpy as np
     >>> from movement.io import load_bboxes
@@ -83,8 +82,27 @@ def from_numpy(
     >>> ds = load_bboxes.from_numpy(
     ...     position_array=rng.random((100, 2, 2)),
     ...     shape_array=np.ones((100, 2, 2)) * [40, 30],
+    ... )
+
+    Create a dataset with the same data as above, but name the individuals
+    ``Alice`` and ``Bob``, and set all confidence scores to 0.5.
+
+    >>> ds = load_bboxes.from_numpy(
+    ...     position_array=rng.random((100, 2, 2)),
+    ...     shape_array=np.ones((100, 2, 2)) * [40, 30],
     ...     confidence_array=np.ones((100, 2)) * 0.5,
-    ...     individual_names=["id_0", "id_1"],
+    ...     individual_names=["Alice", "Bob"],
+    ... )
+
+    Create a dataset with the same data as above, but specify that the
+    100 frames are numbered from the start frame 1200 to the end frame
+    1299, instead of defaulting to 0-based frame numbers.
+
+    >>> ds = load_bboxes.from_numpy(
+    ...     position_array=rng.random((100, 2, 2)),
+    ...     shape_array=np.ones((100, 2, 2)) * [40, 30],
+    ...     confidence_array=np.ones((100, 2)) * 0.5,
+    ...     individual_names=["Alice", "Bob"],
     ...     frame_array=np.arange(1200, 1300).reshape(-1, 1),
     ... )
 
@@ -99,32 +117,8 @@ def from_numpy(
     ...     position_array=rng.random((100, 2, 2)),
     ...     shape_array=np.ones((100, 2, 2)) * [40, 30],
     ...     confidence_array=np.ones((100, 2)) * 0.5,
-    ...     individual_names=["id_0", "id_1"],
+    ...     individual_names=["Alice", "Bob"],
     ...     frame_array=np.arange(1200, 1300).reshape(-1, 1),
-    ...     fps=60,
-    ... )
-
-    Create a dataset with the same data as above, but express the time
-    coordinate in frames, and assume the first tracked frame is frame 0.
-    To do this, we simply omit the ``frame_array`` input argument.
-
-    >>> ds = load_bboxes.from_numpy(
-    ...     position_array=rng.random((100, 2, 2)),
-    ...     shape_array=np.ones((100, 2, 2)) * [40, 30],
-    ...     confidence_array=np.ones((100, 2)) * 0.5,
-    ...     individual_names=["id_0", "id_1"],
-    ... )
-
-    Create a dataset with the same data as above, but express the time
-    coordinate in seconds, and assume the first tracked frame is captured
-    at time = 0 seconds. To do this, we omit the ``frame_array`` input argument
-    and pass an ``fps`` value.
-
-    >>> ds = load_bboxes.from_numpy(
-    ...     position_array=rng.random((100, 2, 2)),
-    ...     shape_array=np.ones((100, 2, 2)) * [40, 30],
-    ...     confidence_array=np.ones((100, 2)) * 0.5,
-    ...     individual_names=["id_0", "id_1"],
     ...     fps=60,
     ... )
 

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -30,6 +30,7 @@ def from_numpy(
     confidence_array: np.ndarray | None = None,
     individual_names: list[str] | None = None,
     keypoint_names: list[str] | None = None,
+    frame_array: np.ndarray | None = None,
     fps: float | None = None,
     source_software: str | None = None,
 ) -> xr.Dataset:
@@ -53,6 +54,11 @@ def from_numpy(
         List of unique names for the keypoints in the skeleton. If None
         (default), the keypoints will be named "keypoint_0", "keypoint_1",
         etc.
+    frame_array
+        Array containing the frame numbers for which poses are defined.
+        It should be a column vector of shape (n_frames, 1). If None
+        (default), frame numbers are assigned as consecutive 0-based
+        integers.
     fps
         Frames per second of the video. Defaults to None, in which case
         the time coordinates will be in frame numbers.
@@ -81,6 +87,7 @@ def from_numpy(
     ...     confidence_array=np.ones((100, 3, 2)),
     ...     individual_names=["Alice", "Bob"],
     ...     keypoint_names=["snout", "centre", "tail_base"],
+    ...     frame_array=np.arange(10, 110).reshape(-1, 1),
     ...     fps=30,
     ... )
 
@@ -90,6 +97,7 @@ def from_numpy(
         confidence_array=confidence_array,
         individual_names=individual_names,
         keypoint_names=keypoint_names,
+        frame_array=frame_array,
         fps=fps,
         source_software=source_software,
     )

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -74,15 +74,34 @@ def from_numpy(
 
     Examples
     --------
-    Create random position data for two individuals, ``Alice`` and ``Bob``,
-    with three keypoints each: ``snout``, ``centre``, and ``tail_base``.
-    These are tracked in 2D space for 100 frames, which are numbered from
-    the start frame 1200 to the end frame 1299. The confidence score for
-    all keypoints is set to 1.
+    Create random position data for two individuals with three keypoints
+    each, tracked in 2D space for 100 frames. As confidence scores are omitted,
+    they default to NaN, and individuals/keypoints are auto-named
+    ("id_0", "id_1", ... and "keypoint_0", "keypoint_1", ...). Time
+    coordinates default to consecutive 0-based frame numbers.
 
     >>> import numpy as np
     >>> from movement.io import load_poses
     >>> rng = np.random.default_rng(seed=42)
+    >>> ds = load_poses.from_numpy(
+    ...     position_array=rng.random((100, 2, 3, 2)),
+    ... )
+
+    Create a dataset with the same data as above, but name the individuals
+    ``Alice`` and ``Bob``, the keypoints ``snout``, ``centre``, and
+    ``tail_base``, and set all confidence scores to 1.
+
+    >>> ds = load_poses.from_numpy(
+    ...     position_array=rng.random((100, 2, 3, 2)),
+    ...     confidence_array=np.ones((100, 3, 2)),
+    ...     individual_names=["Alice", "Bob"],
+    ...     keypoint_names=["snout", "centre", "tail_base"],
+    ... )
+
+    Create a dataset with the same data as above, but specify that the
+    100 frames are numbered from the start frame 1200 to the end frame
+    1299, instead of defaulting to 0-based frame numbers.
+
     >>> ds = load_poses.from_numpy(
     ...     position_array=rng.random((100, 2, 3, 2)),
     ...     confidence_array=np.ones((100, 3, 2)),
@@ -104,30 +123,6 @@ def from_numpy(
     ...     individual_names=["Alice", "Bob"],
     ...     keypoint_names=["snout", "centre", "tail_base"],
     ...     frame_array=np.arange(1200, 1300).reshape(-1, 1),
-    ...     fps=30,
-    ... )
-
-    Create a dataset with the same data as above, but express the time
-    coordinate in frames, and assume the first tracked frame is frame 0.
-    To do this, we simply omit the ``frame_array`` input argument.
-
-    >>> ds = load_poses.from_numpy(
-    ...     position_array=rng.random((100, 2, 3, 2)),
-    ...     confidence_array=np.ones((100, 3, 2)),
-    ...     individual_names=["Alice", "Bob"],
-    ...     keypoint_names=["snout", "centre", "tail_base"],
-    ... )
-
-    Create a dataset with the same data as above, but express the time
-    coordinate in seconds, and assume the first tracked frame is captured
-    at time = 0 seconds. To do this, we omit the ``frame_array`` input
-    argument and pass an ``fps`` value.
-
-    >>> ds = load_poses.from_numpy(
-    ...     position_array=rng.random((100, 2, 3, 2)),
-    ...     confidence_array=np.ones((100, 3, 2)),
-    ...     individual_names=["Alice", "Bob"],
-    ...     keypoint_names=["snout", "centre", "tail_base"],
     ...     fps=30,
     ... )
 

--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -55,10 +55,10 @@ def from_numpy(
         (default), the keypoints will be named "keypoint_0", "keypoint_1",
         etc.
     frame_array
-        Array containing the frame numbers for which poses are defined.
-        It should be a column vector of shape (n_frames, 1). If None
-        (default), frame numbers are assigned as consecutive 0-based
-        integers.
+        Array containing the frame numbers corresponding to the data.
+        It must be a column vector of shape (n_frames, 1) and values
+        must be monotonically increasing. If None (default), frame
+        numbers are assigned as consecutive 0-based integers.
     fps
         Frames per second of the video. Defaults to None, in which case
         the time coordinates will be in frame numbers.
@@ -76,8 +76,9 @@ def from_numpy(
     --------
     Create random position data for two individuals, ``Alice`` and ``Bob``,
     with three keypoints each: ``snout``, ``centre``, and ``tail_base``.
-    These are tracked in 2D space over 100 frames, at 30 fps.
-    The confidence scores are set to 1 for all points.
+    These are tracked in 2D space for 100 frames, which are numbered from
+    the start frame 1200 to the end frame 1299. The confidence score for
+    all keypoints is set to 1.
 
     >>> import numpy as np
     >>> from movement.io import load_poses
@@ -87,7 +88,46 @@ def from_numpy(
     ...     confidence_array=np.ones((100, 3, 2)),
     ...     individual_names=["Alice", "Bob"],
     ...     keypoint_names=["snout", "centre", "tail_base"],
-    ...     frame_array=np.arange(10, 110).reshape(-1, 1),
+    ...     frame_array=np.arange(1200, 1300).reshape(-1, 1),
+    ... )
+
+    Create a dataset with the same data as above, but with the time
+    coordinates in seconds. We use a video sampling rate of 30 fps. The time
+    coordinates in the resulting dataset will indicate the elapsed time from
+    the capture of the 0th frame. So for the frames 1200, 1201, 1202, ...
+    1299 the corresponding time coordinates in seconds will be
+    40.0, 40.033..., 40.067..., ... 43.3 s.
+
+    >>> ds = load_poses.from_numpy(
+    ...     position_array=rng.random((100, 2, 3, 2)),
+    ...     confidence_array=np.ones((100, 3, 2)),
+    ...     individual_names=["Alice", "Bob"],
+    ...     keypoint_names=["snout", "centre", "tail_base"],
+    ...     frame_array=np.arange(1200, 1300).reshape(-1, 1),
+    ...     fps=30,
+    ... )
+
+    Create a dataset with the same data as above, but express the time
+    coordinate in frames, and assume the first tracked frame is frame 0.
+    To do this, we simply omit the ``frame_array`` input argument.
+
+    >>> ds = load_poses.from_numpy(
+    ...     position_array=rng.random((100, 2, 3, 2)),
+    ...     confidence_array=np.ones((100, 3, 2)),
+    ...     individual_names=["Alice", "Bob"],
+    ...     keypoint_names=["snout", "centre", "tail_base"],
+    ... )
+
+    Create a dataset with the same data as above, but express the time
+    coordinate in seconds, and assume the first tracked frame is captured
+    at time = 0 seconds. To do this, we omit the ``frame_array`` input
+    argument and pass an ``fps`` value.
+
+    >>> ds = load_poses.from_numpy(
+    ...     position_array=rng.random((100, 2, 3, 2)),
+    ...     confidence_array=np.ones((100, 3, 2)),
+    ...     individual_names=["Alice", "Bob"],
+    ...     keypoint_names=["snout", "centre", "tail_base"],
     ...     fps=30,
     ... )
 

--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -3,7 +3,7 @@
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
+from typing import Any, ClassVar, Literal, cast
 
 import attrs
 import numpy as np
@@ -12,9 +12,6 @@ from attrs import converters, define, field, validators
 from numpy.typing import NDArray
 
 from movement.utils.logging import logger
-
-if TYPE_CHECKING:
-    from numpy.typing import NDArray
 
 
 def _convert_to_list_of_str(value: str | Iterable[Any]) -> list[str]:
@@ -92,8 +89,8 @@ class _BaseDatasetInputs(ABC):
         validator=validators.optional(validators.instance_of(np.ndarray)),
     )
     """Array containing the frame numbers corresponding to the data.
-    The frame_array should be a column vector of shape (n_frames, 1)
-    and should be monotonically increasing. If None (default),
+    The frame_array must be a column vector of shape (n_frames, 1)
+    and values must be monotonically increasing. If None (default),
     frame numbers are assigned as consecutive 0-based integers.
     """
 
@@ -147,8 +144,7 @@ class _BaseDatasetInputs(ABC):
                 "Individual names were not provided. "
                 f"Setting to {self.individual_names}."
             )
-
-        # assign default frame_array
+        # frame_array default: 0-based integers up to n_frames - 1
         if self.frame_array is None:
             time_dim_index = self.DIM_NAMES.index("time")
             n_frames = self.position_array.shape[time_dim_index]
@@ -176,6 +172,30 @@ class _BaseDatasetInputs(ABC):
                 if d != "space"
             )
         ]
+
+    def _time_coords_and_attrs(
+        self,
+    ) -> tuple[NDArray[np.floating] | NDArray[np.integer], dict]:
+        """Return time coordinate values and associated dataset attrs.
+
+        If ``fps`` is provided, time is expressed in seconds (elapsed
+        from frame 0); otherwise, it is expressed in frames.
+        """
+        # Ignore type error as __attrs_post_init__ ensures
+        # `frame_array` is not None
+        time_coords: NDArray[np.floating] | NDArray[np.integer] = (
+            self.frame_array.squeeze()  # type: ignore[union-attr]
+        )
+        dataset_attrs: dict[str, str | float | None] = {
+            "source_software": self.source_software,
+        }
+        time_unit: Literal["seconds", "frames"] = "frames"
+        if self.fps:
+            time_coords = time_coords / self.fps
+            time_unit = "seconds"
+            dataset_attrs["fps"] = self.fps
+        dataset_attrs["time_unit"] = time_unit
+        return time_coords, dataset_attrs
 
     # --- Validators ---
     @position_array.validator
@@ -364,10 +384,8 @@ class ValidPosesInputs(_BaseDatasetInputs):
       with lengths matching the number of individuals and keypoints
       in the dataset, respectively; otherwise, default names are assigned.
     - The optional ``frame_array``, if provided, is a column vector
-      containing the frame numbers for which poses are defined.
-      The ``frame_array`` should have shape ``(n_frames, 1)``
-      and be monotonically increasing. If None (default),
-      frame numbers are assigned as consecutive 0-based integers.
+      with the frame numbers; otherwise, it defaults to an array of
+      consecutive 0-based integers.
     - The optional ``fps`` is a positive float; otherwise, it defaults to None.
     - The optional ``source_software`` is a string; otherwise,
       it defaults to None.
@@ -448,26 +466,8 @@ class ValidPosesInputs(_BaseDatasetInputs):
         """
         DIM_NAMES = self.DIM_NAMES
         n_space = self.position_array.shape[DIM_NAMES.index("space")]
-        dataset_attrs: dict[str, str | float | None] = {
-            "source_software": self.source_software,
-            "ds_type": "poses",
-        }
-        # Use frame_array as the time coordinate
-        # Ignore type error as _BaseDatasetInputs ensures
-        # `frame_array` is not None
-        time_coords: NDArray[np.floating] | NDArray[np.integer] = (
-            self.frame_array.squeeze()  # type: ignore[union-attr]
-        )
-
-        time_unit: Literal["seconds", "frames"] = "frames"
-
-        # If fps is provided, express time in seconds
-        if self.fps is not None:
-            time_coords = time_coords / self.fps
-            time_unit = "seconds"
-            dataset_attrs["fps"] = self.fps
-
-        dataset_attrs["time_unit"] = time_unit
+        time_coords, dataset_attrs = self._time_coords_and_attrs()
+        dataset_attrs["ds_type"] = "poses"
 
         # confidence_array may be point-wise (all non-space dims) or
         # individual-wise (non-space and non-keypoint dims)
@@ -518,7 +518,7 @@ class ValidBboxesInputs(_BaseDatasetInputs):
       individuals in the dataset; otherwise, default names are assigned.
     - The optional ``frame_array``, if provided, is a column vector
       with the frame numbers; otherwise, it defaults to an array of
-      0-based integers.
+      consecutive 0-based integers.
     - The optional ``fps`` is a positive float; otherwise, it defaults to None.
     - The optional ``source_software`` is a string; otherwise, it defaults to
       None.
@@ -552,10 +552,6 @@ class ValidBboxesInputs(_BaseDatasetInputs):
             attribute, value, expected_shape=self.position_array.shape
         )
 
-    def __attrs_post_init__(self):
-        """Assign default values to optional attributes (if None)."""
-        super().__attrs_post_init__()
-
     def to_dataset(self) -> xr.Dataset:
         """Convert validated bboxes inputs to a ``movement bboxes`` dataset.
 
@@ -566,26 +562,8 @@ class ValidBboxesInputs(_BaseDatasetInputs):
             shapes, confidence scores and associated metadata.
 
         """
-        dataset_attrs: dict[str, str | float | None] = {
-            "source_software": self.source_software,
-            "ds_type": "bboxes",
-        }
-        # Ignore type error as _BaseDatasetInputs ensures
-        # `frame_array` is not None
-        time_coords: NDArray[np.floating] | NDArray[np.integer] = (
-            self.frame_array.squeeze()  # type: ignore[union-attr]
-        )
-        time_unit: Literal["seconds", "frames"] = "frames"
-        # if fps is provided:
-        # time_coords is expressed in seconds, with the time origin
-        # set as frame 0 == time 0 seconds
-        # Store fps as a dataset attribute
-        if self.fps:
-            # Compute elapsed time from frame 0.
-            time_coords = time_coords / self.fps
-            time_unit = "seconds"
-            dataset_attrs["fps"] = self.fps
-        dataset_attrs["time_unit"] = time_unit
+        time_coords, dataset_attrs = self._time_coords_and_attrs()
+        dataset_attrs["ds_type"] = "bboxes"
         # Convert data to an xarray.Dataset
         # with dimensions ('time', 'space', 'individual')
         DIM_NAMES = self.DIM_NAMES

--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -323,6 +323,11 @@ class ValidPosesInputs(_BaseDatasetInputs):
       if provided, is a list of unique names for the individuals and keypoints,
       with lengths matching the number of individuals and keypoints
       in the dataset, respectively; otherwise, default names are assigned.
+    - The optional ``frame_array``, if provided, is a column vector
+      containing the frame numbers for which poses are defined.
+      The ``frame_array`` should have shape ``(n_frames, 1)``
+      and be monotonically increasing. If None (default),
+      frame numbers are assigned as consecutive 0-based integers.
     - The optional ``fps`` is a positive float; otherwise, it defaults to None.
     - The optional ``source_software`` is a string; otherwise,
       it defaults to None.
@@ -342,6 +347,15 @@ class ValidPosesInputs(_BaseDatasetInputs):
     """List of unique names for the keypoints in the skeleton. If None
     (default), the keypoints will be named "keypoint_0", "keypoint_1",
     etc."""
+
+    frame_array: np.ndarray | None = field(
+        default=None,
+        validator=validators.optional(validators.instance_of(np.ndarray)),
+    )
+    """Array containing the frame numbers for which poses are defined.
+    The frame_array should be a column vector of shape (n_frames, 1)
+    and should be monotonically increasing. If None (default),
+    frame numbers are assigned as consecutive 0-based integers."""
 
     DIM_NAMES: ClassVar[tuple[str, ...]] = (
         "time",
@@ -376,6 +390,26 @@ class ValidPosesInputs(_BaseDatasetInputs):
         )
         self._validate_list_uniqueness(attribute, value)
 
+    @frame_array.validator
+    def _validate_frame_array(self, attribute, value):
+        """Validate frame_array type, shape, and monotonicity."""
+        if value is not None:
+            # should be a column vector (n_frames, 1)
+            time_dim_index = self.DIM_NAMES.index("time")
+            self._validate_array_shape(
+                attribute,
+                value,
+                expected_shape=(self.position_array.shape[time_dim_index], 1),
+            )
+            # check frames are monotonically increasing
+            if not np.all(np.diff(value, axis=0) >= 1):
+                raise logger.error(
+                    ValueError(
+                        f"Frame numbers in {attribute.name} are "
+                        "not monotonically increasing."
+                    )
+                )
+
     def __attrs_post_init__(self):
         """Assign default values to optional attributes (if None)."""
         super().__attrs_post_init__()
@@ -390,6 +424,14 @@ class ValidPosesInputs(_BaseDatasetInputs):
                 "Keypoint names were not provided. "
                 f"Setting to {self.keypoint_names}."
             )
+        if self.frame_array is None:
+            time_dim_index = self.DIM_NAMES.index("time")
+            n_frames = position_array_shape[time_dim_index]
+            self.frame_array = np.arange(n_frames).reshape(-1, 1)
+            logger.info(
+                "Frame numbers were not provided. "
+                "Setting to an array of 0-based integers."
+            )
 
     def to_dataset(self) -> xr.Dataset:
         """Convert validated poses inputs to a ``movement poses`` dataset.
@@ -402,23 +444,28 @@ class ValidPosesInputs(_BaseDatasetInputs):
 
         """
         DIM_NAMES = self.DIM_NAMES
-        n_frames = self.position_array.shape[DIM_NAMES.index("time")]
         n_space = self.position_array.shape[DIM_NAMES.index("space")]
         dataset_attrs: dict[str, str | float | None] = {
             "source_software": self.source_software,
             "ds_type": "poses",
         }
-        # Create the time coordinate, depending on the value of fps
-        time_coords: NDArray[np.floating] | NDArray[np.integer]
-        time_unit: Literal["seconds", "frames"]
+        # Use frame_array as the time coordinate
+        # Ignore type error as ValidPosesInputs ensures
+        # `frame_array` is not None
+        time_coords: NDArray[np.floating] | NDArray[np.integer] = (
+            self.frame_array.squeeze()  # type: ignore[union-attr]
+        )
+
+        time_unit: Literal["seconds", "frames"] = "frames"
+
+        # If fps is provided, express time in seconds
         if self.fps is not None:
-            time_coords = np.arange(n_frames, dtype=np.float64) / self.fps
+            time_coords = time_coords / self.fps
             time_unit = "seconds"
             dataset_attrs["fps"] = self.fps
-        else:
-            time_coords = np.arange(n_frames, dtype=np.int64)
-            time_unit = "frames"
+
         dataset_attrs["time_unit"] = time_unit
+
         # confidence_array may be point-wise (all non-space dims) or
         # individual-wise (non-space and non-keypoint dims)
         confidence_dims = tuple(d for d in DIM_NAMES if d != "space")

--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -173,30 +173,6 @@ class _BaseDatasetInputs(ABC):
             )
         ]
 
-    def _time_coords_and_attrs(
-        self,
-    ) -> tuple[NDArray[np.floating] | NDArray[np.integer], dict]:
-        """Return time coordinate values and associated dataset attrs.
-
-        If ``fps`` is provided, time is expressed in seconds (elapsed
-        from frame 0); otherwise, it is expressed in frames.
-        """
-        # Ignore type error as __attrs_post_init__ ensures
-        # `frame_array` is not None
-        time_coords: NDArray[np.floating] | NDArray[np.integer] = (
-            self.frame_array.squeeze()  # type: ignore[union-attr]
-        )
-        dataset_attrs: dict[str, str | float | None] = {
-            "source_software": self.source_software,
-        }
-        time_unit: Literal["seconds", "frames"] = "frames"
-        if self.fps:
-            time_coords = time_coords / self.fps
-            time_unit = "seconds"
-            dataset_attrs["fps"] = self.fps
-        dataset_attrs["time_unit"] = time_unit
-        return time_coords, dataset_attrs
-
     # --- Validators ---
     @position_array.validator
     def _validate_position_array(self, attribute, value):
@@ -267,6 +243,30 @@ class _BaseDatasetInputs(ABC):
             self._validate_list_uniqueness(attribute, value)
 
     # --- Utility methods ---
+    def _time_coords_and_attrs(
+        self,
+    ) -> tuple[NDArray[np.floating] | NDArray[np.integer], dict]:
+        """Return time coordinate values and associated dataset attrs.
+
+        If ``fps`` is provided, time is expressed in seconds (elapsed
+        from frame 0); otherwise, it is expressed in frames.
+        """
+        # Ignore type error as __attrs_post_init__ ensures
+        # `frame_array` is not None
+        time_coords: NDArray[np.floating] | NDArray[np.integer] = (
+            self.frame_array.squeeze()  # type: ignore[union-attr]
+        )
+        dataset_attrs: dict[str, str | float | None] = {
+            "source_software": self.source_software,
+        }
+        time_unit: Literal["seconds", "frames"] = "frames"
+        if self.fps:
+            time_coords = time_coords / self.fps
+            time_unit = "seconds"
+            dataset_attrs["fps"] = self.fps
+        dataset_attrs["time_unit"] = time_unit
+        return time_coords, dataset_attrs
+
     @staticmethod
     def _validate_array_shape(
         attribute: attrs.Attribute,

--- a/movement/validators/datasets.py
+++ b/movement/validators/datasets.py
@@ -56,8 +56,8 @@ class _BaseDatasetInputs(ABC):
     assignment logic for creating ``movement`` datasets
     (e.g. poses, bounding boxes).
     It registers the attrs validators for required fields like
-    ``position_array`` and optional fields like ``confidence_array`` and
-    ``individual_names``.
+    ``position_array`` and optional fields like ``confidence_array``,
+    ``individual_names``, and ``frame_array``.
     Subclasses must implement ``to_dataset()`` and define class variables
     ``DIM_NAMES``, ``VAR_NAMES``, and ``_ALLOWED_SPACE_DIM_SIZE``.
     """
@@ -86,6 +86,16 @@ class _BaseDatasetInputs(ABC):
     ``position_array``. If None (default), the names will be in the format of
     ``id_<N>``, where <N> is an integer from 0 to the size of the
     'individual' dimension minus 1."""
+
+    frame_array: np.ndarray | None = field(
+        default=None,
+        validator=validators.optional(validators.instance_of(np.ndarray)),
+    )
+    """Array containing the frame numbers corresponding to the data.
+    The frame_array should be a column vector of shape (n_frames, 1)
+    and should be monotonically increasing. If None (default),
+    frame numbers are assigned as consecutive 0-based integers.
+    """
 
     fps: float | None = field(
         default=None,
@@ -136,6 +146,16 @@ class _BaseDatasetInputs(ABC):
             logger.info(
                 "Individual names were not provided. "
                 f"Setting to {self.individual_names}."
+            )
+
+        # assign default frame_array
+        if self.frame_array is None:
+            time_dim_index = self.DIM_NAMES.index("time")
+            n_frames = self.position_array.shape[time_dim_index]
+            self.frame_array = np.arange(n_frames).reshape(-1, 1)
+            logger.info(
+                "Frame numbers were not provided. "
+                "Setting to an array of 0-based integers."
             )
 
     # --- Properties (derived attributes) ---
@@ -193,6 +213,26 @@ class _BaseDatasetInputs(ABC):
             self._validate_array_shape(
                 attribute, value, self._confidence_expected_shapes
             )
+
+    @frame_array.validator
+    def _validate_frame_array(self, attribute, value):
+        """Validate frame_array type, shape, and monotonicity."""
+        if value is not None:
+            # should be a column vector (n_frames, 1)
+            time_dim_index = self.DIM_NAMES.index("time")
+            self._validate_array_shape(
+                attribute,
+                value,
+                expected_shape=(self.position_array.shape[time_dim_index], 1),
+            )
+            # check frames are monotonically increasing
+            if not np.all(np.diff(value, axis=0) >= 1):
+                raise logger.error(
+                    ValueError(
+                        f"Frame numbers in '{attribute.name}' are "
+                        "not monotonically increasing."
+                    )
+                )
 
     @individual_names.validator
     def _validate_individual_names(self, attribute, value):
@@ -348,15 +388,6 @@ class ValidPosesInputs(_BaseDatasetInputs):
     (default), the keypoints will be named "keypoint_0", "keypoint_1",
     etc."""
 
-    frame_array: np.ndarray | None = field(
-        default=None,
-        validator=validators.optional(validators.instance_of(np.ndarray)),
-    )
-    """Array containing the frame numbers for which poses are defined.
-    The frame_array should be a column vector of shape (n_frames, 1)
-    and should be monotonically increasing. If None (default),
-    frame numbers are assigned as consecutive 0-based integers."""
-
     DIM_NAMES: ClassVar[tuple[str, ...]] = (
         "time",
         "space",
@@ -390,26 +421,6 @@ class ValidPosesInputs(_BaseDatasetInputs):
         )
         self._validate_list_uniqueness(attribute, value)
 
-    @frame_array.validator
-    def _validate_frame_array(self, attribute, value):
-        """Validate frame_array type, shape, and monotonicity."""
-        if value is not None:
-            # should be a column vector (n_frames, 1)
-            time_dim_index = self.DIM_NAMES.index("time")
-            self._validate_array_shape(
-                attribute,
-                value,
-                expected_shape=(self.position_array.shape[time_dim_index], 1),
-            )
-            # check frames are monotonically increasing
-            if not np.all(np.diff(value, axis=0) >= 1):
-                raise logger.error(
-                    ValueError(
-                        f"Frame numbers in {attribute.name} are "
-                        "not monotonically increasing."
-                    )
-                )
-
     def __attrs_post_init__(self):
         """Assign default values to optional attributes (if None)."""
         super().__attrs_post_init__()
@@ -423,14 +434,6 @@ class ValidPosesInputs(_BaseDatasetInputs):
             logger.info(
                 "Keypoint names were not provided. "
                 f"Setting to {self.keypoint_names}."
-            )
-        if self.frame_array is None:
-            time_dim_index = self.DIM_NAMES.index("time")
-            n_frames = position_array_shape[time_dim_index]
-            self.frame_array = np.arange(n_frames).reshape(-1, 1)
-            logger.info(
-                "Frame numbers were not provided. "
-                "Setting to an array of 0-based integers."
             )
 
     def to_dataset(self) -> xr.Dataset:
@@ -450,7 +453,7 @@ class ValidPosesInputs(_BaseDatasetInputs):
             "ds_type": "poses",
         }
         # Use frame_array as the time coordinate
-        # Ignore type error as ValidPosesInputs ensures
+        # Ignore type error as _BaseDatasetInputs ensures
         # `frame_array` is not None
         time_coords: NDArray[np.floating] | NDArray[np.integer] = (
             self.frame_array.squeeze()  # type: ignore[union-attr]
@@ -536,16 +539,6 @@ class ValidBboxesInputs(_BaseDatasetInputs):
     (extent along the y-axis of the image). The shape_array must have the same
     shape as the position_array."""
 
-    frame_array: np.ndarray | None = field(
-        default=None,
-        validator=validators.optional(validators.instance_of(np.ndarray)),
-    )
-    """Array containing the frame numbers for which bounding boxes are defined.
-    The frame_array should be a column vector of shape (n_frames, 1) and should
-    be monotonically increasing. If None (default), frame numbers will be
-    assigned based on the first dimension of the position_array, starting from
-    0."""
-
     DIM_NAMES: ClassVar[tuple[str, ...]] = ("time", "space", "individual")
     VAR_NAMES: ClassVar[tuple[str, ...]] = ("position", "shape", "confidence")
     _ALLOWED_SPACE_DIM_SIZE: ClassVar[int] = 2
@@ -559,38 +552,9 @@ class ValidBboxesInputs(_BaseDatasetInputs):
             attribute, value, expected_shape=self.position_array.shape
         )
 
-    @frame_array.validator
-    def _validate_frame_array(self, attribute, value):
-        """Validate frame_array type, shape, and monotonicity."""
-        if value is not None:
-            # should be a column vector (n_frames, 1)
-            time_dim_index = self.DIM_NAMES.index("time")
-            self._validate_array_shape(
-                attribute,
-                value,
-                expected_shape=(self.position_array.shape[time_dim_index], 1),
-            )
-            # check frames are monotonically increasing
-            if not np.all(np.diff(value, axis=0) >= 1):
-                raise logger.error(
-                    ValueError(
-                        f"Frame numbers in {attribute.name} are "
-                        "not monotonically increasing."
-                    )
-                )
-
     def __attrs_post_init__(self):
         """Assign default values to optional attributes (if None)."""
         super().__attrs_post_init__()
-        # assign default frame_array
-        if self.frame_array is None:
-            time_dim_index = self.DIM_NAMES.index("time")
-            n_frames = self.position_array.shape[time_dim_index]
-            self.frame_array = np.arange(n_frames).reshape(-1, 1)
-            logger.info(
-                "Frame numbers were not provided. "
-                "Setting to an array of 0-based integers."
-            )
 
     def to_dataset(self) -> xr.Dataset:
         """Convert validated bboxes inputs to a ``movement bboxes`` dataset.
@@ -606,7 +570,7 @@ class ValidBboxesInputs(_BaseDatasetInputs):
             "source_software": self.source_software,
             "ds_type": "bboxes",
         }
-        # Ignore type error as ValidBboxesInputs ensures
+        # Ignore type error as _BaseDatasetInputs ensures
         # `frame_array` is not None
         time_coords: NDArray[np.floating] | NDArray[np.integer] = (
             self.frame_array.squeeze()  # type: ignore[union-attr]

--- a/tests/test_unit/test_io/test_load_poses.py
+++ b/tests/test_unit/test_io/test_load_poses.py
@@ -202,23 +202,32 @@ def test_load_multi_individual_from_lp_file_raises():
         load_poses.from_lp_file(file_path)
 
 
+@pytest.mark.parametrize("with_frame_array", [True, False])
+@pytest.mark.parametrize("fps", [None, 30, 60.0])
 @pytest.mark.parametrize("source_software", [None, "SLEAP"])
-def test_from_numpy_valid(valid_poses_arrays, source_software, helpers):
+def test_from_numpy_valid(
+    valid_poses_arrays, with_frame_array, fps, source_software, helpers
+):
     """Test that loading pose tracks from a multi-animal numpy array
     with valid parameters returns a proper Dataset.
     """
     poses_arrays = valid_poses_arrays("multi_individual_array")
+    frame_array = (
+        np.arange(1200, 1210).reshape(-1, 1) if with_frame_array else None
+    )
     ds = load_poses.from_numpy(
         poses_arrays["position"],
         poses_arrays["confidence"],
         individual_names=["id_0", "id_1"],
         keypoint_names=["centroid", "left", "right"],
-        fps=None,
+        frame_array=frame_array,
+        fps=fps,
         source_software=source_software,
     )
     expected_values = {
         **expected_values_poses,
         "source_software": source_software,
+        "fps": fps,
     }
     helpers.assert_valid_dataset(ds, expected_values)
 

--- a/tests/test_unit/test_validators/test_datasets_validators.py
+++ b/tests/test_unit/test_validators/test_datasets_validators.py
@@ -298,66 +298,38 @@ class TestBaseDatasetInputs:
             )
 
     @pytest.mark.parametrize(
-        "frame_array, fps, expected_time, expected_attrs",
+        "fps, expected_time_unit", [(None, "frames"), (2, "seconds")]
+    )
+    @pytest.mark.parametrize(
+        "frame_array, expected_time",
         [
-            (
-                np.arange(5)[:, None],
-                None,
-                np.arange(5),
-                {
-                    "source_software": None,
-                    "time_unit": "frames",
-                },
-            ),
-            (
-                np.arange(5)[:, None],
-                2,
-                np.arange(5) / 2,
-                {
-                    "source_software": None,
-                    "fps": 2.0,
-                    "time_unit": "seconds",
-                },
-            ),
-            (
-                np.arange(10, 15)[:, None],
-                None,
-                np.arange(10, 15),
-                {
-                    "source_software": None,
-                    "time_unit": "frames",
-                },
-            ),
-            (
-                np.arange(10, 15)[:, None],
-                10,
-                np.arange(10, 15) / 10,
-                {
-                    "source_software": None,
-                    "fps": 10.0,
-                    "time_unit": "seconds",
-                },
-            ),
+            (np.arange(5)[:, None], np.arange(5)),
+            (np.arange(10, 15)[:, None], np.arange(10, 15)),
         ],
+        ids=["zero-based frame numbers", "non-zero-based frame numbers"],
     )
     def test_time_coords_and_attrs(
-        self, frame_array, fps, expected_time, expected_attrs
+        self, frame_array, fps, expected_time, expected_time_unit
     ):
-        """Test _time_coords_and_attrs."""
+        """Test _time_coords_and_attrs time coords and unit assignment."""
         stub_dataset_inputs_class = self.make_stub_dataset_inputs_class(
             dim_names=("time", "space")
         )
-
         data = stub_dataset_inputs_class(
             position_array=np.zeros((5, 2)),
             frame_array=frame_array,
             fps=fps,
         )
-
+        expected_dataset_attrs = {
+            "source_software": None,
+            "time_unit": expected_time_unit,
+        }
         time_coords, dataset_attrs = data._time_coords_and_attrs()
-
+        if fps is not None:
+            expected_time = expected_time / fps
+            expected_dataset_attrs["fps"] = fps
         np.testing.assert_allclose(time_coords, expected_time)
-        assert dataset_attrs == expected_attrs
+        assert dataset_attrs == expected_dataset_attrs
 
     @pytest.mark.parametrize(
         "val, expected_length, expected_exception",

--- a/tests/test_unit/test_validators/test_datasets_validators.py
+++ b/tests/test_unit/test_validators/test_datasets_validators.py
@@ -346,7 +346,75 @@ class TestValidPosesInputs:
             )
             assert data.keypoint_names == expected_keypoint_names
 
+    @pytest.mark.parametrize(
+        "frame_array, expected_context",
+        [
+            (None, does_not_raise(np.arange(5)[:, None])),
+            (
+                np.arange(3, 8)[:, None],
+                does_not_raise(np.arange(3, 8)[:, None]),
+            ),
+            (
+                np.arange(3, 12, 2)[:, None],
+                does_not_raise(np.arange(3, 12, 2)[:, None]),
+            ),
+            (
+                np.arange(5)[::-1][:, None],
+                pytest.raises(
+                    ValueError,
+                    match="not monotonically increasing",
+                ),
+            ),
+            (
+                np.zeros((5, 2)),
+                pytest.raises(
+                    ValueError,
+                    match=re.escape("have shape [(5, 1)], but got (5, 2)"),
+                ),
+            ),
+            (
+                np.zeros((7, 1)),
+                pytest.raises(
+                    ValueError,
+                    match=re.escape("have shape [(5, 1)], but got (7, 1)"),
+                ),
+            ),
+        ],
+        ids=[
+            "Not provided, use default",
+            "Consecutive monotonically increasing",
+            "Non-consecutive but monotonically increasing",
+            "Non-monotonically increasing frame numbers",
+            "Shape mismatch: not a column vector",
+            "Shape mismatch: frame number different from position_array",
+        ],
+    )
+    def test_frame_array(self, frame_array, expected_context):
+        """Test frame_array validation in ValidPosesInputs."""
+        position_array = np.zeros((5, 2, 3, 2))
+
+        with expected_context as expected_frame_array:
+            data = ValidPosesInputs(
+                position_array=position_array,
+                frame_array=frame_array,
+            )
+            np.testing.assert_array_equal(
+                data.frame_array,
+                expected_frame_array,
+            )
+
     @pytest.mark.parametrize("fps", [30, None])
+    @pytest.mark.parametrize(
+        "frame_array",
+        [
+            None,
+            np.arange(10, 20)[:, None],
+        ],
+        ids=[
+            "Default frame numbers",
+            "Custom frame numbers",
+        ],
+    )
     @pytest.mark.parametrize(
         "dataset_fixture",
         [
@@ -358,7 +426,7 @@ class TestValidPosesInputs:
             "Individual-wise confidence array",
         ],
     )
-    def test_to_dataset(self, fps, dataset_fixture, request):
+    def test_to_dataset(self, fps, frame_array, dataset_fixture, request):
         """Test to_dataset creates the expected poses dataset."""
         valid_poses_dataset = request.getfixturevalue(dataset_fixture)
         ds = ValidPosesInputs(
@@ -366,17 +434,23 @@ class TestValidPosesInputs:
             confidence_array=valid_poses_dataset.confidence.values,
             individual_names=valid_poses_dataset.individual.values,
             keypoint_names=valid_poses_dataset.keypoint.values,
+            frame_array=frame_array,
             fps=fps,
             source_software=valid_poses_dataset.attrs["source_software"],
         ).to_dataset()
-        if fps is None:
-            xr.testing.assert_equal(ds, valid_poses_dataset)
-        else:
-            expected_ds = valid_poses_dataset.assign_coords(
-                time=valid_poses_dataset.time.values / fps
+
+        expected_ds = valid_poses_dataset
+
+        if frame_array is not None:
+            expected_ds = expected_ds.assign_coords(time=frame_array.squeeze())
+
+        if fps is not None:
+            expected_ds = expected_ds.assign_coords(
+                time=expected_ds.time.values / fps
             )
             expected_ds.time.attrs["units"] = "seconds"
-            xr.testing.assert_equal(ds, expected_ds)
+
+        xr.testing.assert_equal(ds, expected_ds)
 
     @pytest.mark.parametrize(
         "confidence_array, expected_context",

--- a/tests/test_unit/test_validators/test_datasets_validators.py
+++ b/tests/test_unit/test_validators/test_datasets_validators.py
@@ -164,6 +164,10 @@ class TestBaseDatasetInputs:
         np.testing.assert_allclose(
             data.confidence_array, expected_confidence, equal_nan=True
         )
+        np.testing.assert_array_equal(
+            data.frame_array,
+            np.arange(position_array.shape[0]).reshape(-1, 1),
+        )
         assert data.individual_names == expected_ind_names
         assert data.fps is None
         assert data.source_software is None
@@ -228,6 +232,69 @@ class TestBaseDatasetInputs:
         with expected_exception:
             stub_dataset_inputs_class._validate_array_shape(
                 self.StubAttr(), val, expected_shape
+            )
+
+    @pytest.mark.parametrize(
+        "frame_array, expected_context",
+        [
+            (
+                None,
+                does_not_raise(np.arange(5)[:, None]),
+            ),
+            (
+                np.arange(3, 8)[:, None],
+                does_not_raise(np.arange(3, 8)[:, None]),
+            ),
+            (
+                np.arange(3, 12, 2)[:, None],
+                does_not_raise(np.arange(3, 12, 2)[:, None]),
+            ),
+            (
+                np.arange(5)[::-1][:, None],
+                pytest.raises(
+                    ValueError,
+                    match="not monotonically increasing",
+                ),
+            ),
+            (
+                np.zeros((5, 2)),
+                pytest.raises(
+                    ValueError,
+                    match=re.escape("have shape [(5, 1)], but got (5, 2)"),
+                ),
+            ),
+            (
+                np.zeros((7, 1)),
+                pytest.raises(
+                    ValueError,
+                    match=re.escape("have shape [(5, 1)], but got (7, 1)"),
+                ),
+            ),
+        ],
+        ids=[
+            "Not provided, use default",
+            "Consecutive monotonically increasing",
+            "Non-consecutive but monotonically increasing",
+            "Non-monotonically increasing frame numbers",
+            "Shape mismatch: not a column vector",
+            "Shape mismatch: frame number different from position_array",
+        ],
+    )
+    def test_validate_frame_array(self, frame_array, expected_context):
+        """Test frame_array validation and default assignment."""
+        stub_dataset_inputs_class = self.make_stub_dataset_inputs_class(
+            dim_names=("time", "space")
+        )
+        position_array = np.zeros((5, 2))
+
+        with expected_context as expected_frame_array:
+            data = stub_dataset_inputs_class(
+                position_array=position_array,
+                frame_array=frame_array,
+            )
+            np.testing.assert_array_equal(
+                data.frame_array,
+                expected_frame_array,
             )
 
     @pytest.mark.parametrize(
@@ -345,63 +412,6 @@ class TestValidPosesInputs:
                 keypoint_names=keypoint_names,
             )
             assert data.keypoint_names == expected_keypoint_names
-
-    @pytest.mark.parametrize(
-        "frame_array, expected_context",
-        [
-            (None, does_not_raise(np.arange(5)[:, None])),
-            (
-                np.arange(3, 8)[:, None],
-                does_not_raise(np.arange(3, 8)[:, None]),
-            ),
-            (
-                np.arange(3, 12, 2)[:, None],
-                does_not_raise(np.arange(3, 12, 2)[:, None]),
-            ),
-            (
-                np.arange(5)[::-1][:, None],
-                pytest.raises(
-                    ValueError,
-                    match="not monotonically increasing",
-                ),
-            ),
-            (
-                np.zeros((5, 2)),
-                pytest.raises(
-                    ValueError,
-                    match=re.escape("have shape [(5, 1)], but got (5, 2)"),
-                ),
-            ),
-            (
-                np.zeros((7, 1)),
-                pytest.raises(
-                    ValueError,
-                    match=re.escape("have shape [(5, 1)], but got (7, 1)"),
-                ),
-            ),
-        ],
-        ids=[
-            "Not provided, use default",
-            "Consecutive monotonically increasing",
-            "Non-consecutive but monotonically increasing",
-            "Non-monotonically increasing frame numbers",
-            "Shape mismatch: not a column vector",
-            "Shape mismatch: frame number different from position_array",
-        ],
-    )
-    def test_frame_array(self, frame_array, expected_context):
-        """Test frame_array validation in ValidPosesInputs."""
-        position_array = np.zeros((5, 2, 3, 2))
-
-        with expected_context as expected_frame_array:
-            data = ValidPosesInputs(
-                position_array=position_array,
-                frame_array=frame_array,
-            )
-            np.testing.assert_array_equal(
-                data.frame_array,
-                expected_frame_array,
-            )
 
     @pytest.mark.parametrize("fps", [30, None])
     @pytest.mark.parametrize(
@@ -535,79 +545,35 @@ class TestValidBboxesInputs:
                 shape_array=shape_array,
             )
 
+    @pytest.mark.parametrize("fps", [30, None])
     @pytest.mark.parametrize(
-        "frame_array, expected_context",
+        "frame_array",
         [
-            (None, does_not_raise(np.arange(5)[:, None])),
-            (
-                np.arange(3, 8)[:, None],
-                does_not_raise(np.arange(3, 8)[:, None]),
-            ),
-            (
-                np.arange(3, 12, 2)[:, None],
-                does_not_raise(np.arange(3, 12, 2)[:, None]),
-            ),
-            (
-                np.arange(5)[::-1][:, None],
-                pytest.raises(
-                    ValueError,
-                    match="not monotonically increasing",
-                ),
-            ),
-            (
-                np.zeros((5, 2)),
-                pytest.raises(
-                    ValueError,
-                    match=re.escape("have shape [(5, 1)], but got (5, 2)"),
-                ),
-            ),
-            (
-                np.zeros((7, 1)),
-                pytest.raises(
-                    ValueError,
-                    match=re.escape("have shape [(5, 1)], but got (7, 1)"),
-                ),
-            ),
+            None,
+            np.arange(10, 20)[:, None],
         ],
         ids=[
-            "Not provided, use default",
-            "Consecutive monotonically increasing",
-            "Non-consecutive but monotonically increasing",
-            "Non-monotonically increasing frame numbers",
-            "Shape mismatch: not a column vector",
-            "Shape mismatch: frame number different from position_array",
+            "Default frame numbers",
+            "Custom frame numbers",
         ],
     )
-    def test_frame_array(self, frame_array, expected_context):
-        """Test frame_array validation."""
-        position_array = np.zeros((5, 2, 3))  # time, space, individual
-        shape_array = np.zeros((5, 2, 3))
-        with expected_context as expected_frame_array:
-            data = ValidBboxesInputs(
-                position_array=position_array,
-                shape_array=shape_array,
-                frame_array=frame_array,
-            )
-            np.testing.assert_array_equal(
-                data.frame_array, expected_frame_array
-            )
-
-    @pytest.mark.parametrize("fps", [30, None])
-    def test_to_dataset(self, fps, valid_bboxes_dataset):
+    def test_to_dataset(self, fps, frame_array, valid_bboxes_dataset):
         """Test to_dataset creates the expected bboxes dataset."""
         ds = ValidBboxesInputs(
             position_array=valid_bboxes_dataset.position.values,
             shape_array=valid_bboxes_dataset.shape.values,
             confidence_array=valid_bboxes_dataset.confidence.values,
             individual_names=valid_bboxes_dataset.individual.values,
+            frame_array=frame_array,
             fps=fps,
             source_software=valid_bboxes_dataset.attrs["source_software"],
         ).to_dataset()
-        if fps is None:
-            xr.testing.assert_equal(ds, valid_bboxes_dataset)
-        else:
-            expected_ds = valid_bboxes_dataset.assign_coords(
-                time=valid_bboxes_dataset.time.values / fps
+        expected_ds = valid_bboxes_dataset
+        if frame_array is not None:
+            expected_ds = expected_ds.assign_coords(time=frame_array.squeeze())
+        if fps is not None:
+            expected_ds = expected_ds.assign_coords(
+                time=expected_ds.time.values / fps
             )
             expected_ds.time.attrs["units"] = "seconds"
-            xr.testing.assert_equal(ds, expected_ds)
+        xr.testing.assert_equal(ds, expected_ds)

--- a/tests/test_unit/test_validators/test_datasets_validators.py
+++ b/tests/test_unit/test_validators/test_datasets_validators.py
@@ -280,7 +280,7 @@ class TestBaseDatasetInputs:
             "Shape mismatch: frame number different from position_array",
         ],
     )
-    def test_validate_frame_array(self, frame_array, expected_context):
+    def test_frame_array(self, frame_array, expected_context):
         """Test frame_array validation and default assignment."""
         stub_dataset_inputs_class = self.make_stub_dataset_inputs_class(
             dim_names=("time", "space")
@@ -296,6 +296,68 @@ class TestBaseDatasetInputs:
                 data.frame_array,
                 expected_frame_array,
             )
+
+    @pytest.mark.parametrize(
+        "frame_array, fps, expected_time, expected_attrs",
+        [
+            (
+                np.arange(5)[:, None],
+                None,
+                np.arange(5),
+                {
+                    "source_software": None,
+                    "time_unit": "frames",
+                },
+            ),
+            (
+                np.arange(5)[:, None],
+                2,
+                np.arange(5) / 2,
+                {
+                    "source_software": None,
+                    "fps": 2.0,
+                    "time_unit": "seconds",
+                },
+            ),
+            (
+                np.arange(10, 15)[:, None],
+                None,
+                np.arange(10, 15),
+                {
+                    "source_software": None,
+                    "time_unit": "frames",
+                },
+            ),
+            (
+                np.arange(10, 15)[:, None],
+                10,
+                np.arange(10, 15) / 10,
+                {
+                    "source_software": None,
+                    "fps": 10.0,
+                    "time_unit": "seconds",
+                },
+            ),
+        ],
+    )
+    def test_time_coords_and_attrs(
+        self, frame_array, fps, expected_time, expected_attrs
+    ):
+        """Test _time_coords_and_attrs."""
+        stub_dataset_inputs_class = self.make_stub_dataset_inputs_class(
+            dim_names=("time", "space")
+        )
+
+        data = stub_dataset_inputs_class(
+            position_array=np.zeros((5, 2)),
+            frame_array=frame_array,
+            fps=fps,
+        )
+
+        time_coords, dataset_attrs = data._time_coords_and_attrs()
+
+        np.testing.assert_allclose(time_coords, expected_time)
+        assert dataset_attrs == expected_attrs
 
     @pytest.mark.parametrize(
         "val, expected_length, expected_exception",
@@ -413,18 +475,6 @@ class TestValidPosesInputs:
             )
             assert data.keypoint_names == expected_keypoint_names
 
-    @pytest.mark.parametrize("fps", [30, None])
-    @pytest.mark.parametrize(
-        "frame_array",
-        [
-            None,
-            np.arange(10, 20)[:, None],
-        ],
-        ids=[
-            "Default frame numbers",
-            "Custom frame numbers",
-        ],
-    )
     @pytest.mark.parametrize(
         "dataset_fixture",
         [
@@ -436,7 +486,7 @@ class TestValidPosesInputs:
             "Individual-wise confidence array",
         ],
     )
-    def test_to_dataset(self, fps, frame_array, dataset_fixture, request):
+    def test_to_dataset(self, dataset_fixture, request):
         """Test to_dataset creates the expected poses dataset."""
         valid_poses_dataset = request.getfixturevalue(dataset_fixture)
         ds = ValidPosesInputs(
@@ -444,23 +494,9 @@ class TestValidPosesInputs:
             confidence_array=valid_poses_dataset.confidence.values,
             individual_names=valid_poses_dataset.individual.values,
             keypoint_names=valid_poses_dataset.keypoint.values,
-            frame_array=frame_array,
-            fps=fps,
             source_software=valid_poses_dataset.attrs["source_software"],
         ).to_dataset()
-
-        expected_ds = valid_poses_dataset
-
-        if frame_array is not None:
-            expected_ds = expected_ds.assign_coords(time=frame_array.squeeze())
-
-        if fps is not None:
-            expected_ds = expected_ds.assign_coords(
-                time=expected_ds.time.values / fps
-            )
-            expected_ds.time.attrs["units"] = "seconds"
-
-        xr.testing.assert_equal(ds, expected_ds)
+        xr.testing.assert_equal(ds, valid_poses_dataset)
 
     @pytest.mark.parametrize(
         "confidence_array, expected_context",
@@ -545,35 +581,13 @@ class TestValidBboxesInputs:
                 shape_array=shape_array,
             )
 
-    @pytest.mark.parametrize("fps", [30, None])
-    @pytest.mark.parametrize(
-        "frame_array",
-        [
-            None,
-            np.arange(10, 20)[:, None],
-        ],
-        ids=[
-            "Default frame numbers",
-            "Custom frame numbers",
-        ],
-    )
-    def test_to_dataset(self, fps, frame_array, valid_bboxes_dataset):
+    def test_to_dataset(self, valid_bboxes_dataset):
         """Test to_dataset creates the expected bboxes dataset."""
         ds = ValidBboxesInputs(
             position_array=valid_bboxes_dataset.position.values,
             shape_array=valid_bboxes_dataset.shape.values,
             confidence_array=valid_bboxes_dataset.confidence.values,
             individual_names=valid_bboxes_dataset.individual.values,
-            frame_array=frame_array,
-            fps=fps,
             source_software=valid_bboxes_dataset.attrs["source_software"],
         ).to_dataset()
-        expected_ds = valid_bboxes_dataset
-        if frame_array is not None:
-            expected_ds = expected_ds.assign_coords(time=frame_array.squeeze())
-        if fps is not None:
-            expected_ds = expected_ds.assign_coords(
-                time=expected_ds.time.values / fps
-            )
-            expected_ds.time.attrs["units"] = "seconds"
-        xr.testing.assert_equal(ds, expected_ds)
+        xr.testing.assert_equal(ds, valid_bboxes_dataset)


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

`ValidPosesInputs` currently assumes that frame numbers are contiguous and always start at 0. This makes it difficult to represent pose datasets with non-contiguous frame numbers, which is required for supporting COCO keypoint results and aligns with the existing functionality provided by `ValidBboxesInputs`.

**What does this PR do?**

- Adds optional `frame_array` support to `ValidPosesInputs`. 
- Validates that `frame_array` is a monotonically increasing column vector of shape `(n_frames, 1)`. 
- Adds `frame_array` support to `load_poses.from_numpy()`. 
- Adds tests covering default, custom, invalid, and non-monotonic `frame_array` values, as well as dataset creation with custom frame numbers.

## References

Closes #1049 

## How has this PR been tested?

- Added unit tests covering the new `frame_array` functionality.

- Ran the tests locally

## Is this a breaking change?

No. `frame_array` is optional and defaults to consecutive 0-based frame numbers, preserving the existing behavior.

## Does this PR require an update to the documentation?

Yes
The documentation has been updated to include `frame_array` in `ValidPosesInputs` and `load_poses.from_numpy()`

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
