### PR TITLE
Fix broken setuptools-scm links

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -274,7 +274,7 @@ myst_url_schemes = {
     "github-docs": "https://docs.github.com/en/{{path}}#{{fragment}}",
     "myst-parser": "https://myst-parser.readthedocs.io/en/latest/{{path}}#{{fragment}}",
     "napari": "https://napari.org/stable/{{path}}",
-    "setuptools-scm": "https://setuptools-scm.readthedocs.io/en/latest/{{path}}#{{fragment}}",
+    "setuptools-scm": "https://setuptools-scm.readthedocs.io/latest/{{path}}#{{fragment}}",
     "sleap": "https://sleap.ai/{{path}}#{{fragment}}",
     "sleap-docs": "https://docs.sleap.ai/latest/{{path}}#{{fragment}}",
     "sphinx-doc": "https://www.sphinx-doc.org/en/master/usage/{{path}}#{{fragment}}",


### PR DESCRIPTION
## Description

`make linkcheck` (and the docs CI) flags two broken links in the contributing guide:

- `https://setuptools-scm.readthedocs.io/en/latest/#` → 404
- `https://setuptools-scm.readthedocs.io/en/latest/usage#default-versioning-scheme` → 404

setuptools-scm's Read the Docs site dropped the `/en` language prefix, so the `setuptools-scm` extlink template in `docs/source/conf.py` now points at a 404.

## What this PR does

Drops `/en` from the `setuptools-scm` extlink template. Both links then resolve:

- `https://setuptools-scm.readthedocs.io/latest/` → 200
- `https://setuptools-scm.readthedocs.io/latest/usage#default-versioning-scheme` → 302 → `/latest/usage/` (200, anchor present)

Verified the status codes with `curl`. One-line change; no source markdown edits needed since both usages go through the shared template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)