### PR TITLE
Map individual-wise confidence scores to SLEAP instance_scores

### DIFF
--- a/movement/io/load_poses.py
+++ b/movement/io/load_poses.py
@@ -450,10 +450,14 @@ def _ds_from_sleap_analysis_file(file: Path, fps: float | None) -> xr.Dataset:
                 "Assuming single-individual dataset and assigning "
                 "default individual name."
             )
-        # If present, read the point-wise scores,
-        # and transpose to shape: (n_frames, n_keypoints, n_tracks)
-        if "point_scores" in f:
-            scores = f["point_scores"][:].T
+        # Prioritise point scores if present and non-empty, otherwise use
+        # instance scores, and transpose to shape (n_frames, n_keypoints,
+        # n_tracks) or (n_frames, n_tracks) respectively.
+        for key in ("point_scores", "instance_scores"):
+            if key in f and not np.all(np.isnan(f[key])):
+                scores = f[key][:].T
+                logger.info(f"Using {key} for confidence scores.")
+                break
         return from_numpy(
             position_array=tracks.astype(np.float32),
             confidence_array=scores.astype(np.float32),

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -306,13 +306,21 @@ def to_sleap_analysis_file(ds: xr.Dataset, file_path: str | Path) -> None:
 
     Notes
     -----
-    The output file will contain the following keys (as in SLEAP .h5 analysis
-    files):
+    The output file will contain the following keys (matching the structure of
+    SLEAP .h5 analysis files):
     "track_names", "node_names", "tracks", "track_occupancy", "point_scores",
     "instance_scores", "tracking_scores", "labels_path", "edge_names",
     "edge_inds", "video_path", "video_ind", "provenance" [1]_.
-    However, only "track_names", "node_names", "tracks", "track_occupancy"
-    and "point_scores" will contain data extracted from the input dataset.
+    However, only "track_names", "node_names", "tracks" and "track_occupancy"
+    are guaranteed to contain data extracted from the input dataset.
+    For confidence scores, only one of "point_scores" or "instance_scores"
+    will be populated. The other will contain default NaN values. Specifically:
+
+    - "point_scores" is populated when ``ds`` contains keypoint-wise
+      confidence scores.
+    - "instance_scores" is populated when ``ds`` contains individual-wise
+      confidence scores.
+
     "labels_path" will contain the path to the input file only if the source
     file of the dataset is a SLEAP .slp file. Otherwise, it will be an empty
     string.
@@ -358,9 +366,17 @@ def to_sleap_analysis_file(ds: xr.Dataset, file_path: str | Path) -> None:
     # Mask denoting which individuals are present in each frame
     track_occupancy = (~np.all(np.isnan(pos_x), axis=1)).astype(int)
     tracks = ds.position.data.transpose(3, 1, 2, 0)
-    point_scores = ds.confidence.data.T
-    instance_scores = np.full((n_individuals, n_frames), np.nan, dtype=float)
     tracking_scores = np.full((n_individuals, n_frames), np.nan, dtype=float)
+    if ds.confidence.ndim == 3:  # keypoint-wise confidence in "point_scores"
+        instance_scores = np.full(
+            (n_individuals, n_frames), np.nan, dtype=float
+        )
+        point_scores = ds.confidence.data.T
+    else:  # individual-wise confidence in "instance_scores"
+        instance_scores = ds.confidence.data.T
+        point_scores = np.full(
+            (n_individuals, len(keypoint_names), n_frames), np.nan, dtype=float
+        )
 
     source_file = getattr(ds, "source_file", None)
     labels_path = (

--- a/tests/test_integration/test_io.py
+++ b/tests/test_integration/test_io.py
@@ -49,6 +49,24 @@ def test_convert_sleap_to_dlc_file(sleap_file, dlc_output_file):
 
 
 @pytest.mark.parametrize(
+    "dataset",
+    [
+        "valid_poses_dataset",
+        "valid_poses_dataset_with_individual_wise_confidence",
+    ],
+)
+def test_save_and_load_sleap_file(dataset, new_h5_file, request):
+    """Test that saving pose tracks with keypoint- and individual-wise
+    confidence to SLEAP-style .h5 analysis files and then loading them
+    back in returns the same Dataset.
+    """
+    ds_saved = request.getfixturevalue(dataset)
+    save_poses.to_sleap_analysis_file(ds_saved, new_h5_file)
+    ds_loaded = load_poses.from_sleap_file(new_h5_file)
+    xr.testing.assert_allclose(ds_saved, ds_loaded)
+
+
+@pytest.mark.parametrize(
     "sleap_h5_file, fps",
     [
         ("SLEAP_single-mouse_EPM.analysis.h5", 30),

--- a/tests/test_unit/test_io/test_save_poses.py
+++ b/tests/test_unit/test_io/test_save_poses.py
@@ -1,6 +1,7 @@
 from contextlib import nullcontext as does_not_raise
 from pathlib import Path
 
+import h5py
 import numpy as np
 import pandas as pd
 import pytest
@@ -363,6 +364,45 @@ def test_to_sleap_analysis_file_valid_dataset(
         val = request.getfixturevalue(file_fixture)
         file_path = val.get("file_path") if isinstance(val, dict) else val
         save_poses.to_sleap_analysis_file(valid_poses_dataset, file_path)
+
+
+@pytest.mark.parametrize(
+    "dataset, expected_confidence_key",
+    [
+        ("valid_poses_dataset", "point_scores"),
+        (
+            "valid_poses_dataset_with_individual_wise_confidence",
+            "instance_scores",
+        ),
+    ],
+)
+def test_to_sleap_analysis_file_confidence_scores(
+    dataset, expected_confidence_key, new_h5_file, request
+):
+    """Test that saving to SLEAP analysis files a dataset with:
+    - keypoint-wise confidence scores stores the scores in "point_scores"
+    - individual-wise confidence scores stores the scores in "instance_scores"
+    and that the other score array is filled with NaNs with the correct shape.
+    """
+    ds = request.getfixturevalue(dataset)
+    save_poses.to_sleap_analysis_file(ds, new_h5_file)
+    empty_shapes = {
+        "point_scores": (
+            ds.sizes["time"],
+            ds.sizes["keypoint"],
+            ds.sizes["individual"],
+        ),
+        "instance_scores": (ds.sizes["time"], ds.sizes["individual"]),
+    }
+    with h5py.File(new_h5_file, "r") as f:
+        scores = {key: f[key][:].T for key in empty_shapes}
+    empty_key = next(k for k in empty_shapes if k != expected_confidence_key)
+    np.testing.assert_allclose(
+        scores[expected_confidence_key], ds.confidence.values
+    )
+    np.testing.assert_array_equal(
+        scores[empty_key], np.full(empty_shapes[empty_key], np.nan)
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Closes #1074 

**What does this PR do?**
This PR 
- adds support for falling back to `instance_scores` from SLEAP `.h5` analysis formats as individual-wise confidence scores when `point_scores` are not available (all NaNs or when the "point_scores" key doesn't exist in SLEAP .h5 file) when _loading_ from SLEAP .h5 files
- does _not_ modify the behaviour of loading from `.slp` formats because we expect and read scores from `PredictedInstance` using [`.numpy(scores=True)`](https://github.com/talmolab/sleap-io/blob/80bbcd9c3b005a7616c14b875b761071f10ecde6/sleap_io/model/instance.py#L1362-L1365).
- stores individual-wise confidence score as `instance_scores` when _saving_ to SLEAP `.h5` formats; the behaviour for storing keypoint-wise confidence (as `point_scores`) remains unchanged

## References
#1003 #1074

## How has this PR been tested?
New tests have been added

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
Docstrings are updated accordingly

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
