### PR TITLE
Restore sync-tracks functionality dropped during PR #1054 rebase

### DIFF
--- a/docs/source/user_guide/gui.md
+++ b/docs/source/user_guide/gui.md
@@ -284,13 +284,6 @@ change the colormap of a selected tracks layer.
 over the length of the tail and head tracks. However, we are
 working on a workaround, stay tuned!
 
-- You may occasionally see a warning message in the GUI upon loading a datafile, that says:
-  ```bash
-  UserWarning: Previous color_by key 'keypoint_factorized'
-  not present in features. Falling back to track_id!
-  ```
-  This is a known issue and can be safely ignored. It does not currently affect the functionality of the GUI.
-
 - Also note that currently the `show ID` checkbox in the [tracks layer](napari:howtos/layers/tracks.html) controls panel refers to
 an internal napari track ID, rather than the individual or the keypoint ID. This is a known issue and we are working on a fix or workaround.
 :::

--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -56,9 +56,6 @@ SUPPORTED_DATA_FILES = {
 }
 
 # Metadata keys stored on the movement Points layer.
-# Set in _add_points_layer/_add_tracks_layer (where the layers are created);
-# read in save_widget.py (where the layer is saved) and in
-# _on_points_data_changed (to keep the Tracks layer in sync).
 # - POINTS_LAYER_KEY marks the layer as movement-created.
 # - POINTS_PROPERTIES_KEY holds the full properties df, incl. the NaN rows
 #   dropped from the live layer, needed to reconstruct the dataset.
@@ -91,6 +88,17 @@ class DataLoader(QWidget):
                 self._update_frame_slider_range,
             )
         self._enable_layer_tooltips()
+
+        # Point drags are only guaranteed to stay within their own frame
+        # when frame is the sliced (non-displayed) axis in a 2D view. If
+        # axes are rolled or a 3D view is used, disable editing rather
+        # than risk a drag moving a point onto a different frame.
+        self.viewer.dims.events.order.connect(
+            self._update_points_layers_editable
+        )
+        self.viewer.dims.events.ndisplay.connect(
+            self._update_points_layers_editable
+        )
 
     def _create_source_software_widget(self):
         """Create a combo box for selecting the source software."""
@@ -375,12 +383,44 @@ class DataLoader(QWidget):
             **points_style.as_kwargs(),
         )
         self.points_layer.events.data.connect(self._on_points_data_changed)
+        self.points_layer.editable = self._frame_axis_is_sliced()
 
         # If the loaded dataset already has an `edited` property
         # mark those points with the edited symbol.
         self._set_point_symbol_by_edited(self.points_layer)
 
         logger.info("Added tracked dataset as a napari Points layer.")
+
+    def _frame_axis_is_sliced(self) -> bool:
+        """Whether frame is the sliced axis in a 2D view.
+
+        A point drag only ever touches the currently *displayed* axes
+        (see ``Points._move`` in napari). When frame is the sliced
+        axis, that means x/y -- everything is safe to edit. If axes
+        have been rolled so frame is displayed instead, or a 3D view
+        is active, a drag could move a point onto a different frame.
+        """
+        return (
+            self.viewer.dims.ndisplay == 2 and self.viewer.dims.order[0] == 0
+        )
+
+    def _update_points_layers_editable(self, event=None):
+        """Disable point editing while the frame axis isn't sliced.
+
+        Connected to ``viewer.dims.events.order``/``ndisplay``.
+        In the default view, the frame axis is the slider, so
+        dragging a point can only change its x/y position. Rolling
+        the axes or switching to 3D makes frame draggable too, which
+        would let a drag move a point to another frame. Disable
+        editing on every movement Points layer while that is the
+        case; napari greys out the select/add/delete controls.
+        """
+        frame_axis_is_sliced = self._frame_axis_is_sliced()
+        for layer in self.viewer.layers:
+            if isinstance(layer, Points) and layer.metadata.get(
+                POINTS_LAYER_KEY
+            ):
+                layer.editable = frame_axis_is_sliced
 
     @staticmethod
     def _set_point_symbol_by_edited(layer: Points) -> None:
@@ -393,34 +433,41 @@ class DataLoader(QWidget):
         layer.symbol = symbols
 
     def _on_points_data_changed(self, event):
-        """Set confidence to NaN and flag as edited for moved points.
+        """Keep the corresponding Tracks layer in sync with the Points layer.
 
-        Connected to ``points_layer.events.data``. Fires on
-        ``ActionType.CHANGED`` (i.e., when the data array values
-        change) and sets the confidence score of moved (dragged)
-        points to NaN, marks them as edited, and changes their
-        marker symbol to ``EDITED_POINT_SYMBOL`` so edited points are
-        visually distinguishable. The companion Tracks layer is then
-        updated to match via :meth:`_sync_tracks_layer`.
+        Connected to ``points_layer.events.data``. Handles two actions:
+
+        - ``ActionType.CHANGED`` (a point was dragged): sets the
+          confidence score of moved points to NaN, marks them as
+          edited, and changes their marker symbol to
+          ``EDITED_POINT_SYMBOL`` so edited points are visually
+          distinguishable. The Tracks layer row is updated in place
+          via `_sync_tracks_layer`.
+        - ``ActionType.REMOVED`` (one or more points were deleted):
+          removes the corresponding rows from
+          the Tracks layer via `_remove_from_tracks_layer`.
         """
         layer = event.source
         if not isinstance(layer, Points):
             return
-        if event.action != ActionType.CHANGED:
-            return
-        moved_indices = list(event.data_indices)
-        props = layer.properties
-        props["confidence"] = props["confidence"].copy()
-        props["confidence"][moved_indices] = float("nan")
-        if "edited" in props:
-            props["edited"] = props["edited"].copy()
-        else:
-            props["edited"] = np.full(len(props["confidence"]), False)
-        props["edited"][moved_indices] = True
-        layer.properties = props
-        self._set_point_symbol_by_edited(layer)
 
-        self._sync_tracks_layer(layer, moved_indices)
+        if event.action == ActionType.CHANGED:
+            moved_indices = list(event.data_indices)
+            props = layer.properties
+            props["confidence"] = props["confidence"].copy()
+            props["confidence"][moved_indices] = float("nan")
+            if "edited" in props:
+                props["edited"] = props["edited"].copy()
+            else:
+                props["edited"] = np.full(len(props["confidence"]), False)
+            props["edited"][moved_indices] = True
+            layer.properties = props
+            self._set_point_symbol_by_edited(layer)
+            self._sync_tracks_layer(layer, moved_indices)
+
+        elif event.action == ActionType.REMOVED:
+            removed_indices = list(event.data_indices)
+            self._remove_from_tracks_layer(layer, removed_indices)
 
     def _sync_tracks_layer(self, points_layer, moved_indices):
         """Update the corresponding Tracks layer to match an edited point.
@@ -433,17 +480,49 @@ class DataLoader(QWidget):
 
         # Points and Tracks layers are built from the same NaN-filtered
         # array in the same row order (see _add_points_layer/
-        # _add_tracks_layer). the Tracks layer only has an extra
+        # _add_tracks_layer). The Tracks layer only has an extra
         # leading track_id column.
         tracks_data = tracks_layer.data
         tracks_data[moved_indices, 1:] = points_layer.data[moved_indices]
 
-        # Setting `.data` on a napari Tracks layer resets its internal
-        # features to empty, which transiently invalidates `color_by`
-        # (napari warns and falls back to "track_id") even though we
-        # restore the same properties and colour-by property right
-        # after. Suppress that spurious warning around the sequence.
-        tracks_properties = tracks_layer.properties
+        self._set_tracks_layer_data(
+            tracks_layer, tracks_data, tracks_layer.properties
+        )
+
+    def _remove_from_tracks_layer(self, points_layer, removed_indices):
+        """Remove the rows corresponding to deleted points.
+
+        Users edit the Points layer directly, either dragging points
+        or removing inaccurate predictions. The Tracks layer has no
+        interactive editing of its own, so it must be kept in sync
+        with the Points layer instead.
+
+        ``removed_indices`` are indices in the Points layer which line
+        up with rows in the Tracks layer, the same way
+        :meth:`_sync_tracks_layer` relies on for edits.
+        """
+        tracks_layer = points_layer.metadata[TRACKS_LAYER_KEY]
+
+        tracks_data = np.delete(tracks_layer.data, removed_indices, axis=0)
+        tracks_properties = {
+            key: np.delete(np.asarray(values), removed_indices, axis=0)
+            for key, values in tracks_layer.properties.items()
+        }
+
+        self._set_tracks_layer_data(
+            tracks_layer, tracks_data, tracks_properties
+        )
+
+    @staticmethod
+    def _set_tracks_layer_data(tracks_layer, data, properties):
+        """Set a Tracks layer's data and properties, preserving color_by.
+
+        Setting ``.data`` on a napari Tracks layer resets its internal
+        features to empty, which transiently invalidates ``color_by``
+        (napari warns and falls back to "track_id") even though we
+        restore the same properties and colour-by property right
+        after. Suppress that spurious warning around the sequence.
+        """
         color_by = tracks_layer.color_by
         with warnings.catch_warnings():
             warnings.filterwarnings(
@@ -451,8 +530,8 @@ class DataLoader(QWidget):
                 message=".*Previous color_by key.*",
                 category=UserWarning,
             )
-            tracks_layer.data = tracks_data
-            tracks_layer.properties = tracks_properties
+            tracks_layer.data = data
+            tracks_layer.properties = properties
             tracks_layer.color_by = color_by
 
     def _add_tracks_layer(self):

--- a/tests/fixtures/napari.py
+++ b/tests/fixtures/napari.py
@@ -227,6 +227,32 @@ def move_point():
 
 
 @pytest.fixture
+def remove_point():
+    """Return a factory that simulates a user deleting a single point
+    from a loaded ``DataLoader``'s Points layer.
+
+    Looks up the point by its ``frame``/``keypoint``/``individual``
+    (rather than a raw row index), so callers don't need to reason
+    about how NaN-filtering or earlier edits may have shifted row
+    positions. Returns the row index that was removed.
+    """
+
+    def _remove_point(loader, frame, keypoint, individual):
+        live_props = loader.points_layer.properties
+        edit_idx = int(
+            np.flatnonzero(
+                (live_props["time"] == frame)
+                & (live_props["keypoint"] == keypoint)
+                & (live_props["individual"] == individual)
+            )[0]
+        )
+        loader.points_layer.remove([edit_idx])
+        return edit_idx
+
+    return _remove_point
+
+
+@pytest.fixture
 def loaded_data_loader(make_napari_viewer_proxy):
     """Return a factory of DataLoader widgets with loaded data."""
 

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -39,10 +39,6 @@ from movement.napari.loader_widgets import (
     DataLoader,
 )
 
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:.*Previous color_by key.*:UserWarning"
-)
-
 
 # ------------------- tests for widget instantiation--------------------------#
 def test_data_loader_widget_instantiation(make_napari_viewer_proxy):
@@ -1002,21 +998,22 @@ def test_on_points_data_changed_ignores_tracks_layer(
     "action_type",
     [
         ActionType.ADDED,
-        ActionType.REMOVED,
         ActionType.ADDING,
         ActionType.REMOVING,
         ActionType.CHANGING,
     ],
 )
-def test_on_points_data_changed_ignores_non_move_events(
+def test_on_points_data_changed_ignores_unhandled_action_types(
     action_type, valid_poses_path_and_ds, loaded_data_loader
 ):
-    """Test that the callback leaves confidence untouched for non-drag events.
+    """Test that the callback leaves confidence untouched for other events.
 
-    Verifies that :meth:`DataLoader._on_points_data_changed` only acts on
-    ``ActionType.CHANGED`` (completed drag) and ignores all other action types,
-    including ``ADDING``, ``ADDED``, ``REMOVING``, ``REMOVED``, and
-    ``CHANGING`` (in-progress drag).
+    Verifies that :meth:`DataLoader._on_points_data_changed` leaves
+    ``confidence`` untouched for action types it does not act on:
+    ``ADDING``, ``ADDED``, ``REMOVING``, and ``CHANGING``
+    (in-progress drag). The two action types it does handle,
+    ``ActionType.CHANGED`` (completed drag) and ``ActionType.REMOVED``
+    (completed removal), are covered elsewhere.
     """
     filepath, ds_loaded = valid_poses_path_and_ds
     loader = loaded_data_loader(filepath, ds_loaded)
@@ -1060,7 +1057,6 @@ def test_on_points_data_changed_syncs_tracks_layer(
     )
 
     # `edited` flags exactly the dragged row; use it to partition rows
-    # instead of assuming which index is "the previous frame".
     edited = loader.points_layer.properties["edited"]
     moved_index = int(np.flatnonzero(edited)[0])
     new_position = loader.points_layer.data[moved_index]
@@ -1073,6 +1069,161 @@ def test_on_points_data_changed_syncs_tracks_layer(
     np.testing.assert_array_equal(
         loader.tracks_layer.data[~edited], original_tracks_data[~edited]
     )
+
+
+def test_on_points_data_changed_preserves_tracks_color_by(
+    valid_poses_path_and_ds, loaded_data_loader, move_point
+):
+    """Test that dragging a point leaves the Tracks layer's colouring intact.
+
+    Regression test for GH issue #573: setting ``Tracks.data`` resets
+    the layer's features to empty, which transiently invalidates
+    ``color_by`` and triggers a spurious "Previous color_by key ...
+    not present in features" warning. ``DataLoader._set_tracks_layer_data``
+    restores ``color_by`` and the ``*_factorized`` property right after,
+    so both should be unchanged once a drag completes.
+    """
+    filepath, ds = valid_poses_path_and_ds
+    loader = loaded_data_loader(filepath, ds)
+
+    color_by = loader.tracks_layer.color_by
+    original_factorized = loader.tracks_layer.properties[color_by].copy()
+
+    move_point(
+        loader,
+        frame=5,
+        keypoint="centroid",
+        individual="id_0",
+        new_y=100,
+        new_x=200,
+    )
+
+    assert loader.tracks_layer.color_by == color_by
+    np.testing.assert_array_equal(
+        loader.tracks_layer.properties[color_by], original_factorized
+    )
+
+
+def test_on_points_data_removes_tracks_layer_row(
+    valid_poses_path_and_ds, loaded_data_loader, remove_point
+):
+    """Test that deleting a point removes the matching row from Tracks.
+
+    Verifies that `DataLoader._on_points_data_changed` reacts to
+    the real ``ActionType.REMOVED`` event fired by napari's own
+    ``Points.remove`` by dropping the same row from the companion
+    Tracks layer, leaving every other row untouched.
+    """
+    filepath, ds = valid_poses_path_and_ds
+    loader = loaded_data_loader(filepath, ds)
+
+    original_tracks = loader.tracks_layer.data.copy()
+
+    edit_idx = remove_point(
+        loader, frame=5, keypoint="centroid", individual="id_0"
+    )
+    assert len(loader.tracks_layer.data) == len(original_tracks) - 1
+
+    # Rows before the deleted one are untouched; rows after it have
+    # shifted up by one position, as ``np.delete`` does.
+    np.testing.assert_array_equal(
+        loader.tracks_layer.data[:edit_idx],
+        original_tracks[:edit_idx],
+    )  # is everything before the deleted row identical?
+    np.testing.assert_array_equal(
+        loader.tracks_layer.data[edit_idx:],
+        original_tracks[edit_idx + 1 :],
+    )  # did everything survive after the deleted row and shifted
+    # down by exactly one index to fill the gap?
+
+
+@pytest.mark.parametrize(
+    "sequence", ["drag_delete_drag", "delete_drag_delete"]
+)
+def test_on_points_data_changed_consecutive_edits(
+    valid_poses_path_and_ds,
+    loaded_data_loader,
+    move_point,
+    remove_point,
+    sequence,
+):
+    """Test that interleaved drags and deletes keep tracks layer in sync.
+
+    Regression test for the Points and Tracks layers falling out of
+    sync after a mix of edit types in the same session. Each sequence
+    touches three distinct points, so row-index shifts caused by an
+    earlier deletion don't affect later lookups (both fixtures look
+    points up by frame/keypoint/individual, not raw row index).
+    """
+    filepath, ds = valid_poses_path_and_ds
+    loader = loaded_data_loader(filepath, ds)
+    n_original = len(loader.tracks_layer.data)
+
+    point_a = {"frame": 1, "keypoint": "centroid", "individual": "id_0"}
+    point_b = {"frame": 4, "keypoint": "left", "individual": "id_1"}
+    point_c = {"frame": 7, "keypoint": "right", "individual": "id_0"}
+
+    if sequence == "drag_delete_drag":
+        move_point(loader, **point_a, new_y=111, new_x=222)
+        remove_point(loader, **point_b)
+        move_point(loader, **point_c, new_y=333, new_x=444)
+        last_moved, new_y, new_x = point_c, 333, 444
+        n_expected = n_original - 1
+    else:
+        remove_point(loader, **point_a)
+        move_point(loader, **point_b, new_y=111, new_x=222)
+        remove_point(loader, **point_c)
+        last_moved, new_y, new_x = point_b, 111, 222
+        n_expected = n_original - 2
+
+    assert len(loader.points_layer.data) == n_expected
+    assert len(loader.tracks_layer.data) == n_expected
+
+    live_props = loader.points_layer.properties
+    idx = int(
+        np.flatnonzero(
+            (live_props["time"] == last_moved["frame"])
+            & (live_props["keypoint"] == last_moved["keypoint"])
+            & (live_props["individual"] == last_moved["individual"])
+        )[0]
+    )
+    np.testing.assert_array_equal(
+        loader.tracks_layer.data[idx, 1:],
+        [last_moved["frame"], new_y, new_x],
+    )
+
+
+def test_update_points_layers_editable_toggles_with_axis_order(
+    valid_poses_path_and_ds, loaded_data_loader
+):
+    """Test that ``editable`` follows whether frame is the sliced axis.
+
+    Rolling the displayed axes, or switching to a 3D view, means a
+    point drag could touch a different frame (see
+    ``DataLoader._frame_axis_is_sliced``), so the Points layer should
+    become non-editable; restoring the default order/2D view should
+    make it editable again.
+    """
+    filepath, ds = valid_poses_path_and_ds
+    loader = loaded_data_loader(filepath, ds)
+
+    assert loader.points_layer.editable
+
+    # Roll the axes so frame is no longer the sliced axis.
+    loader.viewer.dims.order = (1, 0, 2)
+    assert not loader.points_layer.editable
+
+    # Restore the default order.
+    loader.viewer.dims.order = (0, 1, 2)
+    assert loader.points_layer.editable
+
+    # Switch to a 3D view.
+    loader.viewer.dims.ndisplay = 3
+    assert not loader.points_layer.editable
+
+    # Back to the default 2D view.
+    loader.viewer.dims.ndisplay = 2
+    assert loader.points_layer.editable
 
 
 def test_on_points_data_changed_second_drag_extends_edited(


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

#1054 went through a rebase before merging, and it looks like the rebase went wrong: a chunk of follow-up commits never made it into the version that got merged into `main`. This was noticed by @anna-teruel (thanks for catching this!) when she was working on #1063, which depends on the missing functionality.

I dug through the reflog of my local remote-tracking branch and (I *think*) I managed to recover the pre-rebase state (preserved on `sync-tracks-recovered`, in case we ever need to double check anything). Comparing that to what's on `main` confirms two bits of functionality are missing.

**What does this PR do?**

Restores the missing functionality from #1054:

- Syncs point deletions from the points layer to the tracks layer (previously only additions/edits were synced).
- Disables point editing when the viewer axes are not in their default order (editing with reordered axes was producing incorrect results).

Also brings back the associated tests, a new napari test fixture, and a small docs tidy-up in the GUI user guide that got dropped along with the rest.

## References

Follow-up to #1054.

## How has this PR been tested?

Applied the recovered diff on top of current `main` (see `sync-tracks-recovered` for the full pre-rebase history) and ran the full napari plugin test suite locally; all tests pass, `loader_widgets.py` back to 100% coverage. I also ran pre-commit on the changed files.

@anna-teruel could you double check nothing here was intentionally dropped rather than lost in the rebase?
It would also be prudent to test the GUI as a user, to make sure all expected behaviours actually happen.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

Restores a small deletion in `docs/source/user_guide/gui.md` that was part of the original PR.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)