### PR TITLE
Run benchmark tests on CI without benchmarking

### DIFF
--- a/docs/source/community/contributing.md
+++ b/docs/source/community/contributing.md
@@ -207,8 +207,11 @@ These datasets are accessible through the `pytest.DATA_PATHS` dictionary, popula
 Avoid including large data files directly in the GitHub repository.
 
 #### Running benchmark tests
-Some tests are marked as `benchmark` because we use them along with [pytest-benchmark](pytest-benchmark:) to measure the performance of a section of the code. These tests are excluded from the default test run to keep CI and local test running fast.
-This applies to all ways of running `pytest` (via command line, IDE, tox or CI).
+Some tests are marked as `benchmark` because we use them with [pytest-benchmark](pytest-benchmark:) to measure the performance of specific code paths.
+These tests are excluded from the default test run to keep the suite fast.
+This applies to any direct `pytest` invocation (command line or IDE).
+Our `tox` environment—used in CI—runs the normal test suite and then runs the benchmark tests once with benchmarking disabled (`--benchmark-disable`).
+This serves as a smoke check: no timing or statistics are collected; it simply verifies that the benchmarked code still executes correctly.
 
 To run only the benchmark tests locally:
 
@@ -216,7 +219,7 @@ To run only the benchmark tests locally:
 pytest -m benchmark
 ```
 
-To run all tests, including those marked as `benchmark`:
+To run the full test suite, including tests marked as `benchmark`:
 
 ```sh
 pytest -m ""

--- a/docs/source/community/contributing.md
+++ b/docs/source/community/contributing.md
@@ -210,8 +210,8 @@ Avoid including large data files directly in the GitHub repository.
 Some tests are marked as `benchmark` because we use them with [pytest-benchmark](pytest-benchmark:) to measure the performance of specific code paths.
 These tests are excluded from the default test run to keep the suite fast.
 This applies to any direct `pytest` invocation (command line or IDE).
-Our `tox` environment—used in CI—runs the normal test suite and then runs the benchmark tests once with benchmarking disabled (`--benchmark-disable`).
-This serves as a smoke check: no timing or statistics are collected; it simply verifies that the benchmarked code still executes correctly.
+Our `tox` environment—used in CI—runs the full test suite, including the benchmark tests, but with benchmarking disabled (`--benchmark-disable`).
+This acts as a smoke check: no timing or statistics are collected; it simply verifies that the benchmarked code still executes correctly.
 
 To run only the benchmark tests locally:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,6 +221,5 @@ passenv =
 dependency_groups =
     dev
 commands =
-    pytest -v --color=yes --cov=movement --cov-report=xml
-    pytest -m benchmark --benchmark-disable
+    pytest -v --color=yes --cov=movement --cov-report=xml -m "" --benchmark-disable
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,4 +222,5 @@ dependency_groups =
     dev
 commands =
     pytest -v --color=yes --cov=movement --cov-report=xml
+    pytest -m benchmark --benchmark-disable
 """

--- a/tests/test_unit/test_io/test_load_bboxes.py
+++ b/tests/test_unit/test_io/test_load_bboxes.py
@@ -523,7 +523,9 @@ def test_benchmark_from_via_tracks_file(via_file_path, benchmark):
         # single individual present in 35 non-consecutive frames
     ],
 )
-def test_benchmark_df_from_valid_via_object(via_file_path, benchmark):
-    """Benchmark the `_df_from_valid_via_object` function."""
+def test_benchmark_numpy_arrays_from_valid_via_object(
+    via_file_path, benchmark
+):
+    """Benchmark the `_numpy_arrays_from_valid_via_object` function."""
     valid_via = ValidVIATracksCSV(via_file_path)
-    benchmark(load_bboxes._df_from_valid_via_object, valid_via)
+    benchmark(load_bboxes._numpy_arrays_from_valid_via_object, valid_via)


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Closes #789 
Supersedes #854 
Follow-up PR to migrate to tox TOML: #1073 

**What does this PR do?**
This PR 
- run the full test suite, including benchmark tests on CI (via tox config in pyproject.toml) with the [--benchmark-disable](https://pytest-benchmark.readthedocs.io/en/latest/usage.html#commandline-options:~:text=that%20contain%20benchmarks.-,%2D%2Dbenchmark%2Ddisable,-Disable%20benchmarks.%20Benchmarked) flag: this is equivalent to a smoke test, running the benchmark tests once without benchmarking. 
- fixes the broken benchmark test that still uses the old `_df_from_valid_via_object` function, replacing it with `_numpy_arrays_from_valid_via_object` introduced in #769 

## How has this PR been tested?
ran `pytest -m benchmark --benchmark-disable` locally and on CI ([as a separate step](https://github.com/neuroinformatics-unit/movement/actions/runs/31510355427/job/93842526810?pr=1071#step:4:2230)) to verify benchmark tests pass in seconds.

## Does this PR require an update to the documentation?
the relevant section in the contributing guide has been updated.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
