### PR TITLE
Migrate data repository to SWC GIN

### DIFF
--- a/docs/source/community/contributing.md
+++ b/docs/source/community/contributing.md
@@ -1000,7 +1000,7 @@ If the limit is reached, previews may temporarily be unavailable until the quota
 (target-contributing-sample-data)=
 ## Sample data
 We maintain some sample datasets to be used for testing, examples and tutorials on an
-[external data repository](swc-gin:lochhh/movement-test-data).
+[external data repository](swc-gin:neuroinformatics/movement-sample-data).
 Our hosting platform of choice is called [GIN](gin:), based on the
 software maintained by the [German Neuroinformatics Node](https://www.g-node.org/).
 GIN has a GitHub-like interface and git-like
@@ -1042,12 +1042,12 @@ Make sure to run the following procedure on a UNIX-like system, as we have obser
 To add a new file, you will need to:
 
 1. Create a [GIN](swc-gin:) account on our self-hosted instance.
-2. Request collaborator access to the [movement data repository](swc-gin:lochhh/movement-test-data) if you don't already have it.
-3. Install and configure the [GIN CLI](gin:G-Node/Info/wiki/GIN+CLI+Setup#quickstart) by running `gin login` in a terminal with your GIN credentials, pointing it at `https://gin.swc.ucl.ac.uk` as the server.
-4. Clone the `movement` data repository to your local machine using `gin get lochhh/movement-test-data`, then run `gin download --content` to download all the files.
+2. Request collaborator access to the [movement data repository](swc-gin:neuroinformatics/movement-sample-data) if you don't already have it.
+3. Install the [GIN CLI](gin:G-Node/Info/wiki/GIN+CLI+Setup#quickstart), then log in by running `gin login --server https://gin.swc.ucl.ac.uk` and following the instructions to authenticate with your GIN account.
+4. Clone the `movement` data repository to your local machine using `gin get neuroinformatics/movement-sample-data`, then run `gin download --content` to download all the files.
 5. Add your new files to the appropriate folders (`poses`, `bboxes`, `videos`, and/or `frames`) following the existing file naming conventions.
 6. Add metadata for your new files to `metadata.yaml` using the [example entry below](target-metadata-yaml) as a template. You can leave all `sha256sum` values as `null` for now.
-7. Update file hashes in `metadata.yaml` by running `python update_hashes.py` from the root of the [movement data repository](swc-gin:lochhh/movement-test-data). This script computes SHA256 hashes for all data files and updates the corresponding `sha256sum` values in the metadata file. Make sure you're in a [Python environment with `movement` installed](#creating-a-development-environment).
+7. Update file hashes in `metadata.yaml` by running `python update_hashes.py` from the root of the [movement data repository](swc-gin:neuroinformatics/movement-sample-data). This script computes SHA256 hashes for all data files and updates the corresponding `sha256sum` values in the metadata file. Make sure you're in a [Python environment with `movement` installed](#creating-a-development-environment).
 8. Commit your changes using `gin commit -m <message> <filename>` for specific files or `gin commit -m <message> .` for all changes.
 9. Upload your committed changes to the GIN repository with `gin upload`. Use `gin download` to pull the latest changes or `gin sync` to synchronise changes bidirectionally.
 10. [Verify](target-verify-sample-data) the new files can be fetched and loaded correctly using the {mod}`movement.sample_data` module.

--- a/docs/source/community/contributing.md
+++ b/docs/source/community/contributing.md
@@ -1000,9 +1000,9 @@ If the limit is reached, previews may temporarily be unavailable until the quota
 (target-contributing-sample-data)=
 ## Sample data
 We maintain some sample datasets to be used for testing, examples and tutorials on an
-[external data repository](gin:neuroinformatics/movement-test-data).
-Our hosting platform of choice is called [GIN](gin:) and is maintained
-by the [German Neuroinformatics Node](https://www.g-node.org/).
+[external data repository](swc-gin:lochhh/movement-test-data).
+Our hosting platform of choice is called [GIN](gin:), based on the
+software maintained by the [German Neuroinformatics Node](https://www.g-node.org/).
 GIN has a GitHub-like interface and git-like
 [CLI](gin:G-Node/Info/wiki/GIN+CLI+Setup#quickstart) functionalities.
 
@@ -1041,13 +1041,13 @@ Only core `movement` developers may add new files to the external data repositor
 Make sure to run the following procedure on a UNIX-like system, as we have observed some weird behaviour on Windows (some sha256sums may end up being different).
 To add a new file, you will need to:
 
-1. Create a [GIN](gin:) account.
-2. Request collaborator access to the [movement data repository](gin:neuroinformatics/movement-test-data) if you don't already have it.
-3. Install and configure the [GIN CLI](gin:G-Node/Info/wiki/GIN+CLI+Setup#quickstart) by running `gin login` in a terminal with your GIN credentials.
-4. Clone the `movement` data repository to your local machine using `gin get neuroinformatics/movement-test-data`, then run `gin download --content` to download all the files.
+1. Create a [GIN](swc-gin:) account on our self-hosted instance.
+2. Request collaborator access to the [movement data repository](swc-gin:lochhh/movement-test-data) if you don't already have it.
+3. Install and configure the [GIN CLI](gin:G-Node/Info/wiki/GIN+CLI+Setup#quickstart) by running `gin login` in a terminal with your GIN credentials, pointing it at `https://gin.swc.ucl.ac.uk` as the server.
+4. Clone the `movement` data repository to your local machine using `gin get lochhh/movement-test-data`, then run `gin download --content` to download all the files.
 5. Add your new files to the appropriate folders (`poses`, `bboxes`, `videos`, and/or `frames`) following the existing file naming conventions.
 6. Add metadata for your new files to `metadata.yaml` using the [example entry below](target-metadata-yaml) as a template. You can leave all `sha256sum` values as `null` for now.
-7. Update file hashes in `metadata.yaml` by running `python update_hashes.py` from the root of the [movement data repository](gin:neuroinformatics/movement-test-data). This script computes SHA256 hashes for all data files and updates the corresponding `sha256sum` values in the metadata file. Make sure you're in a [Python environment with `movement` installed](#creating-a-development-environment).
+7. Update file hashes in `metadata.yaml` by running `python update_hashes.py` from the root of the [movement data repository](swc-gin:lochhh/movement-test-data). This script computes SHA256 hashes for all data files and updates the corresponding `sha256sum` values in the metadata file. Make sure you're in a [Python environment with `movement` installed](#creating-a-development-environment).
 8. Commit your changes using `gin commit -m <message> <filename>` for specific files or `gin commit -m <message> .` for all changes.
 9. Upload your committed changes to the GIN repository with `gin upload`. Use `gin download` to pull the latest changes or `gin sync` to synchronise changes bidirectionally.
 10. [Verify](target-verify-sample-data) the new files can be fetched and loaded correctly using the {mod}`movement.sample_data` module.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -271,6 +271,7 @@ myst_url_schemes = {
     "conda": "https://docs.conda.io/projects/conda/en/latest/{{path}}#{{fragment}}",
     "dlc": "https://mlabofai.org/deeplabcut/",
     "gin": "https://gin.g-node.org/{{path}}#{{fragment}}",
+    "swc-gin": "https://gin.swc.ucl.ac.uk/{{path}}#{{fragment}}",
     "github-docs": "https://docs.github.com/en/{{path}}#{{fragment}}",
     "myst-parser": "https://myst-parser.readthedocs.io/en/latest/{{path}}#{{fragment}}",
     "napari": "https://napari.org/stable/{{path}}",

--- a/examples/advanced/annotate_boris_events.py
+++ b/examples/advanced/annotate_boris_events.py
@@ -75,7 +75,7 @@ ds = sample_data.fetch_dataset(
 vid_name = "single-mouse_DBTravelator_video.avi"
 video_path = pooch.retrieve(
     url=(
-        f"https://gin.swc.ucl.ac.uk/lochhh/movement-test-data/raw"
+        f"https://gin.swc.ucl.ac.uk/neuroinformatics/movement-sample-data/raw"
         f"/master/videos/{vid_name}"
     ),
     known_hash=None,

--- a/examples/advanced/annotate_boris_events.py
+++ b/examples/advanced/annotate_boris_events.py
@@ -75,7 +75,7 @@ ds = sample_data.fetch_dataset(
 vid_name = "single-mouse_DBTravelator_video.avi"
 video_path = pooch.retrieve(
     url=(
-        f"https://gin.g-node.org/neuroinformatics/movement-test-data/raw"
+        f"https://gin.swc.ucl.ac.uk/lochhh/movement-test-data/raw"
         f"/master/videos/{vid_name}"
     ),
     known_hash=None,

--- a/movement/sample_data.py
+++ b/movement/sample_data.py
@@ -21,7 +21,7 @@ from movement.utils.logging import logger
 
 # URL to the remote data repository on GIN
 # noinspection PyInterpreter
-DATA_URL = "https://gin.swc.ucl.ac.uk/lochhh/movement-test-data/raw/master"
+DATA_URL = "https://gin.swc.ucl.ac.uk/neuroinformatics/movement-sample-data/raw/master"
 
 # Save data in ~/.movement/data
 DATA_DIR = Path("~", ".movement", "data").expanduser()

--- a/movement/sample_data.py
+++ b/movement/sample_data.py
@@ -21,9 +21,7 @@ from movement.utils.logging import logger
 
 # URL to the remote data repository on GIN
 # noinspection PyInterpreter
-DATA_URL = (
-    "https://gin.g-node.org/neuroinformatics/movement-test-data/raw/master"
-)
+DATA_URL = "https://gin.swc.ucl.ac.uk/lochhh/movement-test-data/raw/master"
 
 # Save data in ~/.movement/data
 DATA_DIR = Path("~", ".movement", "data").expanduser()


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
CI is often failing because movement sample datasets are currently hosted on [G-Node GIN](https://gin.g-node.org/neuroinformatics/movement-test-data), which is frequently down.
We have now migrated the data repository to [SWC GIN](https://gin.swc.ucl.ac.uk/neuroinformatics/movement-sample-data).

**What does this PR do?**
This PR replaces URLs pointing to movement's data repository on G-Node to SWC's instance.

## How has this PR been tested?
Tests retrieve the sample data from the data repository. If all tests pass, this indicates the data is fully migrated and available.

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
Docs mentioning the gnode data repository have been updated but the exact instructions to upload using the GIN CLI may not work now since CLI access is restricted within the institute's network.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
