### PR TITLE
Save single-individual datasets to the given path in `to_dlc_file`

### DIFF
--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -87,6 +87,7 @@ def _save_dlc_df(filepath: Path, df: pd.DataFrame) -> None:
         Pandas Dataframe to save
 
     """
+    validate_file_path(filepath, permission="w", suffixes={".csv", ".h5"})
     if filepath.suffix == ".csv":
         df.to_csv(filepath, sep=",")
     else:  # at this point it can only be .h5 (because of validation)

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -1,7 +1,7 @@
 """Save pose tracking data from ``movement`` to various file formats."""
 
 from pathlib import Path
-from typing import Literal
+from typing import Literal, overload
 
 import h5py
 import numpy as np
@@ -75,12 +75,6 @@ def _ds_to_dlc_style_df(
     return df
 
 
-def _auto_split_individuals(ds: xr.Dataset) -> bool:
-    """Return True if there is only one individual in the dataset."""
-    n_individuals = ds.sizes["individual"]
-    return n_individuals == 1
-
-
 def _save_dlc_df(filepath: Path, df: pd.DataFrame) -> None:
     """Save the dataframe as either a .h5 or .csv depending on the file path.
 
@@ -99,6 +93,18 @@ def _save_dlc_df(filepath: Path, df: pd.DataFrame) -> None:
         df.to_hdf(filepath, key="df_with_missing")
 
 
+@overload
+def to_dlc_style_df(
+    ds: xr.Dataset, split_individuals: Literal[False] = False
+) -> pd.DataFrame: ...
+@overload
+def to_dlc_style_df(
+    ds: xr.Dataset, split_individuals: Literal[True]
+) -> dict[str, pd.DataFrame]: ...
+@overload
+def to_dlc_style_df(
+    ds: xr.Dataset, split_individuals: bool
+) -> pd.DataFrame | dict[str, pd.DataFrame]: ...
 def to_dlc_style_df(
     ds: xr.Dataset, split_individuals: bool = False
 ) -> pd.DataFrame | dict[str, pd.DataFrame]:
@@ -223,8 +229,7 @@ def to_dlc_file(
 
     # Sets default behaviour for the function
     if split_individuals == "auto":
-        split_individuals = _auto_split_individuals(ds)
-
+        split_individuals = ds.individual.size == 1
     elif not isinstance(split_individuals, bool):
         raise logger.error(
             ValueError(
@@ -232,29 +237,22 @@ def to_dlc_file(
                 f"but got {type(split_individuals)}."
             )
         )
-
-    if split_individuals:
-        # split the dataset into a dictionary of dataframes per individual
-        df_dict = to_dlc_style_df(ds, split_individuals=True)
-        # only disambiguate the file paths if there is more than one file
-        append_name = len(df_dict) > 1
-
-        for key, df in df_dict.items():
-            # the key is the individual's name
-            filepath = (
-                Path(f"{valid_path.with_suffix('')}_{key}{valid_path.suffix}")
-                if append_name
-                else valid_path
+    assert isinstance(split_individuals, bool)
+    df_all = to_dlc_style_df(ds, split_individuals=split_individuals)
+    if isinstance(df_all, pd.DataFrame):
+        df_all = {"": df_all}
+    for individual, df in df_all.items():
+        # a single individual is always saved to the given path as is;
+        # multiple individuals get their name appended to the path
+        filepath = (
+            valid_path
+            if len(df_all) == 1
+            else Path(
+                f"{valid_path.with_suffix('')}_{individual}{valid_path.suffix}"
             )
-            if isinstance(df, pd.DataFrame):
-                _save_dlc_df(filepath, df)
-            logger.info(f"Saved poses for individual {key} to {filepath}.")
-    else:
-        # convert the dataset to a single dataframe for all individuals
-        df_all = to_dlc_style_df(ds, split_individuals=False)
-        if isinstance(df_all, pd.DataFrame):
-            _save_dlc_df(valid_path, df_all)
-        logger.info(f"Saved poses dataset to {valid_path}.")
+        )
+        _save_dlc_df(filepath, df)
+        logger.info(f"Saved poses dataset to {filepath}.")
 
 
 def to_lp_file(

--- a/movement/io/save_poses.py
+++ b/movement/io/save_poses.py
@@ -196,9 +196,11 @@ def to_dlc_file(
     -----
     If ``split_individuals`` is True, each individual will be saved to a
     separate file, formatted as in a single-animal DeepLabCut project
-    (without the "individuals" column level). The individual's name will be
-    appended to the file path, just before the file extension, e.g.
-    "/path/to/filename_individual1.h5". If False, all individuals will be
+    (without the "individuals" column level). If the dataset contains more
+    than one individual, the individual's name will be appended to the file
+    path, just before the file extension, e.g.
+    "/path/to/filename_individual1.h5". If it contains only one individual,
+    the given file path is used as is. If False, all individuals will be
     saved to the same file, formatted as in a multi-animal DeepLabCut project
     (with the "individuals" column level). The file path will not be modified.
     If "auto", the argument's value is determined based on the number of
@@ -234,13 +236,19 @@ def to_dlc_file(
     if split_individuals:
         # split the dataset into a dictionary of dataframes per individual
         df_dict = to_dlc_style_df(ds, split_individuals=True)
+        # only disambiguate the file paths if there is more than one file
+        append_name = len(df_dict) > 1
 
         for key, df in df_dict.items():
             # the key is the individual's name
-            filepath = f"{valid_path.with_suffix('')}_{key}{valid_path.suffix}"
+            filepath = (
+                Path(f"{valid_path.with_suffix('')}_{key}{valid_path.suffix}")
+                if append_name
+                else valid_path
+            )
             if isinstance(df, pd.DataFrame):
-                _save_dlc_df(Path(filepath), df)
-            logger.info(f"Saved poses for individual {key} to {valid_path}.")
+                _save_dlc_df(filepath, df)
+            logger.info(f"Saved poses for individual {key} to {filepath}.")
     else:
         # convert the dataset to a single dataframe for all individuals
         df_all = to_dlc_style_df(ds, split_individuals=False)
@@ -269,9 +277,10 @@ def to_lp_file(
     format as single-animal DeepLabCut projects. Therefore, under the hood,
     this function calls :func:`movement.io.save_poses.to_dlc_file`
     with ``split_individuals=True``. This setting means that each individual
-    is saved to a separate file, with the individual's name appended to the
-    file path, just before the file extension,
-    i.e. "/path/to/filename_individual1.csv".
+    is saved to a separate file. If the dataset contains more than one
+    individual, the individual's name is appended to the file path, just
+    before the file extension, i.e. "/path/to/filename_individual1.csv".
+    If it contains only one individual, the given file path is used as is.
 
     See Also
     --------

--- a/tests/test_unit/test_io/test_save_poses.py
+++ b/tests/test_unit/test_io/test_save_poses.py
@@ -214,20 +214,6 @@ def test_to_dlc_file_invalid_dataset(
 
 
 @pytest.mark.parametrize(
-    "valid_poses_dataset, split_value",
-    [("single_individual_array", True), ("multi_individual_array", False)],
-    indirect=["valid_poses_dataset"],
-)
-def test_auto_split_individuals(valid_poses_dataset, split_value):
-    """Test that setting 'split_individuals' to 'auto' yields True
-    for single-individual datasets and False for multi-individual ones.
-    """
-    assert (
-        save_poses._auto_split_individuals(valid_poses_dataset) == split_value
-    )
-
-
-@pytest.mark.parametrize(
     "valid_poses_dataset",
     ["single_individual_array", "multi_individual_array"],
     indirect=True,

--- a/tests/test_unit/test_io/test_save_poses.py
+++ b/tests/test_unit/test_io/test_save_poses.py
@@ -228,7 +228,7 @@ def test_to_dlc_style_df_split_individuals(
     df = save_poses.to_dlc_style_df(valid_poses_dataset, split_individuals)
     # Get the names of the individuals in the dataset
     ind_names = valid_poses_dataset.individual.values
-    if split_individuals is False:
+    if not split_individuals:
         # this should produce a single df in multi-animal DLC format
         assert isinstance(df, pd.DataFrame)
         assert df.columns.names == [
@@ -241,7 +241,7 @@ def test_to_dlc_style_df_split_individuals(
             [ind in df.columns.get_level_values("individuals")]
             for ind in ind_names
         )
-    elif split_individuals is True:
+    else:
         # this should produce a dict of dfs in single-animal DLC format
         assert isinstance(df, dict)
         for ind in ind_names:
@@ -294,26 +294,11 @@ def test_to_dlc_file_split_individuals(
         else:
             # this should save a single file, at the given file path
             assert new_h5_file.is_file()
+            for ind in ind_names:
+                assert not Path(
+                    f"{new_h5_file.with_suffix('')}_{ind}.h5"
+                ).is_file()
             new_h5_file.unlink()
-
-
-@pytest.mark.parametrize(
-    "valid_poses_dataset", ["single_individual_array"], indirect=True
-)
-@pytest.mark.parametrize("split_individuals", [True, "auto"])
-def test_to_dlc_file_single_individual_keeps_file_path(
-    valid_poses_dataset, split_individuals, tmp_path
-):
-    """Test that a single-individual dataset is saved to the given file
-    path, without the individual's name appended to it.
-    """
-    file_path = tmp_path / "x.h5"
-    save_poses.to_dlc_file(valid_poses_dataset, file_path, split_individuals)
-    ind_name = valid_poses_dataset.individual.values[0]
-    assert file_path.is_file()
-    assert not (tmp_path / f"x_{ind_name}.h5").is_file()
-    # no other files should have been created
-    assert [path.name for path in tmp_path.iterdir()] == ["x.h5"]
 
 
 def test_to_lp_file_valid_dataset(

--- a/tests/test_unit/test_io/test_save_poses.py
+++ b/tests/test_unit/test_io/test_save_poses.py
@@ -176,7 +176,7 @@ def test_to_dlc_file_with_individual_confidence(
         tmp_path / "test.h5",
         split_individuals=split_individuals,
     )
-    if split_individuals:
+    if split_individuals and ds.sizes["individual"] > 1:
         for ind in ds.individual.values:
             assert (tmp_path / f"test_{ind}.h5").is_file()
     else:
@@ -269,6 +269,11 @@ def test_to_dlc_style_df_split_individuals(
 
 
 @pytest.mark.parametrize(
+    "valid_poses_dataset",
+    ["single_individual_array", "multi_individual_array"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
     "split_individuals, expected_exception",
     [
         (True, does_not_raise()),
@@ -292,17 +297,37 @@ def test_to_dlc_file_split_individuals(
         )
         # Get the names of the individuals in the dataset
         ind_names = valid_poses_dataset.individual.values
-        # "auto" becomes False, default valid dataset is multi-individual
-        if split_individuals in [False, "auto"]:
-            # this should save only one file
-            assert new_h5_file.is_file()
-            new_h5_file.unlink()
-        elif split_individuals is True:
-            # this should save one file per individual
+        if split_individuals is True and len(ind_names) > 1:
+            # this should save one file per individual, with the
+            # individual's name appended to the file path
+            assert not new_h5_file.is_file()
             for ind in ind_names:
                 file_path_ind = Path(f"{new_h5_file.with_suffix('')}_{ind}.h5")
                 assert file_path_ind.is_file()
                 file_path_ind.unlink()
+        else:
+            # this should save a single file, at the given file path
+            assert new_h5_file.is_file()
+            new_h5_file.unlink()
+
+
+@pytest.mark.parametrize(
+    "valid_poses_dataset", ["single_individual_array"], indirect=True
+)
+@pytest.mark.parametrize("split_individuals", [True, "auto"])
+def test_to_dlc_file_single_individual_keeps_file_path(
+    valid_poses_dataset, split_individuals, tmp_path
+):
+    """Test that a single-individual dataset is saved to the given file
+    path, without the individual's name appended to it.
+    """
+    file_path = tmp_path / "x.h5"
+    save_poses.to_dlc_file(valid_poses_dataset, file_path, split_individuals)
+    ind_name = valid_poses_dataset.individual.values[0]
+    assert file_path.is_file()
+    assert not (tmp_path / f"x_{ind_name}.h5").is_file()
+    # no other files should have been created
+    assert [path.name for path in tmp_path.iterdir()] == ["x.h5"]
 
 
 def test_to_lp_file_valid_dataset(
@@ -349,8 +374,11 @@ def test_to_lp_file_with_individual_confidence(
     ds = valid_poses_dataset_with_individual_wise_confidence
     save_poses.to_lp_file(ds, tmp_path / "test.csv")
     assert "only supports keypoint-wise confidence scores" in caplog.text
-    for ind in ds.individual.values:
-        assert (tmp_path / f"test_{ind}.csv").is_file()
+    if ds.sizes["individual"] > 1:
+        for ind in ds.individual.values:
+            assert (tmp_path / f"test_{ind}.csv").is_file()
+    else:
+        assert (tmp_path / "test.csv").is_file()
 
 
 def test_to_sleap_analysis_file_valid_dataset(


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

`_auto_split_individuals` returns True when a dataset has exactly one individual, which sends `to_dlc_file` into the branch that appends the individual's name to the file path. So `to_dlc_file(ds, "dataset.h5")` on a single-individual dataset wrote `dataset_id_0.h5` rather than `dataset.h5`. With one individual there is only one output file, so there is nothing to disambiguate and the path the caller gave should be used as is. The log line was wrong too, it reported the requested path even when the data went somewhere else.

**What does this PR do?**

Appends the individual's name only when more than one file is written, and logs the path that was actually used. `to_lp_file` picks this up as well, since it calls `to_dlc_file` with `split_individuals=True`. Behaviour for multi-individual datasets is unchanged. The Notes in both docstrings now say the name is appended only when the dataset holds more than one individual.

## References

Closes #1067

## How has this PR been tested?

`pytest tests/test_unit/test_io/test_save_poses.py` and `pytest tests/test_integration tests/test_unit/test_io` pass locally. Three existing tests asserted the old file name for the single-individual fixture and were corrected, `test_to_dlc_file_split_individuals` now runs against the single-individual dataset as well, and there is a new test checking that a single-individual dataset lands at the given path and that no suffixed file is created. Six of these cases fail without the source change and pass with it. Multi-individual cases are covered by the same tests and still pass.

## Is this a breaking change?

Yes for anyone relying on the suffixed file name when exporting a single-individual dataset, though the issue treats that name as the bug.

## Does this PR require an update to the documentation?

Only the docstring Notes for `to_dlc_file` and `to_lp_file`, which are updated here. The user guide does not describe the file naming, so it needed no change.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)