### PR TITLE
Set property edited=True on removed predictions

### DIFF
--- a/movement/napari/convert.py
+++ b/movement/napari/convert.py
@@ -181,7 +181,8 @@ def napari_layers_to_ds(
         to a list of values, and each value corresponding to a point.
     properties_with_nans:
         Properties DataFrame derived from the original loaded dataset
-        including any NaN position data.
+        including any NaN position data. Must include a
+        ``position_is_nan`` boolean column flagging any such points.
     attrs
         Attributes of the original loaded dataset (e.g.
         ``source_software``, ``fps``, ``time_unit`` and
@@ -268,9 +269,16 @@ def napari_layers_to_ds(
 
         position_df["keypoint"] = properties_df["keypoint"].to_numpy()
         position_df["individual"] = properties_df["individual"].to_numpy()
-        confidence_da = (
+        # Points dragged in napari gain an `edited` flag; the column is
+        # absent until the first drag.
+        if "edited" not in properties_df.columns:
+            properties_df["edited"] = False
+
+        # Reconstruct the confidence and edited arrays from the live
+        # properties DataFrame
+        live_das = (
             properties_df.set_index(["time", "keypoint", "individual"])[
-                "confidence"
+                ["confidence", "edited"]
             ]
             .to_xarray()
             .reindex(
@@ -279,41 +287,9 @@ def napari_layers_to_ds(
                 individual=individual_coords,
             )
         )
-        edited_da_full = (
-            (
-                properties_df.set_index(["time", "keypoint", "individual"])[
-                    "edited"
-                ]
-                .to_xarray()
-                .reindex(
-                    time=time_coords,
-                    keypoint=keypoint_coords,
-                    individual=individual_coords,
-                )
-                .fillna(False)
-                .astype(bool)
-                if "edited" in properties_df.columns
-                else xr.full_like(confidence_da, False, dtype=bool)
-            )
-            | (
-                confidence_da.isnull()
-                & properties_with_nans.set_index(
-                    ["time", "keypoint", "individual"]
-                )["confidence"]
-                .notna()
-                .to_xarray()
-                .reindex(
-                    time=time_coords,
-                    keypoint=keypoint_coords,
-                    individual=individual_coords,
-                    fill_value=False,
-                )
-            )
-        ).astype(bool)
-        edited_da: xr.DataArray | None = (
-            edited_da_full if edited_da_full.any() else None
-        )
+        confidence_da = live_das["confidence"]
 
+        # Reconstruct the position array from the live napari Points layer
         position_df = position_df.melt(
             id_vars=["time", "frame", "keypoint", "individual"],
             value_vars=["x", "y"],
@@ -333,15 +309,34 @@ def napari_layers_to_ds(
             )
         )
 
-        data_vars = {
-            "position": position_da,
-            "confidence": confidence_da,
-        }
-        if edited_da is not None:
-            data_vars["edited"] = edited_da
+        # A point missing from the live layer shows up as NaN position
+        # after the reindex above
+        point_missing_now = position_da.isnull().all("space")
+        position_was_present_originally = ~(
+            properties_with_nans.set_index(["time", "keypoint", "individual"])[
+                "position_is_nan"
+            ]
+            .to_xarray()
+            .reindex(
+                time=time_coords,
+                keypoint=keypoint_coords,
+                individual=individual_coords,
+                fill_value=True,
+            )
+            .astype(bool)
+        )
+        # A point counts as edited if it was dragged in napari, or removed
+        # by the user (i.e. is now missing but was present originally).
+        edited_da = live_das["edited"].fillna(False).astype(bool) | (
+            point_missing_now & position_was_present_originally
+        )
 
         ds = xr.Dataset(
-            data_vars=data_vars,
+            data_vars={
+                "position": position_da,
+                "confidence": confidence_da,
+                "edited": edited_da,
+            },
             coords={
                 "time": time_coords,
                 "space": space_coords,
@@ -351,10 +346,9 @@ def napari_layers_to_ds(
             attrs=attrs if attrs is not None else {},
         )
         # Drop keypoints/individuals with no data left; never `time`.
-        # `edited` (if present) is excluded from the check: it's
-        # boolean (fill value False), so it's never "null" and would
-        # otherwise prevent any keypoint/individual from ever being
-        # dropped.
+        # `edited` is excluded from the check: it's boolean (fill value
+        # False), so it's never "null" and would otherwise prevent any
+        # keypoint/individual from ever being dropped.
         dropna_subset = ["position", "confidence"]
         ds = ds.dropna(dim="keypoint", how="all", subset=dropna_subset).dropna(
             dim="individual", how="all", subset=dropna_subset
@@ -366,6 +360,10 @@ def napari_layers_to_ds(
                     "This happens when all points have been removed."
                 )
             )
+        # Drop `edited` entirely if nothing survived the trim above:
+        # e.g. the only edits were on a keypoint/individual just dropped.
+        if not ds["edited"].any():
+            ds = ds.drop_vars("edited")
         return ds
 
     raise NotImplementedError(

--- a/movement/napari/convert.py
+++ b/movement/napari/convert.py
@@ -279,9 +279,8 @@ def napari_layers_to_ds(
                 individual=individual_coords,
             )
         )
-        edited_da = None
-        if "edited" in properties_df.columns:
-            edited_da = (
+        edited_da_full = (
+            (
                 properties_df.set_index(["time", "keypoint", "individual"])[
                     "edited"
                 ]
@@ -293,7 +292,27 @@ def napari_layers_to_ds(
                 )
                 .fillna(False)
                 .astype(bool)
+                if "edited" in properties_df.columns
+                else xr.full_like(confidence_da, False, dtype=bool)
             )
+            | (
+                confidence_da.isnull()
+                & properties_with_nans.set_index(
+                    ["time", "keypoint", "individual"]
+                )["confidence"]
+                .notna()
+                .to_xarray()
+                .reindex(
+                    time=time_coords,
+                    keypoint=keypoint_coords,
+                    individual=individual_coords,
+                    fill_value=False,
+                )
+            )
+        ).astype(bool)
+        edited_da: xr.DataArray | None = (
+            edited_da_full if edited_da_full.any() else None
+        )
 
         position_df = position_df.melt(
             id_vars=["time", "frame", "keypoint", "individual"],

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -244,6 +244,9 @@ class DataLoader(QWidget):
 
         # Find rows that do not contain NaN values
         self.data_not_nan = ~np.any(np.isnan(self.data), axis=1)
+        # Record which points had a NaN position originally as a property
+        # This is used to reconstruct a dataset on save
+        self.properties["position_is_nan"] = ~self.data_not_nan
         return True
 
     def _load_third_party_file(self) -> xr.Dataset:
@@ -348,10 +351,13 @@ class DataLoader(QWidget):
             properties_df=self.properties,
         )
 
-        # Filter out columns ending in _factorized (used internally for
-        # Tracks/Shapes coloring but not needed in Points layer tooltips)
+        # Filter out columns used internally (for Tracks/Shapes coloring,
+        # or for reconstructing the dataset on save) but not needed in
+        # Points layer tooltips: _factorized columns and position_is_nan.
         points_properties = self.properties.loc[
-            :, ~self.properties.columns.str.endswith("_factorized")
+            :,
+            ~self.properties.columns.str.endswith("_factorized")
+            & (self.properties.columns != "position_is_nan"),
         ]
         self.points_layer = self.viewer.add_points(
             self.data[self.data_not_nan, 1:],

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -656,6 +656,51 @@ def test_removed_pose_napari_layers_restores_nans(
     xr.testing.assert_equal(ds, expected_ds)
 
 
+def test_removed_point_marked_edited(
+    valid_poses_path_and_ds,
+    loaded_data_loader,
+):
+    """Test that a point removed from the napari Points layer is
+    reconstructed with ``edited=True``.
+
+    Mirrors :func:`test_edited_pose_napari_layers`, but the point is
+    deleted rather than dragged. Unlike a drag, there is no live row
+    left in the Points layer to carry an ``edited`` property once the
+    point is removed, so :func:`napari_layers_to_ds` must recover the
+    flag from the point's confidence value instead: it was real before
+    removal, and is missing (reconstructed as NaN) afterwards.
+    """
+    filepath, ds_expected = valid_poses_path_and_ds
+    loader = loaded_data_loader(filepath, ds_expected)
+
+    removed_point = {
+        "time": [2],
+        "individual": ["id_0"],
+        "keypoint": ["centroid"],
+    }
+    target = _target_points_to_remove(removed_point, ds_expected)
+    points, properties = _remove_points(loader, target)
+
+    ds = napari_layers_to_ds(
+        points_as_napari=points,
+        properties=properties,
+        properties_with_nans=loader.properties,
+        attrs=ds_expected.attrs,
+    )
+    # check if `edited` is boolean
+    assert ds["edited"].dtype == bool
+
+    expected_ds = _nan_confidence_at_nan_pos(ds_expected)
+    removed_point = {"time": 2, "keypoint": "centroid", "individual": "id_0"}
+    expected_ds.position.loc[{**removed_point, "space": ["x", "y"]}] = np.nan
+    expected_ds["confidence"].loc[removed_point] = np.nan
+    expected_ds["edited"] = xr.full_like(
+        expected_ds["confidence"], False, dtype=bool
+    )
+    expected_ds["edited"].loc[removed_point] = True
+    xr.testing.assert_equal(ds, expected_ds)
+
+
 @pytest.mark.parametrize(
     "removal_selector, dropped_dim",
     [

--- a/tests/test_unit/test_napari_plugin/test_convert.py
+++ b/tests/test_unit/test_napari_plugin/test_convert.py
@@ -310,6 +310,7 @@ def test_valid_poses_roundtrip_napari_layer_to_dataset(ds_dataset, request):
 
     # simulate loader widget filtering of nans
     valid_point_mask = ~np.any(np.isnan(napari_tracks[:, 2:4]), axis=1)
+    properties_with_nan["position_is_nan"] = ~valid_point_mask
 
     # napari_tracks is shape (N,4): (track_id, frame, y, x)
     # but our function is expecting the points layer (N,3): (frame, y, x)
@@ -528,6 +529,7 @@ def test_edited_property_round_trip(
     # Simulate the loader widget filtering out NaN position rows, then
     # convert back to a dataset again.
     valid_point_mask = ~np.any(np.isnan(napari_tracks[:, 2:4]), axis=1)
+    properties_with_nan["position_is_nan"] = ~valid_point_mask
     napari_points = napari_tracks[valid_point_mask, 1:]
     properties = properties_with_nan.iloc[valid_point_mask].reset_index(
         drop=True
@@ -612,7 +614,8 @@ def test_removed_pose_napari_layers_restores_nans(
     for a range of frames (for one individual, or for all of them).
     Parametrized over datasets with and without pre-existing NaN
     positions, to check removal still works when combined with data
-    that's already missing.
+    that's already missing. Removed points are marked ``edited=True``;
+    pre-existing NaNs are not, since they were never real data.
     """
     if nan_location is None:
         filepath, ds_expected = valid_poses_path_and_ds
@@ -630,9 +633,6 @@ def test_removed_pose_napari_layers_restores_nans(
         properties_with_nans=loader.properties,
         attrs=ds_expected.attrs,
     )
-    # No point was ever dragged, so the live properties never gained an
-    # `edited` key: deletion alone does not add the variable.
-    assert "edited" not in ds
 
     # Removed points are restored as NaN; nothing is dropped from the
     # dataset's time/keypoint/individual coordinates.
@@ -652,6 +652,22 @@ def test_removed_pose_napari_layers_restores_nans(
             "individual": target["individual"],
         }
     ] = np.nan
+
+    # Points removed by the user are marked as edited, but only if
+    # they had real (non-NaN) data to begin with. Points that were
+    # already NaN before removal (pre-existing NaNs) are not edits.
+    originally_valid = ~ds_expected.position.isnull().all("space")
+    removed_target_mask = xr.zeros_like(originally_valid)
+    removed_target_mask.loc[
+        {
+            "time": target["time"],
+            "keypoint": target["keypoint"],
+            "individual": target["individual"],
+        }
+    ] = True
+    expected_ds["edited"] = (removed_target_mask & originally_valid).astype(
+        bool
+    )
 
     xr.testing.assert_equal(ds, expected_ds)
 


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

We have added an `edited` property to flag the points that were edited (dragged) from the original dataset (#1041). When a point is instead deleted, `napari` removes the row from the layer's live properties table entirely. So, by the time `napari_layers_to_ds` reconstructs the dataset, a removed point looks indistinguishable from a point that was simply never tracked. Both reconstruct with `edited = False`. 

We want to keep track of both dragged and removed points. Thus, we need to change the implementation to support removed points flagged as `edited = True`. 

**What does this PR do?**

This PR updates `napari_layers_to_ds` in `movement/napari/convert.py` to also infer `edited=True` for removed points. 

Since a deleted point no longer appears in the `napari` live properties table, we need to infer removed points by comparing the reconstructed dataset against the original. That is, if a point had a real (non-NaN) confidence value in `properties_with_nans` (original `ds`), but is now missing (`NaN` confidence) in the reconstructed `confidence_da`, it's treated as removed and flagged as `edited = True`. 


## References

This PR extends the implementation in #1041 to `edited` properties `True` for removed points. 
It is also part of #993. 

## How has this PR been tested?

Added `test_removed_point_marked_edited` in `tests/test_unit/test_napari_plugin/test_convert.py`, mirroring the existing `test_edited_pose_napari_layers`. Instead of dragging a point, in this case we remove it and assert the reconstructed dataset has `edited = True` at the point's coordinate and `edited.dtype == bool`. 

The rest of the tests written in `tests/test_unit/test_napari_plugin/test_convert.py` still pass, indicating that this change does not break any functionality. 

## Is this a breaking change?

No. This just changes `edited` properties when points are removed from `False` to `True`

## Does this PR require an update to the documentation?

No. 

## Checklist:

- [ ] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
