### PR TITLE
Migrate tox INI to TOML

### DIFF
--- a/docs/source/community/contributing.md
+++ b/docs/source/community/contributing.md
@@ -207,8 +207,11 @@ These datasets are accessible through the `pytest.DATA_PATHS` dictionary, popula
 Avoid including large data files directly in the GitHub repository.
 
 #### Running benchmark tests
-Some tests are marked as `benchmark` because we use them along with [pytest-benchmark](pytest-benchmark:) to measure the performance of a section of the code. These tests are excluded from the default test run to keep CI and local test running fast.
-This applies to all ways of running `pytest` (via command line, IDE, tox or CI).
+Some tests are marked as `benchmark` because we use them with [pytest-benchmark](pytest-benchmark:) to measure the performance of specific code paths.
+These tests are excluded from the default test run to keep the suite fast.
+This applies to any direct `pytest` invocation (command line or IDE).
+Our `tox` environment—used in CI—runs the normal test suite and then runs the benchmark tests once with benchmarking disabled (`--benchmark-disable`).
+This serves as a smoke check: no timing or statistics are collected; it simply verifies that the benchmarked code still executes correctly.
 
 To run only the benchmark tests locally:
 
@@ -216,7 +219,7 @@ To run only the benchmark tests locally:
 pytest -m benchmark
 ```
 
-To run all tests, including those marked as `benchmark`:
+To run the full test suite, including tests marked as `benchmark`:
 
 ```sh
 pytest -m ""

--- a/docs/source/community/contributing.md
+++ b/docs/source/community/contributing.md
@@ -210,8 +210,8 @@ Avoid including large data files directly in the GitHub repository.
 Some tests are marked as `benchmark` because we use them with [pytest-benchmark](pytest-benchmark:) to measure the performance of specific code paths.
 These tests are excluded from the default test run to keep the suite fast.
 This applies to any direct `pytest` invocation (command line or IDE).
-Our `tox` environment—used in CI—runs the normal test suite and then runs the benchmark tests once with benchmarking disabled (`--benchmark-disable`).
-This serves as a smoke check: no timing or statistics are collected; it simply verifies that the benchmarked code still executes correctly.
+Our `tox` environment—used in CI—runs the full test suite, including the benchmark tests, but with benchmarking disabled (`--benchmark-disable`).
+This acts as a smoke check: no timing or statistics are collected; it simply verifies that the benchmarked code still executes correctly.
 
 To run only the benchmark tests locally:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,30 +196,26 @@ skip = '.git,.tox,*.svg,docs/source/community/people.md'
 check-hidden = true
 
 [tool.tox]
-legacy_tox_ini = """
-[tox]
-requires =
-    tox>=4
-    tox-gh-actions
-envlist = py{312,313,314}
-isolated_build = True
+requires = ["tox>=4", "tox-gh-actions"]
+env_list = ["py312", "py313", "py314"]
 
-[gh-actions]
-python =
+[tool.tox.gh-actions]
+python = """
     3.12: py312
     3.13: py313
     3.14: py314
-
-[testenv]
-passenv =
-    CI
-    GITHUB_ACTIONS
-    DISPLAY
-    XAUTHORITY
-    NUMPY_EXPERIMENTAL_ARRAY_FUNCTION
-    PYVISTA_OFF_SCREEN
-dependency_groups =
-    dev
-commands =
-    pytest -v --color=yes --cov=movement --cov-report=xml -m "" --benchmark-disable
 """
+
+[tool.tox.env_run_base]
+pass_env = [
+    "CI",
+    "GITHUB_ACTIONS",
+    "DISPLAY",
+    "XAUTHORITY",
+    "NUMPY_EXPERIMENTAL_ARRAY_FUNCTION",
+    "PYVISTA_OFF_SCREEN",
+]
+dependency_groups = ["dev"]
+commands = [
+    ["pytest", "-v", "--color=yes", "--cov=movement", "--cov-report=xml", "-m", "", "--benchmark-disable"],
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,6 +221,5 @@ passenv =
 dependency_groups =
     dev
 commands =
-    pytest -v --color=yes --cov=movement --cov-report=xml
-    pytest -m benchmark --benchmark-disable
+    pytest -v --color=yes --cov=movement --cov-report=xml -m "" --benchmark-disable
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,4 +222,5 @@ dependency_groups =
     dev
 commands =
     pytest -v --color=yes --cov=movement --cov-report=xml
+    pytest -m benchmark --benchmark-disable
 """

--- a/tests/test_unit/test_io/test_load_bboxes.py
+++ b/tests/test_unit/test_io/test_load_bboxes.py
@@ -523,7 +523,9 @@ def test_benchmark_from_via_tracks_file(via_file_path, benchmark):
         # single individual present in 35 non-consecutive frames
     ],
 )
-def test_benchmark_df_from_valid_via_object(via_file_path, benchmark):
-    """Benchmark the `_df_from_valid_via_object` function."""
+def test_benchmark_numpy_arrays_from_valid_via_object(
+    via_file_path, benchmark
+):
+    """Benchmark the `_numpy_arrays_from_valid_via_object` function."""
     valid_via = ValidVIATracksCSV(via_file_path)
-    benchmark(load_bboxes._df_from_valid_via_object, valid_via)
+    benchmark(load_bboxes._numpy_arrays_from_valid_via_object, valid_via)


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Closes #1072 

**What does this PR do?**
This PR is a follow-up to #1071 and is branched off it:

- replaces the deprecated tox INI format in pyproject.toml with TOML
- removes the `isolated_build` key dropped in tox v4; [isolated builds are always used](https://tox.wiki/en/4.23.1/upgrading.html#removed-tox-ini-keys)

## References
#1071 #1072 https://github.com/neuroinformatics-unit/actions/issues/60

## How has this PR been tested?
Tests continue to run on CI

## Checklist:

- [ ] Rebase against main when #1071 is merged
- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
