### PR TITLE
Fix redirected UCL ARC URLs

### DIFF
--- a/docs/source/community/people.md
+++ b/docs/source/community/people.md
@@ -14,7 +14,7 @@ The current active core development team is composed of:
 We are eager to explore collaboration opportunities with research labs and research software engineering teams.
 Our current and past collaborators include:
 - [Keshavarzi Laboratory](https://www.keshavarzilab.com/) at the University of Cambridge
-- [UCL Advanced Research Computing Centre](https://www.ucl.ac.uk/advanced-research-computing/advanced-research-computing-centre)
+- [UCL Advanced Research Computing Centre](https://www.ucl.ac.uk/research-innovation/advanced-research-computing)
 
 (target-contributors)=
 ## Contributors

--- a/docs/source/community/resources.md
+++ b/docs/source/community/resources.md
@@ -86,7 +86,7 @@ A selection of talks, posters, and blogposts about `movement`.
 | Talk  | [TheBehaviourForum](https://www.thebehaviourforum.org) Virtual Workshop | Apr 2026 | [Video on YouTube](https://www.youtube.com/watch?v=RUDhXB1ZZIg) |
 | Talk  | [FOSDEM 2026](https://fosdem.org/2026/schedule/) | Jan 2026 | [Video on fosdem.org](https://fosdem.org/2026/schedule/event/9VLSXV-movement-tracks-python/) |
 | Talk  | [CBIAS 2025](https://www.crick.ac.uk/whats-on/crick-bioimage-analysis-symposium-2025) | Nov 2025 | [Slides](https://neuroinformatics.dev/slides-movement-cbias2025/) |
-| Blogpost  | [UCL-ARC Showcase](https://www.ucl.ac.uk/advanced-research-computing/arc-showcase) | May 2025 | [URL](https://www.ucl.ac.uk/advanced-research-computing/case-studies/2025/may/movement-python-package-simplifies-analysis-animals-motion) |
+| Blogpost  | [UCL-ARC Showcase](https://www.ucl.ac.uk/research-innovation/advanced-research-computing/arc-showcase) | May 2025 | [URL](https://www.ucl.ac.uk/advanced-research-computing/case-studies/2025/may/movement-python-package-simplifies-analysis-animals-motion) |
 | Talk  | [ABIDE](https://abide.ics.ulisboa.pt/en/) Seminar | Feb 2025 | [Video on YouTube](https://www.youtube.com/watch?v=GXBQsqqZZTg) |
 
 

--- a/docs/source/community/resources.md
+++ b/docs/source/community/resources.md
@@ -86,7 +86,7 @@ A selection of talks, posters, and blogposts about `movement`.
 | Talk  | [TheBehaviourForum](https://www.thebehaviourforum.org) Virtual Workshop | Apr 2026 | [Video on YouTube](https://www.youtube.com/watch?v=RUDhXB1ZZIg) |
 | Talk  | [FOSDEM 2026](https://fosdem.org/2026/schedule/) | Jan 2026 | [Video on fosdem.org](https://fosdem.org/2026/schedule/event/9VLSXV-movement-tracks-python/) |
 | Talk  | [CBIAS 2025](https://www.crick.ac.uk/whats-on/crick-bioimage-analysis-symposium-2025) | Nov 2025 | [Slides](https://neuroinformatics.dev/slides-movement-cbias2025/) |
-| Blogpost  | [UCL-ARC Showcase](https://www.ucl.ac.uk/research-innovation/advanced-research-computing/arc-showcase) | May 2025 | [URL](https://www.ucl.ac.uk/advanced-research-computing/case-studies/2025/may/movement-python-package-simplifies-analysis-animals-motion) |
+| Blogpost  | [UCL-ARC Life Sciences Collaborations](https://www.ucl.ac.uk/research-innovation/advanced-research-computing/collaborations-and-consultancy/life-sciences-collaborations) | May 2025 | [Blogpost](https://www.ucl.ac.uk/research-innovation/case-studies/2025/may/movement-python-package-simplifies-analysis-animals-motion) |
 | Talk  | [ABIDE](https://abide.ics.ulisboa.pt/en/) Seminar | Feb 2025 | [Video on YouTube](https://www.youtube.com/watch?v=GXBQsqqZZTg) |
 
 

--- a/examples/advanced/broadcasting_your_own_methods.py
+++ b/examples/advanced/broadcasting_your_own_methods.py
@@ -12,7 +12,7 @@ to efficiently apply functions across any data dimension.
 #   This example was originally contributed by `Will Graham
 #   <https://github.com/willGraham01>`_, as part of a collaboration between the
 #   `UCL Advanced Research Computing Centre
-#   <https://www.ucl.ac.uk/advanced-research-computing>`_
+#   <https://www.ucl.ac.uk/research-innovation/advanced-research-computing>`_
 #   and the `Keshavarzi Laboratory <https://www.keshavarzilab.com/>`_ at the
 #   University of Cambridge.
 

--- a/examples/boundary_angles.py
+++ b/examples/boundary_angles.py
@@ -12,7 +12,7 @@ boundary angles relative to regions of interest (RoIs).
 #   This example was originally contributed by `Will Graham
 #   <https://github.com/willGraham01>`_, as part of a collaboration between the
 #   `UCL Advanced Research Computing Centre
-#   <https://www.ucl.ac.uk/advanced-research-computing>`_
+#   <https://www.ucl.ac.uk/research-innovation/advanced-research-computing>`_
 #   and the `Keshavarzi Laboratory <https://www.keshavarzilab.com/>`_ at the
 #   University of Cambridge.
 

--- a/examples/mouse_eye_movements.py
+++ b/examples/mouse_eye_movements.py
@@ -11,7 +11,7 @@ Look at eye movements and pupil diameter.
 #   This example was originally contributed by `Stella Prins
 #   <https://github.com/stellaprins>`_, as part of a collaboration between the
 #   `UCL Advanced Research Computing Centre
-#   <https://www.ucl.ac.uk/advanced-research-computing>`_
+#   <https://www.ucl.ac.uk/research-innovation/advanced-research-computing>`_
 #   and the `Keshavarzi Laboratory <https://www.keshavarzilab.com/>`_ at the
 #   University of Cambridge.
 


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Build docs workflow is failing on CI because ARC pages have been permanently redirected/are broken (linkcheck fails). 

**What does this PR do?**
- closes #1084 
- Updates redirected ARC URLs
- ~Temporarily adds ARC case studies URL to linkcheck ignore ❓❓what should we actually do about the broken page? Remove it completely from the table?~

## References
#1084 

## How has this PR been tested?
linkcheck run locally and on CI

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
