### PR TITLE
Trusted pypi publishing and release guide

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -62,12 +62,14 @@ jobs:
     needs: [build_sdist_wheels]
     if: github.event_name == 'push' && github.ref_type == 'tag'
     runs-on: ubuntu-latest
+    environment: # use Trusted Publisher route
+      name: pypi
+      url: https://pypi.org/p/movement
+    permissions:
+      id-token: write # mandatory for trusted publishing
     steps:
     - uses: actions/download-artifact@v8
       with:
         name: artifact
         path: dist
     - uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.TWINE_API_KEY }}

--- a/docs/source/community/contributing.md
+++ b/docs/source/community/contributing.md
@@ -578,29 +578,93 @@ A GitHub actions workflow (`.github/workflows/test_and_deploy.yml`) has been set
 * Testing (only if linting checks pass)
 * Release to PyPI (only if a git tag is present and if tests pass).
 
-### Versioning and releases
+The PyPI upload uses [trusted publishing](https://docs.pypi.org/trusted-publishers/),
+so no API tokens are stored in the repository.
+
+### Versioning
 We use [semantic versioning](https://semver.org/), which includes `MAJOR`.`MINOR`.`PATCH` version numbers:
 
 * PATCH = small bugfix
 * MINOR = new feature
 * MAJOR = breaking change
 
+For now, semantic versioning applies to `MINOR` and `PATCH` versions only.
+Until we are ready for a `v1` `MAJOR` version, we cannot commit to backward compatibility,
+so the `MAJOR` version stays at 0 even for breaking changes.
+Any such changes should be clearly communicated in the release notes, and,
+where possible, preceded by a deprecation warning
+(see [Deprecation lifecycle](#deprecation-lifecycle)).
+
 We use [setuptools_scm](setuptools-scm:) to automatically version `movement`.
 It has been pre-configured in the `pyproject.toml` file.
-`setuptools_scm` will automatically [infer the version using git](setuptools-scm:usage#default-versioning-scheme).
-To manually set a new semantic version, create a tag and make sure the tag is pushed to GitHub.
-Make sure you commit any changes you wish to be included in this version. E.g. to bump the version to `1.0.0`:
+`setuptools_scm` will automatically [infer the version using git](setuptools-scm:usage#default-versioning-scheme),
+based on the latest tag matching the `vMAJOR.MINOR.PATCH` format on the _main_ branch.
+Pushing such a tag triggers the package's deployment to PyPI, as well as a documentation build for that version.
+In practice, we create tags via the GitHub release interface, as described below.
 
-```sh
-git add .
-git commit -m "Add new changes"
-git tag -a v1.0.0 -m "Bump to version 1.0.0"
-git push --follow-tags
-```
-Alternatively, you can also use the GitHub web interface to create a new release and tag.
+### Making a new release
 
-The addition of a GitHub tag triggers the package's deployment to PyPI.
-The version number is automatically determined from the latest tag on the _main_ branch.
+:::{note}
+The steps in this section require write access to the `movement` repository,
+so they can only be carried out by maintainers.
+:::
+
+#### 1. Start a draft release
+Go to the [new release page](movement-github:releases/new), which is equivalent to going to
+[Releases](movement-github:releases) and clicking the "Draft a new release" button.
+
+#### 2. Set the tag and title
+* In the "Tag" dropdown, create a new tag following the `vMAJOR.MINOR.PATCH` format (e.g. `v0.10.0`). Don't forget the `v` prefix; it is required.
+* Leave "Target" set to `main`.
+* Use the tag name as the release title.
+
+#### 3. Generate release notes
+* Leave "Previous tag" set to "Auto" and click the "Generate release notes" button.
+* Organise the PR list under "What's Changed" into meaningful subsections (`###` headers).
+* Start with the most important updates (e.g. a flagship feature or breaking change).
+  You may put those under a _Highlights_ subsection.
+* Other common subsections are:
+    * _Housekeeping_: bot PRs, dependency updates, CI changes
+    * _Documentation_
+
+:::{tip}
+Acknowledge first-time or external contributors.
+For breaking changes, include code snippets showing the old vs new syntax.
+:::
+
+#### 4. Publish the release
+Leave the "Set as the latest release" checkbox ticked (default) and publish.
+Then check the "Actions" tab to ensure both the "Tests" and "Docs" workflows finish successfully.
+
+#### 5. Verify the docs and Binder
+Confirm that the new version appears on the [website](target-movement) and that the API reference is up to date.
+As a bonus, try launching an [example](target-examples) in Binder. The first launch may take a while,
+but Binder caches the environment, so later runs are fast (across all examples).
+
+#### 6. Announce the release
+* Post in the ["Releases" topic on Zulip](movement-releases:)
+  with a link to the GitHub release notes. Optionally include a relevant image.
+* You may also link to relevant new pages of the docs, e.g. a new example or the
+  API reference page for a new function.
+* Someone from the team will usually adapt this announcement for social media.
+
+#### 7. Release on conda-forge
+* Wait for the `regro-cf-autotick-bot` to open a PR on `movement`'s
+  [conda-forge feedstock](https://github.com/conda-forge/movement-feedstock)
+  (typically a few hours after the PyPI release).
+* Inspect the PR's diff. Normally there are only two changes in `recipes/meta.yaml`:
+  the version number and the sha256 hash of the source.
+* Check whether dependencies need to be changed. If that's not obvious from the list of PRs
+  in the GitHub release notes, inspect the "Full Changelog" linked at the bottom of the
+  release notes and look for any changes to `pyproject.toml`.
+* If no dependencies have changed and the CI on the feedstock PR has passed, merge the bot's PR
+  to trigger the conda-forge build and release.
+* If dependencies have changed, make the corresponding changes under `requirements` in
+  `recipes/meta.yaml`. You can push these directly to the feedstock PR branch and wait for the CI to pass.
+* After merging, wait for the CI to pass on the feedstock's `main` branch.
+
+See the [conda-forge docs on maintaining packages](https://conda-forge.org/docs/maintainer/updating_pkgs/)
+for more information.
 
 ### Deprecation lifecycle
 

--- a/docs/source/community/contributing.md
+++ b/docs/source/community/contributing.md
@@ -650,7 +650,7 @@ but Binder caches the environment, so later runs (for any example) are fast.
   (typically a few hours after the PyPI release).
 * Review the PR diff. In most cases, there are only two changes in `recipes/meta.yaml`:
   the version number and the sha256 hash of the source.
-* Check whether dependencies need to be changed. Inspect the "Full Changelog" linked at 
+* Check whether dependencies need to be changed. Inspect the "Full Changelog" linked at
   the bottom of the GitHub release notes and look for any changes to `pyproject.toml`.
 * If no dependencies have changed and CI on the feedstock PR passes, merge the bot's PR
   to trigger the conda-forge build and release.

--- a/docs/source/community/contributing.md
+++ b/docs/source/community/contributing.md
@@ -576,7 +576,7 @@ This will usually include linting, testing and deployment.
 A GitHub actions workflow (`.github/workflows/test_and_deploy.yml`) has been set up to run (on each push/PR):
 * Linting checks (pre-commit).
 * Testing (only if linting checks pass)
-* Release to PyPI (only if a git tag is present and if tests pass).
+* Release to PyPI using [trusted publishing](https://docs.pypi.org/trusted-publishers/) (only if a git tag is present and if tests pass).
 
 ### Versioning
 We use [semantic versioning](https://semver.org/), which includes `MAJOR`.`MINOR`.`PATCH` version numbers:
@@ -585,11 +585,13 @@ We use [semantic versioning](https://semver.org/), which includes `MAJOR`.`MINOR
 * MINOR = new feature
 * MAJOR = breaking change
 
+::: {note}
 While the project is still in the `v0.x` phase, breaking changes may occur in
 `MINOR` releases. Backward compatibility is not guaranteed at this stage.
 Any breaking change must be clearly communicated in the release notes and,
 where possible, introduced with a deprecation warning
 (see [Deprecation lifecycle](#deprecation-lifecycle)).
+:::
 
 We use [setuptools_scm](setuptools-scm:) (configured in `pyproject.toml`) to
 automatically version `movement`.

--- a/docs/source/community/contributing.md
+++ b/docs/source/community/contributing.md
@@ -578,9 +578,6 @@ A GitHub actions workflow (`.github/workflows/test_and_deploy.yml`) has been set
 * Testing (only if linting checks pass)
 * Release to PyPI (only if a git tag is present and if tests pass).
 
-The PyPI upload uses [trusted publishing](https://docs.pypi.org/trusted-publishers/),
-so no API tokens are stored in the repository.
-
 ### Versioning
 We use [semantic versioning](https://semver.org/), which includes `MAJOR`.`MINOR`.`PATCH` version numbers:
 
@@ -588,19 +585,18 @@ We use [semantic versioning](https://semver.org/), which includes `MAJOR`.`MINOR
 * MINOR = new feature
 * MAJOR = breaking change
 
-For now, semantic versioning applies to `MINOR` and `PATCH` versions only.
-Until we are ready for a `v1` `MAJOR` version, we cannot commit to backward compatibility,
-so the `MAJOR` version stays at 0 even for breaking changes.
-Any such changes should be clearly communicated in the release notes, and,
-where possible, preceded by a deprecation warning
+While the project is still in the `v0.x` phase, breaking changes may occur in
+`MINOR` releases. Backward compatibility is not guaranteed at this stage.
+Any breaking change must be clearly communicated in the release notes and,
+where possible, introduced with a deprecation warning
 (see [Deprecation lifecycle](#deprecation-lifecycle)).
 
-We use [setuptools_scm](setuptools-scm:) to automatically version `movement`.
-It has been pre-configured in the `pyproject.toml` file.
-`setuptools_scm` will automatically [infer the version using git](setuptools-scm:usage#default-versioning-scheme),
-based on the latest tag matching the `vMAJOR.MINOR.PATCH` format on the _main_ branch.
+We use [setuptools_scm](setuptools-scm:) (configured in `pyproject.toml`) to
+automatically version `movement`.
+`setuptools_scm` [derives the version from git](setuptools-scm:usage#default-versioning-scheme),
+based on the most recent tag on the _main_ branch that matches the `vMAJOR.MINOR.PATCH` pattern.
 Pushing such a tag triggers the package's deployment to PyPI, as well as a documentation build for that version.
-In practice, we create tags via the GitHub release interface, as described below.
+In practice, tags are created via the GitHub release interface, as described below.
 
 ### Making a new release
 
@@ -614,7 +610,7 @@ Go to the [new release page](movement-github:releases/new), which is equivalent 
 [Releases](movement-github:releases) and clicking the "Draft a new release" button.
 
 #### 2. Set the tag and title
-* In the "Tag" dropdown, create a new tag following the `vMAJOR.MINOR.PATCH` format (e.g. `v0.10.0`). Don't forget the `v` prefix; it is required.
+* In the "Tag" dropdown, create a new tag following the `vMAJOR.MINOR.PATCH` format (e.g. `v0.10.0`). Don't forget the required `v` prefix.
 * Leave "Target" set to `main`.
 * Use the tag name as the release title.
 
@@ -627,7 +623,7 @@ Go to the [new release page](movement-github:releases/new), which is equivalent 
     * _Housekeeping_: bot PRs, dependency updates, CI changes
     * _Documentation_
 
-:::{tip}
+:::{important}
 Acknowledge first-time or external contributors.
 For breaking changes, include code snippets showing the old vs new syntax.
 :::
@@ -637,9 +633,9 @@ Leave the "Set as the latest release" checkbox ticked (default) and publish.
 Then check the "Actions" tab to ensure both the "Tests" and "Docs" workflows finish successfully.
 
 #### 5. Verify the docs and Binder
-Confirm that the new version appears on the [website](target-movement) and that the API reference is up to date.
-As a bonus, try launching an [example](target-examples) in Binder. The first launch may take a while,
-but Binder caches the environment, so later runs are fast (across all examples).
+Confirm that the new version appears on the [website](target-movement) and that the API reference reflects the latest changes.
+As an extra check, try launching an [example](target-examples) in Binder. The first launch may take a while,
+but Binder caches the environment, so later runs (for any example) are fast.
 
 #### 6. Announce the release
 * Post in the ["Releases" topic on Zulip](movement-releases:)
@@ -652,16 +648,15 @@ but Binder caches the environment, so later runs are fast (across all examples).
 * Wait for the `regro-cf-autotick-bot` to open a PR on `movement`'s
   [conda-forge feedstock](https://github.com/conda-forge/movement-feedstock)
   (typically a few hours after the PyPI release).
-* Inspect the PR's diff. Normally there are only two changes in `recipes/meta.yaml`:
+* Review the PR diff. In most cases, there are only two changes in `recipes/meta.yaml`:
   the version number and the sha256 hash of the source.
-* Check whether dependencies need to be changed. If that's not obvious from the list of PRs
-  in the GitHub release notes, inspect the "Full Changelog" linked at the bottom of the
-  release notes and look for any changes to `pyproject.toml`.
-* If no dependencies have changed and the CI on the feedstock PR has passed, merge the bot's PR
+* Check whether dependencies need to be changed. Inspect the "Full Changelog" linked at 
+  the bottom of the GitHub release notes and look for any changes to `pyproject.toml`.
+* If no dependencies have changed and CI on the feedstock PR passes, merge the bot's PR
   to trigger the conda-forge build and release.
-* If dependencies have changed, make the corresponding changes under `requirements` in
-  `recipes/meta.yaml`. You can push these directly to the feedstock PR branch and wait for the CI to pass.
-* After merging, wait for the CI to pass on the feedstock's `main` branch.
+* If dependencies _have_ changed, update the corresponding entries under `requirements` in
+  `recipes/meta.yaml`. You can push these edits directly to the bot's PR branch and wait for CI to pass.
+* After merging, wait for CI to pass on the feedstock's `main` branch.
 
 See the [conda-forge docs on maintaining packages](https://conda-forge.org/docs/maintainer/updating_pkgs/)
 for more information.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -259,6 +259,7 @@ myst_url_schemes = {
     "movement-github": "https://github.com/neuroinformatics-unit/movement/{{path}}",
     "movement-zulip": "https://neuroinformatics.zulipchat.com/#narrow/stream/406001-Movement",
     "movement-community-calls": "https://neuroinformatics.zulipchat.com/#narrow/channel/406001-Movement/topic/Community.20Calls",
+    "movement-releases": "https://neuroinformatics.zulipchat.com/#narrow/channel/406001-Movement/topic/Releases/with/601196586",
     "conda": "https://docs.conda.io/projects/conda/en/latest/{{path}}#{{fragment}}",
     "dlc": "https://www.mackenziemathislab.org/deeplabcut/",
     "gin": "https://gin.g-node.org/{{path}}#{{fragment}}",


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other: CI and docs

**Why is this PR needed?**

[Trusted Publishing](https://docs.pypi.org/trusted-publishers/) is the method recommended by PyPI, but our actions workflow was using the older, less secure method (having a long-lived token).

We've recently migrated [poseinterface to trusted publishing](https://github.com/neuroinformatics-unit/poseinterface/pull/67) and are also [changing our python-cookiecutter](https://github.com/neuroinformatics-unit/python-cookiecutter/pull/179) accordingly.

**What does this PR do?**

- Updates the `test_and_deploy.yml` workflow to use the trusted publishing route. I've already configured PyPI accordingly and I've also set up a GitHub environment named `pypi`, with deployment tag rule (`v*`).
- Updates the contributing guide. At first, I only meant to mention trusted publishing, but I realised that our "Versioning and releases" section was severely out of date. We already had some internal notes on how to make a new release (on HackMD), and I thought the time is ripe for porting them to the contributing guide. I originally meant for these notes to become part of a new 'Maintainer's guide' (#826), but since that will take time, better to have these as part of the current contributing guide rather than not at all. Therefore, this PR introduces a detailed "Making a new release" section, which is marked as being aimed at maintainers. The PR also updates the existing section on "Versioning" to document our practices re semantic versioning.

## References

- Follows the example of https://github.com/neuroinformatics-unit/poseinterface/pull/67 and https://github.com/neuroinformatics-unit/python-cookiecutter/pull/179
- The idea of documenting the release process as part of a 'Maintainer's guide' had been floated in https://github.com/neuroinformatics-unit/movement/issues/808

## How has this PR been tested?

The new route has been confirmed to work by releasing `poseinterface` v0.2.0 succesfully.

I've checked the updated contributing guide via a local docs build.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

Yes, the contributing guide now includes a whole new section on 'Making a new release', and also mentioned trusted publishing.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
