### PR TITLE
Update FOSDEM links to archive version

### DIFF
--- a/docs/source/community/resources.md
+++ b/docs/source/community/resources.md
@@ -84,7 +84,7 @@ A selection of talks, posters, and blogposts about `movement`.
 |-------|-------|------|------|
 | Poster  | Multiple conferences | Apr 2025 onwards | [PDFs on Zenodo](https://doi.org/10.5281/zenodo.17924159) |
 | Talk  | [TheBehaviourForum](https://www.thebehaviourforum.org) Virtual Workshop | Apr 2026 | [Video on YouTube](https://www.youtube.com/watch?v=RUDhXB1ZZIg) |
-| Talk  | [FOSDEM 2026](https://fosdem.org/2026/schedule/) | Jan 2026 | [Video on fosdem.org](https://fosdem.org/2026/schedule/event/9VLSXV-movement-tracks-python/) |
+| Talk  | [FOSDEM 2026](https://archive.fosdem.org/2026/schedule/) | Jan 2026 | [Video on fosdem.org](https://archive.fosdem.org/2026/schedule/event/9VLSXV-movement-tracks-python/) |
 | Talk  | [CBIAS 2025](https://www.crick.ac.uk/whats-on/crick-bioimage-analysis-symposium-2025) | Nov 2025 | [Slides](https://neuroinformatics.dev/slides-movement-cbias2025/) |
 | Blogpost  | [UCL-ARC Life Sciences Collaborations](https://www.ucl.ac.uk/research-innovation/advanced-research-computing/collaborations-and-consultancy/life-sciences-collaborations) | May 2025 | [Blogpost](https://www.ucl.ac.uk/research-innovation/case-studies/2025/may/movement-python-package-simplifies-analysis-animals-motion) |
 | Talk  | [ABIDE](https://abide.ics.ulisboa.pt/en/) Seminar | Feb 2025 | [Video on YouTube](https://www.youtube.com/watch?v=GXBQsqqZZTg) |


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

We are getting the following failures from linkcheck in CI:

```bash
  /home/runner/work/movement/movement/docs/source/community/resources.md:87: WARNING: redirect  https://fosdem.org/2026/schedule/ - permanently to https://archive.fosdem.org/2026/schedule/
  /home/runner/work/movement/movement/docs/source/community/resources.md:87: WARNING: redirect  https://fosdem.org/2026/schedule/event/9VLSXV-movement-tracks-python/ - permanently to https://archive.fosdem.org/2026/schedule/event/9VLSXV-movement-tracks-python/
```

**What does this PR do?**

Updates the 2 links to their new, permanently redirected locations.

## References

CI failures first noticed in #1063 and #1086.

## How has this PR been tested?

Locally ran linkcheck.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

N/A

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
