### PR TITLE
Set napari axis labels

### DIFF
--- a/movement/napari/loader_widgets.py
+++ b/movement/napari/loader_widgets.py
@@ -342,7 +342,12 @@ class DataLoader(QWidget):
         self.text_property = text_property
 
     def _set_initial_state(self):
-        """Set slider at first frame and last points layer as active."""
+        """Set axis labels, slider position and last points layer as active."""
+        # Label the axes of our layers' data as "t", "y", "x"
+        self.viewer.dims.set_axis_label(
+            axis=(-3, -2, -1), label=("t", "y", "x")
+        )
+
         # Set slider to first frame so that first view is not cluttered
         # with tracks
         default_current_step = self.viewer.dims.current_step

--- a/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
+++ b/tests/test_unit/test_napari_plugin/test_data_loader_widget.py
@@ -381,6 +381,9 @@ def test_on_load_clicked_with_valid_file_path(
     # Check the frame slider is set to the first frame
     assert viewer.dims.current_step[0] == 0
 
+    # Check the axes are labelled t, y, x
+    assert viewer.dims.axis_labels[-3:] == ("t", "y", "x")
+
     # Check that the expected log messages were emitted
     expected_log_messages = {
         "Converted dataset to a napari Tracks array.",


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

The axis labels of the `napari` viewer are auto-assigned as negative numbers (-3, -2, -1) (see the [napari 0.7.0 release notes](https://github.com/napari/napari/releases/tag/v0.7.0) for the 'why'). It is mildly confusing for us to see a `-3` to the left of our frame slider (see screenshots in our [GUI guide](https://movement.neuroinformatics.dev/latest/user_guide/gui.html)).

The [napari 0.9.0 release notes](https://github.com/napari/napari/releases/tag/v0.9.0) release notes reminded me that we can set those axis labels to anythin we want (a feature that has been present since 0.6.0 actually). So we can set them to meaninful for us values.

**What does this PR do?**

Adds the following snippet to the `_set_initial_state` method of the `DataLoader` widget:

```python
self.viewer.dims.set_axis_label(axis=(-3, -2, -1), label=("t", "y", "x"))
```

This does the trick.

Some notes:
- We don't want these axis labels to take effect when a video/frame is drag-n-dropped, but specifically when tracked data is loaded.
- The exact place where `set_axis_label` is called may be moved, depending on the outcome of #1090.
- The labels assume 2D tracking data (x,y), which is fine for now since our plugin doesn't yet support 3D tracking data (x,y,z).

The screenshot below was taken with 'View > Floating Axes > Floating Axes Visible" enabled, to also show the y,x. The `t` in the slide bar is always shown. The labels change correctly when axes are rolled.

<img width="1319" height="883" alt="napari_tracks_2D" src="https://github.com/user-attachments/assets/44e1974d-2729-426b-8246-fa4d5415865e" />

The "Floating Axes" also help with interpreting what we see when the 3D view is toggled.
 
<img width="1319" height="883" alt="napari_tracks_3D" src="https://github.com/user-attachments/assets/35150bb6-af77-4fb1-b766-d15ef8787e30" />

## References

Will wait for #1063 and #1090 before I finalise this and mark it as ready to review.

## How has this PR been tested?

I modify an existing test to check that the axis labels are set after widget instantiation.
We don't really have to check the precise funcitonality of this features, since it's napari-native.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

Not strictly required. But would be nice to make the following changes to the GUI user guide:
- [ ] Update screenshot to contain the correct axis labels
- [ ] Mention the option to display floating axes, and to change their labels?
- [ ] Mention rolling axes and 3D view, but caution against doing these when a video is loaded.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
