### PR TITLE
Changing the point symbol to ring for edited points in napari

### DIFF
--- a/movement/napari/layer_styles.py
+++ b/movement/napari/layer_styles.py
@@ -9,7 +9,7 @@ from napari.utils.color import ColorValue
 from napari.utils.colormaps import ensure_colormap
 
 DEFAULT_COLORMAP = "turbo"
-EDITED_SYMBOL = "ring"
+EDITED_POINT_SYMBOL = "ring"
 
 
 @dataclass

--- a/movement/napari/layer_styles.py
+++ b/movement/napari/layer_styles.py
@@ -9,6 +9,7 @@ from napari.utils.color import ColorValue
 from napari.utils.colormaps import ensure_colormap
 
 DEFAULT_COLORMAP = "turbo"
+EDITED_SYMBOL = "ring"
 
 
 @dataclass

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -353,7 +353,6 @@ class DataLoader(QWidget):
         points_properties = self.properties.loc[
             :, ~self.properties.columns.str.endswith("_factorized")
         ]
-
         self.points_layer = self.viewer.add_points(
             self.data[self.data_not_nan, 1:],
             properties=points_properties.iloc[self.data_not_nan, :],
@@ -367,17 +366,20 @@ class DataLoader(QWidget):
         )
         self.points_layer.events.data.connect(self._on_points_data_changed)
 
+        # If the loaded dataset already has an `edited` property
+        # mark those points with the edited symbol.
+        self._set_symbol_by_edited(self.points_layer)
+
         logger.info("Added tracked dataset as a napari Points layer.")
 
     @staticmethod
-    def _set_symbol_by_edited(
-        layer: Points, edited_indices: list | np.ndarray
-    ) -> None:
-        """Mark the given point indices with the edited marker symbol."""
-        if len(edited_indices) == 0:
+    def _set_symbol_by_edited(layer: Points) -> None:
+        """Show points flagged as edited with a distinct marker symbol."""
+        edited = layer.properties.get("edited")
+        if edited is None or not edited.any():
             return
         symbols = np.asarray(layer.symbol).copy()
-        symbols[edited_indices] = EDITED_SYMBOL
+        symbols[edited] = EDITED_SYMBOL
         layer.symbol = symbols
 
     def _on_points_data_changed(self, event):
@@ -405,7 +407,7 @@ class DataLoader(QWidget):
             props["edited"] = np.full(len(props["confidence"]), False)
         props["edited"][moved_indices] = True
         layer.properties = props
-        self._set_symbol_by_edited(layer, moved_indices)
+        self._set_symbol_by_edited(layer)
 
     def _add_tracks_layer(self):
         """Add the tracked data to the viewer as a Tracks layer."""

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -25,7 +25,7 @@ from qtpy.QtWidgets import (
 from movement.io.load import load_dataset, rename_legacy_dimensions
 from movement.napari.convert import ds_to_napari_layers
 from movement.napari.layer_styles import (
-    EDITED_SYMBOL,
+    EDITED_POINT_SYMBOL,
     BoxesStyle,
     PointsStyle,
     TracksStyle,
@@ -368,18 +368,18 @@ class DataLoader(QWidget):
 
         # If the loaded dataset already has an `edited` property
         # mark those points with the edited symbol.
-        self._set_symbol_by_edited(self.points_layer)
+        self._set_point_symbol_by_edited(self.points_layer)
 
         logger.info("Added tracked dataset as a napari Points layer.")
 
     @staticmethod
-    def _set_symbol_by_edited(layer: Points) -> None:
+    def _set_point_symbol_by_edited(layer: Points) -> None:
         """Show points flagged as edited with a distinct marker symbol."""
         edited = layer.properties.get("edited")
         if edited is None or not edited.any():
             return
         symbols = np.asarray(layer.symbol).copy()
-        symbols[edited] = EDITED_SYMBOL
+        symbols[edited] = EDITED_POINT_SYMBOL
         layer.symbol = symbols
 
     def _on_points_data_changed(self, event):
@@ -389,7 +389,7 @@ class DataLoader(QWidget):
         ``ActionType.CHANGED`` (i.e., when the data array values
         change) and sets the confidence score of moved (dragged)
         points to NaN, marks them as edited, and changes their
-        marker symbol to ``EDITED_SYMBOL`` so edited points are
+        marker symbol to ``EDITED_POINT_SYMBOL`` so edited points are
         visually distinguishable.
         """
         layer = event.source
@@ -407,7 +407,7 @@ class DataLoader(QWidget):
             props["edited"] = np.full(len(props["confidence"]), False)
         props["edited"][moved_indices] = True
         layer.properties = props
-        self._set_symbol_by_edited(layer)
+        self._set_point_symbol_by_edited(layer)
 
     def _add_tracks_layer(self):
         """Add the tracked data to the viewer as a Tracks layer."""

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -24,7 +24,12 @@ from qtpy.QtWidgets import (
 
 from movement.io.load import load_dataset, rename_legacy_dimensions
 from movement.napari.convert import ds_to_napari_layers
-from movement.napari.layer_styles import BoxesStyle, PointsStyle, TracksStyle
+from movement.napari.layer_styles import (
+    EDITED_SYMBOL,
+    BoxesStyle,
+    PointsStyle,
+    TracksStyle,
+)
 from movement.utils.logging import logger
 from movement.validators.datasets import ValidBboxesInputs, ValidPosesInputs
 
@@ -364,13 +369,26 @@ class DataLoader(QWidget):
 
         logger.info("Added tracked dataset as a napari Points layer.")
 
+    @staticmethod
+    def _set_symbol_by_edited(
+        layer: Points, edited_indices: list | np.ndarray
+    ) -> None:
+        """Mark the given point indices with the edited marker symbol."""
+        if len(edited_indices) == 0:
+            return
+        symbols = np.asarray(layer.symbol).copy()
+        symbols[edited_indices] = EDITED_SYMBOL
+        layer.symbol = symbols
+
     def _on_points_data_changed(self, event):
         """Set confidence to NaN and flag as edited for moved points.
 
         Connected to ``points_layer.events.data``. Fires on
         ``ActionType.CHANGED`` (i.e., when the data array values
         change) and sets the confidence score of moved (dragged)
-        points to NaN, and marks them as edited.
+        points to NaN, marks them as edited, and changes their
+        marker symbol to ``EDITED_SYMBOL`` so edited points are
+        visually distinguishable.
         """
         layer = event.source
         if not isinstance(layer, Points):
@@ -387,6 +405,7 @@ class DataLoader(QWidget):
             props["edited"] = np.full(len(props["confidence"]), False)
         props["edited"][moved_indices] = True
         layer.properties = props
+        self._set_symbol_by_edited(layer, moved_indices)
 
     def _add_tracks_layer(self):
         """Add the tracked data to the viewer as a Tracks layer."""

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -12,6 +12,7 @@ from unittest.mock import Mock
 import numpy as np
 import pandas as pd
 import pytest
+import xarray as xr
 from napari.components.dims import RangeTuple
 from napari.layers import (
     Image,
@@ -945,17 +946,17 @@ def test_add_points_and_tracks_layer_style(
         )
 
 
-def test_set_symbol_by_edited_no_indices_is_noop(
+def test_set_symbol_by_edited_no_edited_property_is_noop(
     valid_poses_path_and_ds, loaded_data_loader
 ):
     """Test that ``_set_symbol_by_edited`` leaves symbols unchanged
-    when given an empty list of indices.
+    when the layer has no ``edited`` property yet (nothing dragged so far).
     """
     filepath, ds = valid_poses_path_and_ds
     loader = loaded_data_loader(filepath, ds)
 
     original_symbol = loader.points_layer.symbol.copy()
-    loader._set_symbol_by_edited(loader.points_layer, [])
+    loader._set_symbol_by_edited(loader.points_layer)
 
     np.testing.assert_array_equal(loader.points_layer.symbol, original_symbol)
 
@@ -1075,3 +1076,31 @@ def test_on_points_data_changed_second_drag_extends_edited(
     assert not np.isnan(confidence[3:]).any()  # untouched points untouched
     assert (symbol[[0, 1, 2]] == "ring").all()  # all dragged points ringed
     assert (symbol[3:] == "disc").all()  # untouched points stay disc
+
+
+def test_add_points_layer_shows_edited_symbol_for_previously_edited_points(
+    valid_poses_dataset, tmp_path, make_napari_viewer_proxy
+):
+    """Test that points already flagged as ``edited`` when a dataset is
+    loaded are shown with the "ring" marker symbol immediately, without
+    requiring a fresh drag in this session.
+    """
+    ds = valid_poses_dataset.copy(deep=True)
+    ds.attrs["source_software"] = "movement (netCDF)"
+    ds["edited"] = xr.full_like(ds["confidence"], False, dtype=bool)
+    ds["edited"].loc[
+        {"individual": "id_0", "keypoint": "centroid", "time": 0}
+    ] = True
+
+    file_path = tmp_path / "ds_with_edited.nc"
+    ds.to_netcdf(file_path)
+
+    loader = DataLoader(make_napari_viewer_proxy())
+    loader.file_path_edit.setText(str(file_path))
+    loader.source_software_combo.setCurrentText("movement (netCDF)")
+    loader._on_load_clicked()
+
+    edited = loader.points_layer.properties["edited"]
+    symbol = loader.points_layer.symbol
+    assert (symbol[edited] == "ring").all()
+    assert (symbol[~edited] == "disc").all()

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -946,17 +946,17 @@ def test_add_points_and_tracks_layer_style(
         )
 
 
-def test_set_symbol_by_edited_no_edited_property_is_noop(
+def test_set_point_symbol_by_edited_no_edited_property_is_noop(
     valid_poses_path_and_ds, loaded_data_loader
 ):
-    """Test that ``_set_symbol_by_edited`` leaves symbols unchanged
+    """Test that ``_set_point_symbol_by_edited`` leaves symbols unchanged
     when the layer has no ``edited`` property yet (nothing dragged so far).
     """
     filepath, ds = valid_poses_path_and_ds
     loader = loaded_data_loader(filepath, ds)
 
     original_symbol = loader.points_layer.symbol.copy()
-    loader._set_symbol_by_edited(loader.points_layer)
+    loader._set_point_symbol_by_edited(loader.points_layer)
 
     np.testing.assert_array_equal(loader.points_layer.symbol, original_symbol)
 

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -945,6 +945,21 @@ def test_add_points_and_tracks_layer_style(
         )
 
 
+def test_set_symbol_by_edited_no_indices_is_noop(
+    valid_poses_path_and_ds, loaded_data_loader
+):
+    """Test that ``_set_symbol_by_edited`` leaves symbols unchanged
+    when given an empty list of indices.
+    """
+    filepath, ds = valid_poses_path_and_ds
+    loader = loaded_data_loader(filepath, ds)
+
+    original_symbol = loader.points_layer.symbol.copy()
+    loader._set_symbol_by_edited(loader.points_layer, [])
+
+    np.testing.assert_array_equal(loader.points_layer.symbol, original_symbol)
+
+
 def test_on_points_data_changed_ignores_tracks_layer(
     valid_poses_path_and_ds, loaded_data_loader
 ):
@@ -1028,7 +1043,9 @@ def test_on_points_data_changed_second_drag_extends_edited(
     The first drag creates ``edited`` (the ``else`` branch). The second
     drag moves two points at once, as napari does for a multi-point
     selection, hitting the ``if "edited" in props`` branch and covering
-    multi-point drags in the same test.
+    multi-point drags in the same test. Also checks that dragged points'
+    marker symbol is changed to "ring", while untouched points keep the
+    default "disc" symbol.
     """
     filepath, ds = valid_poses_path_and_ds
     loader = loaded_data_loader(filepath, ds)
@@ -1043,6 +1060,7 @@ def test_on_points_data_changed_second_drag_extends_edited(
     # First drag: creates `edited` (the `else` branch), one point moved
     drag((0,))
     assert loader.points_layer.properties["edited"][0]
+    assert loader.points_layer.symbol[0] == "ring"
 
     # Second drag: extends `edited` (the `if "edited" in props` branch),
     # moving two points (1, 2) at once in a single event
@@ -1050,7 +1068,10 @@ def test_on_points_data_changed_second_drag_extends_edited(
 
     edited = loader.points_layer.properties["edited"]
     confidence = loader.points_layer.properties["confidence"]
+    symbol = loader.points_layer.symbol
     assert edited[[0, 1, 2]].all()  # all dragged points flagged
     assert not edited[3:].any()  # untouched points stay False
     assert np.isnan(confidence[[0, 1, 2]]).all()  # confidence set to NaN
     assert not np.isnan(confidence[3:]).any()  # untouched points untouched
+    assert (symbol[[0, 1, 2]] == "ring").all()  # all dragged points ringed
+    assert (symbol[3:] == "disc").all()  # untouched points stay disc


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Since #1041, dragging a keypoint in the napari Points layer flags it as `edited = True` in the layer's properties, but there was no visual indication of this on the canvas itself. An edited point looked identical to an untouched one, so it is hard to remember which points were edited at a glance. 

**What does this PR do?**

- Adds a `EDITED_SYMBOL = "ring"` to `layers_style.py`,  because it is purely a styling value (what symbol represents an edited point). Also, if we want to change it from ring to a different symbol type, it is faster to change this way. 
- On `loader_widget.py` I added the `_set_symbol_by_edited()` so dragging one or more points changes its symbol type from `fill` to `ring`. 
- Calls the helper `_set_symbol_by_edited()` on `_on_points_data_changed()` to change to `ring` the `moved_indices` (edited points). 
- Also, applies it in `_add_points_layer()` on initial load, so reopening a dataset that already was edited shows the edited points constantly, based on the `edited` properties. 

## References

Builds on #1041 and #1044. 

## How has this PR been tested?

- Update on `test_on_points_data_changed_second_drag_extends_edited` to assert on `points_layer.symbol`, not only on the `edited` property. 
- Added `test_set_symbol_by_edited_no_indices_is_noop` to cover early return branch when no indices are passed. 
- Manually verified in napari that dragging a point changes the symbol to `ring` type. 

<img width="1384" height="880" alt="Screenshot From 2026-07-27 15-20-10" src="https://github.com/user-attachments/assets/5d25a4f4-9dad-424d-8962-13e1074265af" />

## Is this a breaking change?

No. This only changes the style of points that are already flagged in `edited`. 

## Does this PR require an update to the documentation?

Documentation will be updated to show examples on how to use this feature. 

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
