### PR TITLE
Ignore all g-node subdomains during linkcheck

### DIFF
--- a/docs/source/community/contributing.md
+++ b/docs/source/community/contributing.md
@@ -971,7 +971,6 @@ If the linkcheck step incorrectly marks links with valid anchors as broken, you 
 # The linkcheck builder will skip verifying that anchors exist when checking
 # these URLs
 linkcheck_anchors_ignore_for_url = [
-    "https://gin.g-node.org/G-Node/Info/wiki/",
     "https://neuroinformatics.zulipchat.com/",
 ]
 ```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -219,7 +219,6 @@ linkcheck_retries = 3  # default is 1
 # The linkcheck builder will skip verifying that anchors exist when checking
 # these URLs (because they are generated dynamically)
 linkcheck_anchors_ignore_for_url = [
-    "https://gin.g-node.org/G-Node/Info/wiki/",
     "https://neuroinformatics.zulipchat.com/",
     "https://github.com/talmolab/sleap/blob/v1.3.3/sleap/info/write_tracking_h5.py",
 ]
@@ -239,7 +238,7 @@ linkcheck_ignore = [
     "https://www.iso.org/",
     "https://www.ffmpeg.org/",
     "https://gis.stackexchange.com/",
-    "https://www.g-node.org/",
+    "https?://([\w-]+\.)*g-node\.org(/\S*)?",
     "https://www.contributor-covenant.org/",
     "https://opensource.org/license/bsd-3-clause/",
     "https://www.sainsburywellcome.org/",


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Linkcheck fails because G-Node GIN is frequently unavailable. 

**What does this PR do?**
We already ignore g-node org website. This PR now additionally ignores gin.g-node and now generally ignores all subdomains of g-node.org during linkcheck. 

## How has this PR been tested?
linkcheck run locally and verified that g-node subdomains are ignored:

> 
> {"filename": "community\\contributing.md", "lineno": 1001, "status": "ignored", "code": 0, "uri": "https://gin.g-node.org/#", "info": ""}
> {"filename": "community\\contributing.md", "lineno": 1001, "status": "ignored", "code": 0, "uri": "https://www.g-node.org/", "info": ""}
> {"filename": "community\\contributing.md", "lineno": 1001, "status": "ignored", "code": 0, "uri": "https://gin.g-node.org/G-Node/Info/wiki/GIN+CLI+Setup#quickstart", "info": ""}
> 

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
