### PR TITLE
Synchronize tracks layer to points layer

### DIFF
--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -430,7 +430,7 @@ class DataLoader(QWidget):
 
         # Points and Tracks layers are built from the same NaN-filtered
         # array in the same row order (see _add_points_layer/
-        # _add_tracks_layer). the Tracks layer only has an extra
+        # _add_tracks_layer). The Tracks layer only has an extra
         # leading track_id column.
         tracks_data = tracks_layer.data
         tracks_data[moved_indices, 1:] = points_layer.data[moved_indices]

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -428,9 +428,7 @@ class DataLoader(QWidget):
         in the Tracks layer, so the track segment connecting the
         previous frame to this one terminates at the dragged position.
         """
-        tracks_layer = points_layer.metadata.get(TRACKS_LAYER_KEY)
-        if tracks_layer is None:
-            return
+        tracks_layer = points_layer.metadata[TRACKS_LAYER_KEY]
 
         # Points and Tracks layers are built from the same NaN-filtered
         # array in the same row order (see _add_points_layer/

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -56,9 +56,6 @@ SUPPORTED_DATA_FILES = {
 }
 
 # Metadata keys stored on the movement Points layer.
-# Set in _add_points_layer/_add_tracks_layer (where the layers are created);
-# read in save_widget.py (where the layer is saved) and in
-# _on_points_data_changed (to keep the Tracks layer in sync).
 # - POINTS_LAYER_KEY marks the layer as movement-created.
 # - POINTS_PROPERTIES_KEY holds the full properties df, incl. the NaN rows
 #   dropped from the live layer, needed to reconstruct the dataset.

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -400,7 +400,8 @@ class DataLoader(QWidget):
         change) and sets the confidence score of moved (dragged)
         points to NaN, marks them as edited, and changes their
         marker symbol to ``EDITED_POINT_SYMBOL`` so edited points are
-        visually distinguishable.
+        visually distinguishable. The companion Tracks layer is then
+        updated to match via :meth:`_sync_tracks_layer`.
         """
         layer = event.source
         if not isinstance(layer, Points):

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -1,5 +1,6 @@
 """Widgets for loading movement datasets from file."""
 
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -55,15 +56,18 @@ SUPPORTED_DATA_FILES = {
 }
 
 # Metadata keys stored on the movement Points layer.
-# Set in _add_points_layer (where the layer is created);
-# read in save_widget.py (where the layer is saved).
+# Set in _add_points_layer/_add_tracks_layer (where the layers are created);
+# read in save_widget.py (where the layer is saved) and in
+# _on_points_data_changed (to keep the Tracks layer in sync).
 # - POINTS_LAYER_KEY marks the layer as movement-created.
 # - POINTS_PROPERTIES_KEY holds the full properties df, incl. the NaN rows
 #   dropped from the live layer, needed to reconstruct the dataset.
 # - DATASET_ATTRS_KEY holds the source dataset's attrs (source_software, fps…).
+# - TRACKS_LAYER_KEY holds a reference to the companion Tracks layer.
 POINTS_LAYER_KEY: str = "movement_points_layer"
 POINTS_PROPERTIES_KEY: str = "movement_points_properties"
 DATASET_ATTRS_KEY: str = "movement_dataset_attrs"
+TRACKS_LAYER_KEY: str = "movement_tracks_layer"
 
 
 class DataLoader(QWidget):
@@ -415,6 +419,43 @@ class DataLoader(QWidget):
         layer.properties = props
         self._set_point_symbol_by_edited(layer)
 
+        self._sync_tracks_layer(layer, moved_indices)
+
+    def _sync_tracks_layer(self, points_layer, moved_indices):
+        """Update the corresponding Tracks layer to match an edited point.
+
+        A moved point's new (frame, y, x) is written to the same row
+        in the Tracks layer, so the track segment connecting the
+        previous frame to this one terminates at the dragged position.
+        """
+        tracks_layer = points_layer.metadata.get(TRACKS_LAYER_KEY)
+        if tracks_layer is None:
+            return
+
+        # Points and Tracks layers are built from the same NaN-filtered
+        # array in the same row order (see _add_points_layer/
+        # _add_tracks_layer). the Tracks layer only has an extra
+        # leading track_id column.
+        tracks_data = tracks_layer.data
+        tracks_data[moved_indices, 1:] = points_layer.data[moved_indices]
+
+        # Setting `.data` on a napari Tracks layer resets its internal
+        # features to empty, which transiently invalidates `color_by`
+        # (napari warns and falls back to "track_id") even though we
+        # restore the same properties and colour-by property right
+        # after. Suppress that spurious warning around the sequence.
+        tracks_properties = tracks_layer.properties
+        color_by = tracks_layer.color_by
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=".*Previous color_by key.*",
+                category=UserWarning,
+            )
+            tracks_layer.data = tracks_data
+            tracks_layer.properties = tracks_properties
+            tracks_layer.color_by = color_by
+
     def _add_tracks_layer(self):
         """Add the tracked data to the viewer as a Tracks layer."""
         # Define style for tracks layer
@@ -430,12 +471,14 @@ class DataLoader(QWidget):
         tracks_style.set_color_by(property=self.color_property_factorized)
 
         # Add data as a tracks layer
-        self.viewer.add_tracks(
+        self.tracks_layer = self.viewer.add_tracks(
             self.data[self.data_not_nan, :],
             properties=self.properties.iloc[self.data_not_nan, :],
             metadata={"max_frame_idx": max(self.data[:, 1])},
             **tracks_style.as_kwargs(),
         )
+        # Let the Points layer's callback find its companion Tracks layer
+        self.points_layer.metadata[TRACKS_LAYER_KEY] = self.tracks_layer
         logger.info("Added tracked dataset as a napari Tracks layer.")
 
     def _add_boxes_layer(self):

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -390,34 +390,41 @@ class DataLoader(QWidget):
         layer.symbol = symbols
 
     def _on_points_data_changed(self, event):
-        """Set confidence to NaN and flag as edited for moved points.
+        """Keep the corresponding Tracks layer in sync with the Points layer.
 
-        Connected to ``points_layer.events.data``. Fires on
-        ``ActionType.CHANGED`` (i.e., when the data array values
-        change) and sets the confidence score of moved (dragged)
-        points to NaN, marks them as edited, and changes their
-        marker symbol to ``EDITED_POINT_SYMBOL`` so edited points are
-        visually distinguishable. The companion Tracks layer is then
-        updated to match via :meth:`_sync_tracks_layer`.
+        Connected to ``points_layer.events.data``. Handles two actions:
+
+        - ``ActionType.CHANGED`` (a point was dragged): sets the
+          confidence score of moved points to NaN, marks them as
+          edited, and changes their marker symbol to
+          ``EDITED_POINT_SYMBOL`` so edited points are visually
+          distinguishable. The Tracks layer row is updated in place
+          via `_sync_tracks_layer`.
+        - ``ActionType.REMOVED`` (one or more points were deleted):
+          removes the corresponding rows from
+          the Tracks layer via `_remove_from_tracks_layer`.
         """
         layer = event.source
         if not isinstance(layer, Points):
             return
-        if event.action != ActionType.CHANGED:
-            return
-        moved_indices = list(event.data_indices)
-        props = layer.properties
-        props["confidence"] = props["confidence"].copy()
-        props["confidence"][moved_indices] = float("nan")
-        if "edited" in props:
-            props["edited"] = props["edited"].copy()
-        else:
-            props["edited"] = np.full(len(props["confidence"]), False)
-        props["edited"][moved_indices] = True
-        layer.properties = props
-        self._set_point_symbol_by_edited(layer)
 
-        self._sync_tracks_layer(layer, moved_indices)
+        if event.action == ActionType.CHANGED:
+            moved_indices = list(event.data_indices)
+            props = layer.properties
+            props["confidence"] = props["confidence"].copy()
+            props["confidence"][moved_indices] = float("nan")
+            if "edited" in props:
+                props["edited"] = props["edited"].copy()
+            else:
+                props["edited"] = np.full(len(props["confidence"]), False)
+            props["edited"][moved_indices] = True
+            layer.properties = props
+            self._set_point_symbol_by_edited(layer)
+            self._sync_tracks_layer(layer, moved_indices)
+
+        elif event.action == ActionType.REMOVED:
+            removed_indices = list(event.data_indices)
+            self._remove_from_tracks_layer(layer, removed_indices)
 
     def _sync_tracks_layer(self, points_layer, moved_indices):
         """Update the corresponding Tracks layer to match an edited point.
@@ -435,12 +442,44 @@ class DataLoader(QWidget):
         tracks_data = tracks_layer.data
         tracks_data[moved_indices, 1:] = points_layer.data[moved_indices]
 
-        # Setting `.data` on a napari Tracks layer resets its internal
-        # features to empty, which transiently invalidates `color_by`
-        # (napari warns and falls back to "track_id") even though we
-        # restore the same properties and colour-by property right
-        # after. Suppress that spurious warning around the sequence.
-        tracks_properties = tracks_layer.properties
+        self._set_tracks_layer_data(
+            tracks_layer, tracks_data, tracks_layer.properties
+        )
+
+    def _remove_from_tracks_layer(self, points_layer, removed_indices):
+        """Remove the rows corresponding to deleted points.
+
+        Users edit the Points layer directly, either dragging points
+        or removing inaccurate predictions. The Tracks layer has no
+        interactive editing of its own, so it must be kept in sync
+        with the Points layer instead.
+
+        ``removed_indices`` are indices in the Points layer which line
+        up with rows in the Tracks layer, the same way
+        :meth:`_sync_tracks_layer` relies on for edits.
+        """
+        tracks_layer = points_layer.metadata[TRACKS_LAYER_KEY]
+
+        tracks_data = np.delete(tracks_layer.data, removed_indices, axis=0)
+        tracks_properties = {
+            key: np.delete(np.asarray(values), removed_indices, axis=0)
+            for key, values in tracks_layer.properties.items()
+        }
+
+        self._set_tracks_layer_data(
+            tracks_layer, tracks_data, tracks_properties
+        )
+
+    @staticmethod
+    def _set_tracks_layer_data(tracks_layer, data, properties):
+        """Set a Tracks layer's data and properties, preserving color_by.
+
+        Setting ``.data`` on a napari Tracks layer resets its internal
+        features to empty, which transiently invalidates ``color_by``
+        (napari warns and falls back to "track_id") even though we
+        restore the same properties and colour-by property right
+        after. Suppress that spurious warning around the sequence.
+        """
         color_by = tracks_layer.color_by
         with warnings.catch_warnings():
             warnings.filterwarnings(
@@ -448,8 +487,8 @@ class DataLoader(QWidget):
                 message=".*Previous color_by key.*",
                 category=UserWarning,
             )
-            tracks_layer.data = tracks_data
-            tracks_layer.properties = tracks_properties
+            tracks_layer.data = data
+            tracks_layer.properties = properties
             tracks_layer.color_by = color_by
 
     def _add_tracks_layer(self):

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -89,6 +89,17 @@ class DataLoader(QWidget):
             )
         self._enable_layer_tooltips()
 
+        # Point drags are only guaranteed to stay within their own frame
+        # when frame is the sliced (non-displayed) axis in a 2D view. If
+        # axes are rolled or a 3D view is used, disable editing rather
+        # than risk a drag moving a point onto a different frame.
+        self.viewer.dims.events.order.connect(
+            self._update_points_layers_editable
+        )
+        self.viewer.dims.events.ndisplay.connect(
+            self._update_points_layers_editable
+        )
+
     def _create_source_software_widget(self):
         """Create a combo box for selecting the source software."""
         self.source_software_combo = QComboBox()
@@ -372,12 +383,51 @@ class DataLoader(QWidget):
             **points_style.as_kwargs(),
         )
         self.points_layer.events.data.connect(self._on_points_data_changed)
+        self.points_layer.editable = self._is_canonical_dims()
 
         # If the loaded dataset already has an `edited` property
         # mark those points with the edited symbol.
         self._set_point_symbol_by_edited(self.points_layer)
 
         logger.info("Added tracked dataset as a napari Points layer.")
+
+    def _is_canonical_dims(self) -> bool:
+        """Whether frame is the sliced axis in a 2D view.
+
+        A point drag only ever touches the currently *displayed* axes
+        (see ``Points._move`` in napari). When frame is the sliced
+        axis, that means x/y -- everything is safe to edit. If axes
+        have been rolled so frame is displayed instead, or a 3D view
+        is active, a drag could move a point onto a different frame.
+        """
+        return (
+            self.viewer.dims.ndisplay == 2 and self.viewer.dims.order[0] == 0
+        )
+
+    def _update_points_layers_editable(self, event=None):
+        """Disable point editing while axes aren't in the canonical order.
+
+        Connected to ``viewer.dims.events.order``/``ndisplay``. This
+        greys out each movement Points layer's select/add/delete
+        controls (via napari's built-in ``Layer.editable``), since a
+        drag only ever touches the currently *displayed* axes (see
+        ``Points._move`` in napari) -- if frame isn't the sliced axis,
+        a drag could otherwise move a point onto a different frame.
+        """
+        is_canonical = self._is_canonical_dims()
+        movement_points_layers = [
+            ly
+            for ly in self.viewer.layers
+            if isinstance(ly, Points) and ly.metadata.get(POINTS_LAYER_KEY)
+        ]
+        for layer in movement_points_layers:
+            layer.editable = is_canonical
+        if not is_canonical and movement_points_layers:
+            show_warning(
+                "Point editing disabled: axes must be in the default "
+                "order and 2D view, otherwise a drag could move a "
+                "point onto a different frame."
+            )
 
     @staticmethod
     def _set_point_symbol_by_edited(layer: Points) -> None:

--- a/tests/fixtures/napari.py
+++ b/tests/fixtures/napari.py
@@ -1,8 +1,10 @@
 import string
+from unittest.mock import Mock
 
 import numpy as np
 import pandas as pd
 import pytest
+from napari.layers.base import ActionType
 
 from movement.io import save_poses
 from movement.napari.loader_widgets import DataLoader
@@ -191,6 +193,37 @@ def sample_properties_with_factorized():
         return properties_df
 
     return _sample_properties_with_factorized
+
+
+@pytest.fixture
+def move_point():
+    """Return a factory that simulates a user dragging a single point
+    to a new position in a loaded ``DataLoader``'s Points layer.
+
+    Looks up the point by its ``frame``/``keypoint``/``individual``
+    (rather than a raw row index), so callers don't need to reason
+    about how NaN-filtering may have shifted row positions.
+    """
+
+    def _move_point(loader, frame, keypoint, individual, new_y, new_x):
+        live_props = loader.points_layer.properties
+        edit_idx = int(
+            np.flatnonzero(
+                (live_props["time"] == frame)
+                & (live_props["keypoint"] == keypoint)
+                & (live_props["individual"] == individual)
+            )[0]
+        )
+        loader.points_layer.data[edit_idx, 1] = new_y
+        loader.points_layer.data[edit_idx, 2] = new_x
+
+        mock_event = Mock()
+        mock_event.source = loader.points_layer
+        mock_event.action = ActionType.CHANGED
+        mock_event.data_indices = (edit_idx,)
+        loader._on_points_data_changed(mock_event)
+
+    return _move_point
 
 
 @pytest.fixture

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -1,12 +1,9 @@
 """Test suite for the movement.napari.convert module."""
 
-from unittest.mock import Mock
-
 import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-from napari.layers.base import ActionType
 from pandas.testing import assert_frame_equal
 
 from movement.io import save_poses
@@ -397,32 +394,13 @@ def test_napari_layers_to_ds_bboxes_not_implemented():
         )
 
 
-def _move_point(loader, frame, keypoint, individual, new_y, new_x):
-    """Simulate a user dragging a single point to a new position."""
-    live_props = loader.points_layer.properties
-    edit_idx = int(
-        np.flatnonzero(
-            (live_props["time"] == frame)
-            & (live_props["keypoint"] == keypoint)
-            & (live_props["individual"] == individual)
-        )[0]
-    )
-    loader.points_layer.data[edit_idx, 1] = new_y
-    loader.points_layer.data[edit_idx, 2] = new_x
-
-    mock_event = Mock()
-    mock_event.source = loader.points_layer
-    mock_event.action = ActionType.CHANGED
-    mock_event.data_indices = (edit_idx,)
-    loader._on_points_data_changed(mock_event)
-
-
 @pytest.mark.parametrize("nan_location", NAN_LOCATIONS)
 def test_edited_pose_napari_layers(
     nan_location,
     valid_poses_path_and_ds,
     valid_poses_path_and_ds_with_localised_nans,
     loaded_data_loader,
+    move_point,
 ):
     """Test that :func:`napari_layers_to_ds` correctly converts edited layers,
     and sets the new confidence value to ``NaN`` after the edit.
@@ -443,7 +421,7 @@ def test_edited_pose_napari_layers(
     frame = 2  # safe: not NaN in any parametrize case
     keypoint = "centroid"
     individual = "id_0"
-    _move_point(
+    move_point(
         loader,
         frame=frame,
         keypoint=keypoint,
@@ -487,6 +465,7 @@ def test_edited_property_round_trip(
     valid_poses_path_and_ds,
     valid_poses_path_and_ds_with_localised_nans,
     loaded_data_loader,
+    move_point,
 ):
     """Test that an ``edited`` variable survives a full round trip.
 
@@ -505,7 +484,7 @@ def test_edited_property_round_trip(
         )
     loader = loaded_data_loader(filepath, ds_loaded)
 
-    _move_point(
+    move_point(
         loader,
         frame=2,  # safe: not NaN in any parametrize case
         keypoint="centroid",

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -1036,6 +1036,45 @@ def test_on_points_data_changed_ignores_non_move_events(
     )
 
 
+def test_on_points_data_changed_syncs_tracks_layer(
+    valid_poses_path_and_ds, loaded_data_loader, move_point
+):
+    """Test that dragging a point updates the corresponding Tracks layer.
+
+    Verifies that :meth:`DataLoader._on_points_data_changed` writes a
+    moved point's new (frame, y, x) to the same row in the Tracks
+    layer, and leaves every other row untouched.
+    """
+    filepath, ds = valid_poses_path_and_ds
+    loader = loaded_data_loader(filepath, ds)
+
+    original_tracks_data = loader.tracks_layer.data.copy()
+
+    move_point(
+        loader,
+        frame=5,
+        keypoint="centroid",
+        individual="id_0",
+        new_y=100,
+        new_x=200,
+    )
+
+    # `edited` flags exactly the dragged row; use it to partition rows
+    # instead of assuming which index is "the previous frame".
+    edited = loader.points_layer.properties["edited"]
+    moved_index = int(np.flatnonzero(edited)[0])
+    new_position = loader.points_layer.data[moved_index]
+
+    # The dragged row is updated to the new position in the Tracks layer...
+    np.testing.assert_array_equal(
+        loader.tracks_layer.data[moved_index, 1:], new_position
+    )
+    # ...while every non-edited row is untouched.
+    np.testing.assert_array_equal(
+        loader.tracks_layer.data[~edited], original_tracks_data[~edited]
+    )
+
+
 def test_on_points_data_changed_second_drag_extends_edited(
     valid_poses_path_and_ds, loaded_data_loader
 ):

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -1002,21 +1002,24 @@ def test_on_points_data_changed_ignores_tracks_layer(
     "action_type",
     [
         ActionType.ADDED,
-        ActionType.REMOVED,
         ActionType.ADDING,
         ActionType.REMOVING,
         ActionType.CHANGING,
     ],
 )
-def test_on_points_data_changed_ignores_non_move_events(
+def test_on_points_data_changed_ignores_unhandled_action_types(
     action_type, valid_poses_path_and_ds, loaded_data_loader
 ):
-    """Test that the callback leaves confidence untouched for non-drag events.
+    """Test that the callback leaves confidence untouched for other events.
 
-    Verifies that :meth:`DataLoader._on_points_data_changed` only acts on
-    ``ActionType.CHANGED`` (completed drag) and ignores all other action types,
-    including ``ADDING``, ``ADDED``, ``REMOVING``, ``REMOVED``, and
-    ``CHANGING`` (in-progress drag).
+    Verifies that :meth:`DataLoader._on_points_data_changed` leaves
+    ``confidence`` untouched for action types it does not act on:
+    ``ADDING``, ``ADDED``, ``REMOVING``, and ``CHANGING``
+    (in-progress drag). The two action types it does handle,
+    ``ActionType.CHANGED`` (completed drag) and ``ActionType.REMOVED``
+    (completed removal), are covered separately - see
+    :func:`test_on_points_data_changed_syncs_tracks_layer` and
+    :func:`test_on_points_data_changed_removes_tracks_layer_row`.
     """
     filepath, ds_loaded = valid_poses_path_and_ds
     loader = loaded_data_loader(filepath, ds_loaded)
@@ -1073,6 +1076,46 @@ def test_on_points_data_changed_syncs_tracks_layer(
     np.testing.assert_array_equal(
         loader.tracks_layer.data[~edited], original_tracks_data[~edited]
     )
+
+
+def test_on_points_data_removes_tracks_layer_row(
+    valid_poses_path_and_ds, loaded_data_loader
+):
+    """Test that deleting a point removes the matching row from Tracks.
+
+    Verifies that `DataLoader._on_points_data_changed` reacts to
+    the real ``ActionType.REMOVED`` event fired by napari's own
+    ``Points.remove`` by dropping the same row from the companion
+    Tracks layer, leaving every other row untouched.
+    """
+    filepath, ds = valid_poses_path_and_ds
+    loader = loaded_data_loader(filepath, ds)
+
+    live_props = loader.points_layer.properties
+    edit_idx = int(
+        np.flatnonzero(
+            (live_props["time"] == 5)
+            & (live_props["keypoint"] == "centroid")
+            & (live_props["individual"] == "id_0")
+        )[0]
+    )
+    original_tracks = loader.tracks_layer.data.copy()
+
+    # Use napari's `Points.remove(indices)``
+    loader.points_layer.remove([edit_idx])
+    assert len(loader.tracks_layer.data) == len(original_tracks) - 1
+
+    # Rows before the deleted one are untouched; rows after it have
+    # shifted up by one position, as ``np.delete`` does.
+    np.testing.assert_array_equal(
+        loader.tracks_layer.data[:edit_idx],
+        original_tracks[:edit_idx],
+    )  # is everything before the deleted row identical?
+    np.testing.assert_array_equal(
+        loader.tracks_layer.data[edit_idx:],
+        original_tracks[edit_idx + 1 :],
+    )  # did everything survive after the deleted row and shifted
+    # down by exactly one index to fill the gap?
 
 
 def test_on_points_data_changed_second_drag_extends_edited(


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Previously, `_add_tracks_layer` created the napari `Tracks` layer once at load time and never touched it again. `_on_points_data_changed` only updated the Points layer's properties when a point was dragged (setting `confidence` to `NaN` and flagging `edited`). The visible Tracks line never reflected the edit. This made it visually confusing to follow corrections: a user could drag a keypoint to fix a bad prediction, but the track line kept showing the old, uncorrected trajectory until the file was reloaded.

**What does this PR do?**

It keeps the Tracks layer in sync with the Points layer whenever a point is dragged, via a new `_sync_tracks_layer` method called from `_on_points_data_changed`. Specifically:

1. **Links the Points and Tracks layers.** Both are independent napari layer objects with no built-in relationship. A new metadata key, `TRACKS_LAYER_KEY`, is stored on the Points layer's `.metadata` dict (the same pattern already used for `POINTS_LAYER_KEY` / `POINTS_PROPERTIES_KEY` / `DATASET_ATTRS_KEY`, which `save_widget.py` reads). `_add_tracks_layer` now does:

   ```python
   self.tracks_layer = self.viewer.add_tracks(...)
   self.points_layer.metadata[TRACKS_LAYER_KEY] = self.tracks_layer
   ```
   so the drag callback can look up `points_layer.metadata[TRACKS_LAYER_KEY]` to find the matching Tracks layer directly.

2. **Relies on matching row order between the two layers.** `_add_points_layer` builds the Points layer from `self.data[self.data_not_nan, 1:]` (columns: frame, y, x), and `_add_tracks_layer` builds the Tracks layer from `self.data[self.data_not_nan, :]` (columns: track_id, frame, y, x). Both slice the same underlying array with the *same* boolean mask, so row `i` in the Points layer is always row `i` in the Tracks layer. This means a moved point's row index can be reused directly against the Tracks array, with no lookup by frame/track_id needed.

3. **Adds the actual sync logic** in `_sync_tracks_layer`, called at the end of `_on_points_data_changed` right after the existing confidence/edited-flag update:
   ```python
   tracks_data = tracks_layer.data
   tracks_data[moved_indices, 1:] = points_layer.data[moved_indices]
   ```
   This copies the dragged point's new `(frame, y, x)` into the same row of the Tracks array, so the track segment connecting the previous frame to this one now terminates at the corrected position.

4. **Fixes a resulting `color_by` warning.** napari's `Tracks.data` setter internally does `self.features = {}` every time `.data` is reassigned (part of rebuilding the track geometry). Since the layer's `color_by` was set to `individual_factorized`, and that column momentarily doesn't exist in the wiped features table, napari's own `_check_color_by_in_features` immediately warns `"Previous color_by key ... Falling back to track_id"` and silently resets `color_by` to `track_id`. Since we always restore the exact same properties right after (only positions changed, not the property columns), this warning is a false alarm about a transient state that gets fixed one line later:
   ```python
   tracks_properties = tracks_layer.properties  # save before .data wipes it
   color_by = tracks_layer.color_by
   with warnings.catch_warnings():
       warnings.filterwarnings(
           "ignore", message=".*Previous color_by key.*", category=UserWarning
       )
       tracks_layer.data = tracks_data              # wipes features, triggers the warning
       tracks_layer.properties = tracks_properties  # restore properties (incl. individual_factorized)
       tracks_layer.color_by = color_by              # restore coloring
   ```
   The suppression is scoped narrowly (this message text, only around these three lines) so genuine warnings elsewhere aren't hidden.

## References

Part of #993 

Related to: 
#1024 set the confidence of edited points to NaN and flag them as edited.
#1053  change the point symbol to a ring for edited points in napari (open).

## How has this PR been tested?

This has been tested manually, locally in napari: loading a dataset, dragging keypoints across multiple frames/individuals, and confirming the Tracks layer updates immediately to match, with correct coloring and no stray console warnings.

Following tests were added: 

- `test_on_points_data_changed_syncs_tracks_layer` drags a point and verifies `_sync_tracks_layer` write the new `(frame, y, x)` into the same row of the Tracks layer, while every other row is left untouched. Uses the `edited` property (set by `_on_points_data_changed`) to differentiate dragged and untouched rows. 
- In `test_convert.py` we had a helper function `_move_points()` to simulate a mock event that moves a point. That was reused in several tests in that script. However, in `test_data_loader_widget.py` we also needed to move an event and see if the Tracks layer was accordingly updated. That is why, in the end I though that it would be better to add a factory fixture in `tests/fixtures/napari.py` called `move_point()` that is reused both in `test_convert.py` and `test_data_loader_widget.py`. What do you think of this approach? 

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
