### PR TITLE
Implement 2D and 3D egocentric alignment classes with associated tests

### DIFF
--- a/movement/transforms.py
+++ b/movement/transforms.py
@@ -1,13 +1,17 @@
 """Compute and apply spatial transforms."""
 
 import itertools
+from functools import partial
+from typing import cast
 
 import cv2
 import numpy as np
 import xarray as xr
 from numpy.typing import ArrayLike
+from scipy.spatial.transform import Rotation
 
-from movement.utils.logging import log_to_attrs
+from movement.utils.logging import log_to_attrs, logger
+from movement.utils.vector import compute_signed_angle_2d
 from movement.validators.arrays import validate_dims_coords
 
 
@@ -255,7 +259,7 @@ def compute_homography_transform(
     This function estimates a 3x3 homography matrix using corresponding 2D
     point pairs from two images or planes. A homography describes a
     projective transformation suitable for **planar scenes** where
-    perspective effects are present — e.g., when the camera is tilted,
+    perspective effects are present - e.g., when the camera is tilted,
     moved closer, or rotated relative to the plane.
 
     The transformation preserves straight lines but not
@@ -384,3 +388,414 @@ def _is_collinear_set(points: np.ndarray, eps):
     _, s, _ = np.linalg.svd(pts)
     rank = np.sum(s > eps)
     return rank < 2
+
+
+def _rotation_matrix_2d_from_angle(
+    angle: xr.DataArray, space_coord
+) -> xr.DataArray:
+    """Build 2D rotation matrices with dims (..., space_rot, space).
+
+    `space_rot` indexes rows, `space` indexes columns
+    """
+    c = cast("xr.DataArray", np.cos(angle))
+    s = cast("xr.DataArray", np.sin(angle))
+
+    row_x = xr.concat([c, -s], dim="space").assign_coords(space=space_coord)
+    row_y = xr.concat([s, c], dim="space").assign_coords(space=space_coord)
+
+    return xr.concat([row_x, row_y], dim="space_rot").assign_coords(
+        space_rot=space_coord
+    )
+
+
+class EgocentricAligner2d:
+    """Align 2D pose tracks to an egocentric coordinate system.
+
+    For each frame and individual, computes a centroid (the origin of the
+    egocentric coordinate system) and a rotation angle (derived from the
+    heading of ``keypoint_to_align`` relative to the new origin). That
+    maps the input world coordinates onto a ego-centerically aligned
+    coordinates such that its heading points along ``align_to_vector``.
+
+    The fitted transform can be applied to position data via :meth:`align`,
+    and inverted via :meth:`inverse_align`.
+
+    Parameters
+    ----------
+    keypoint_to_align : str
+        Keypoint whose position (relative to the centroid) defines the
+        heading direction used to compute the rotation angle.
+    keypoint_to_center : str or None
+        Keypoint used to define the egocentric origin at each frame. If
+        ``None``, the centroid is the mean position over all keypoints.
+    align_to_vector : tuple of int, default (1, 0)
+        The 2D vector that ``keypoint_to_align``'s heading is rotated to
+        align with, expressed in (x, y) order. Defaults to the positive
+        x-axis.
+
+    Attributes
+    ----------
+    centroid_ : xarray.DataArray or None
+        The fitted per-frame, per-individual centroid position. Set by
+        :meth:`fit`; ``None`` before fitting.
+    rotation_ : xarray.DataArray or None
+        The fitted per-frame, per-individual 2D rotation matrices, with
+        dims ``(..., space_rot, space)`` where ``space`` is the axis
+        contracted over when applying the rotation. Set by :meth:`fit`;
+        ``None`` before fitting.
+
+    Notes
+    -----
+    This class borrows its ``fit``/``align``/``inverse_align`` structure from
+    the scikit-learn transformer convention (``fit``/``transform``/
+    ``inverse_transform``), even though ``fit`` is typically called on the
+    same data subsequently passed to ``align`` rather than on a separate
+    training set. Keeping the estimated transform as fitted state
+    (:attr:`centroid_`, :attr:`rotation_`) rather than returning it directly
+    means the same fitted transform can be reused later - e.g. applied to a
+    different set of keypoints than the ones used to estimate it.
+
+    """
+
+    def __init__(
+        self,
+        keypoint_to_align: str,
+        keypoint_to_center: str | None,
+        align_to_vector: tuple[float, float] = (1, 0),
+    ):
+        """Create a new instance."""
+        self.keypoint_to_align = keypoint_to_align
+        self.keypoint_to_center = keypoint_to_center
+        self.align_to_vector = np.asarray(align_to_vector)
+
+        self.centroid_: xr.DataArray | None = None
+        self.rotation_: xr.DataArray | None = (
+            None  # dims: (..., space, space_rot)
+        )
+
+    def fit(self, position: xr.DataArray) -> "EgocentricAligner2d":
+        """Compute the egocentric centroid and rotation matrix for each frame.
+
+        Parameters
+        ----------
+        position : xarray.DataArray
+            Position data with dims including ``space`` (with coordinates
+            ``"x"`` and ``"y"``) and ``keypoint``.
+
+        Returns
+        -------
+        EgocentricAligner2d
+            self, with :attr:`centroid_` and :attr:`rotation_` populated.
+
+        Raises
+        ------
+        ValueError
+            If ``ds`` is missing the expected ``space`` coordinates or
+            ``keypoint_to_align`` is not among ``ds``'s keypoints.
+
+        """
+        validate_dims_coords(position, {"space": ["x", "y"]})
+        validate_dims_coords(position, {"keypoint": [self.keypoint_to_align]})
+
+        if self.keypoint_to_center is None:
+            self.centroid_ = position.mean(dim="keypoint")
+        else:
+            self.centroid_ = position.sel(keypoint=self.keypoint_to_center)
+
+        centered = position - self.centroid_
+
+        angles = compute_signed_angle_2d(
+            centered.sel(keypoint=self.keypoint_to_align), self.align_to_vector
+        )
+
+        self.rotation_ = _rotation_matrix_2d_from_angle(
+            angles, position.coords["space"].values
+        )
+        return self
+
+    def _check_is_fitted(self):
+        if self.rotation_ is None or self.centroid_ is None:
+            raise RuntimeError(
+                "Call `.fit(position)` before using the aligner."
+            )
+
+    def align(self, position: xr.DataArray) -> xr.DataArray:
+        """Transform position data from world to egocentric coordinates.
+
+        Parameters
+        ----------
+        position : xarray.DataArray
+            Position data with a ``space`` dimension, sharing the
+            coordinates system with the data used in :meth:`fit`.
+
+        Returns
+        -------
+        xarray.DataArray
+            ``position`` re-centred on the fitted centroid and rotated so
+            that ``keypoint_to_align``'s heading points along
+            ``align_to_vector``. Same dims/shape as the input.
+
+        Raises
+        ------
+        RuntimeError
+            If called before :meth:`fit`.
+
+        """
+        self._check_is_fitted()
+        assert self.centroid_ is not None
+        assert self.rotation_ is not None
+
+        # Center
+        centered = position - self.centroid_
+
+        # Apply rotation
+        rotated = xr.dot(self.rotation_, centered, dim="space")
+
+        # Clean-up and transpose to original order
+        aligned = rotated.rename(space_rot="space").transpose(*position.dims)
+
+        return aligned
+
+    def inverse_align(self, position: xr.DataArray) -> xr.DataArray:
+        """Transform position data from egocentric back to world coordinates.
+
+        Applies the inverse of :meth:`align` - the transpose of the fitted
+        rotation followed by adding back the fitted centroid.
+
+        Parameters
+        ----------
+        position : xarray.DataArray
+            Position data in the egocentric frame produced by :meth:`align`.
+
+        Returns
+        -------
+        xarray.DataArray
+            ``position`` mapped back into world coordinates. Same dims/
+            shape as the input.
+
+        Raises
+        ------
+        RuntimeError
+            If called before :meth:`fit`.
+
+        """
+        self._check_is_fitted()
+        assert self.centroid_ is not None
+        assert self.rotation_ is not None
+
+        # Create inverse rotation by transposing the rotation matrices
+        rot_T = self.rotation_.rename(space="space_tmp").rename(
+            space_rot="space", space_tmp="space_rot"
+        )
+
+        # Apply inverse rotation
+        rotated = xr.dot(rot_T, position, dim="space")
+
+        # Clean-up and transpose to original order
+        rotated = rotated.rename(space_rot="space").transpose(*position.dims)
+
+        # Undo centering
+        inverse_aligned = rotated + self.centroid_
+
+        return inverse_aligned
+
+
+class EgocentricAligner3d:
+    """Align 3D pose tracks to an egocentric coordinate system.
+
+    Unlike :class:`EgocentricAligner2d`, which derives a single heading
+    angle from one keypoint, this aligner estimates a full 3D rotation by
+    solving Wahba's problem (via :meth:`scipy.spatial.transform.Rotation.
+    align_vectors`): given the centred positions of ``keypoints_to_align``
+    at each frame, it finds the rotation that best maps them, in a
+    weighted least-squares sense, onto the corresponding directions in
+    ``align_to_vectors``. The fitted transform is applied to full position
+    data via :meth:`align`, and inverted via :meth:`inverse_align`.
+
+    Parameters
+    ----------
+    keypoints_to_align : list of str
+        Keypoints whose (centered) positions define the orientation. At
+        least two (non-collinear) keypoints are needed to fully determine
+        the rotation; with only one, the rotation about that axis, defined
+        by that keypoint, is left undetermined (scipy returns a valid but
+        arbitrary solution along that axis).
+    align_to_vectors : list of tuple of float
+        Target (x, y, z) direction for each entry in ``keypoints_to_align``,
+        in the same order, that its centred position is rotated towards.
+        Must be the same length as ``keypoints_to_align``.
+    alignment_weights : list of float, optional
+        Per-keypoint weight in the least-squares rotation fit, in the same
+        order as ``keypoints_to_align``. Must be the same length as
+        ``keypoints_to_align`` if given. Defaults to equal weighting.
+    keypoint_to_center : str or None, default None
+        Keypoint used to define the egocentric origin at each frame. If
+        ``None``, the centroid is the mean position over all keypoints.
+
+    Attributes
+    ----------
+    centroid_ : xarray.DataArray or None
+        The fitted per-frame, per-individual centroid position. Set by
+        :meth:`fit`; ``None`` before fitting.
+    rotation_ : xarray.DataArray or None
+        Object-dtype array of :class:`scipy.spatial.transform.Rotation`,
+        one per frame/individual. Set by :meth:`fit`; ``None`` before
+        fitting.
+
+    Raises
+    ------
+    ValueError
+        If ``keypoints_to_align``, ``align_to_vectors``, and
+        ``alignment_weights`` do not all have the same length.
+
+    Notes
+    -----
+    This class borrows its ``fit``/``align``/``inverse_align`` structure from
+    the scikit-learn transformer convention (``fit``/``transform``/
+    ``inverse_transform``), see :class:`EgocentricAligner2d`
+
+    Both ``align_to_vectors`` and the observed per-frame keypoint vectors
+    (centred on the centroid) are normalized to unit length internally
+    before the rotation fit, so only their *directions* - not their
+    magnitudes - influence the estimated rotation. Relative importance
+    between keypoints is controlled solely via ``alignment_weights``.
+
+    """
+
+    def __init__(
+        self,
+        keypoints_to_align: list[str],
+        align_to_vectors: list[tuple[float, float, float]],
+        alignment_weights: list[float] | None = None,
+        keypoint_to_center: str | None = None,
+    ):
+        """Create a new instance and check alignment vector parameters."""
+        n_alignment_vectors = len(keypoints_to_align)
+
+        if n_alignment_vectors == 0:
+            raise ValueError(
+                "`keypoints_to_align` must have at least length one."
+            )
+
+        elif n_alignment_vectors == 1:
+            logger.warning(
+                "At least two (non-collinear) keypoints are needed to "
+                "fully determine the rotation; with only one, the "
+                "rotation about that axis, defined by that keypoint, "
+                "is left undetermined"
+            )
+
+        if alignment_weights is None:
+            alignment_weights = [1.0] * n_alignment_vectors
+
+        if (
+            len(align_to_vectors) != n_alignment_vectors
+            or len(alignment_weights) != n_alignment_vectors
+        ):
+            raise ValueError(
+                "`keypoints_to_align`, `align_to_vectors`, and "
+                "`alignment_weights` must all have the same length."
+            )
+
+        self.keypoints_to_align = keypoints_to_align
+
+        self.align_to_vectors = np.asarray(align_to_vectors)
+        norms = np.linalg.norm(self.align_to_vectors, axis=1, keepdims=True)
+        self.align_to_vectors = self.align_to_vectors / norms
+
+        self.alignment_weights = np.asarray(alignment_weights)
+        self.keypoint_to_center = keypoint_to_center
+
+        self.centroid_: xr.DataArray | None = None
+        self.rotation_: xr.DataArray | None = (
+            None  # object-dtype array of Rotation
+        )
+
+    def fit(self, position: xr.DataArray) -> "EgocentricAligner3d":
+        """Compute per-frame/individual centroid + rotation from da."""
+        validate_dims_coords(position, {"space": ["x", "y", "z"]})
+        validate_dims_coords(position, {"keypoint": self.keypoints_to_align})
+
+        if self.keypoint_to_center is None:
+            self.centroid_ = position.mean(dim="keypoint")
+        else:
+            self.centroid_ = position.sel(keypoint=self.keypoint_to_center)
+
+        centered_positions = position - self.centroid_
+
+        def estimate_rot_3d(v, ref_v):
+            v_unit = v / np.linalg.norm(v, axis=0, keepdims=True)
+            rot, _ = Rotation.align_vectors(
+                ref_v, v_unit.T, weights=self.alignment_weights
+            )
+            return rot
+
+        self.rotation_ = xr.apply_ufunc(
+            partial(estimate_rot_3d, ref_v=self.align_to_vectors),
+            centered_positions.sel(keypoint=self.keypoints_to_align),
+            input_core_dims=[["space", "keypoint"]],
+            output_core_dims=[[]],
+            vectorize=True,
+            output_dtypes=[Rotation],
+        )
+        return self
+
+    def align(self, position: xr.DataArray) -> xr.DataArray:
+        """World -> egocentric. Requires fit() first."""
+        self._check_is_fitted()
+        assert self.centroid_ is not None
+        assert self.rotation_ is not None
+
+        # Center
+        centered_positions = position - self.centroid_
+
+        # Apply rotation
+        def apply_rot(v, rot):
+            return rot.apply(v)
+
+        aligned = xr.apply_ufunc(
+            apply_rot,
+            centered_positions,
+            self.rotation_,
+            input_core_dims=[["space"], []],
+            output_core_dims=[["space"]],
+            vectorize=True,
+        )
+
+        # Clean-up and transpose to original order
+        aligned = aligned.transpose(*position.dims)
+
+        return aligned
+
+    def inverse_align(self, position: xr.DataArray) -> xr.DataArray:
+        """Egocentric -> world. Requires fit() first."""
+        self._check_is_fitted()
+        assert self.centroid_ is not None
+        assert self.rotation_ is not None
+
+        # Apply inverse rotation
+        def apply_inv_rot(v, rot):
+            return rot.inv().apply(v)
+
+        inverse_rotated = xr.apply_ufunc(
+            apply_inv_rot,
+            position,
+            self.rotation_,
+            input_core_dims=[["space"], []],
+            output_core_dims=[["space"]],
+            vectorize=True,
+        )
+
+        # Clean-up and transpose to original order
+        inverse_rotated = inverse_rotated.transpose(*position.dims)
+
+        # Undo centering
+        inverse_aligned = inverse_rotated + self.centroid_
+
+        return inverse_aligned
+
+    def _check_is_fitted(self):
+        if self.rotation_ is None or self.centroid_ is None:
+            raise RuntimeError(
+                "Call `.fit(position)` before using the aligner."
+            )

--- a/tests/test_unit/test_transforms.py
+++ b/tests/test_unit/test_transforms.py
@@ -8,6 +8,9 @@ import pytest
 import xarray as xr
 
 from movement.transforms import (
+    EgocentricAligner2d,
+    EgocentricAligner3d,
+    _rotation_matrix_2d_from_angle,
     compute_homography_transform,
     poses_to_bboxes,
     scale,
@@ -702,3 +705,160 @@ def test_poses_to_bboxes_invalid_padding(
     """Test that invalid padding values raise the expected errors."""
     with pytest.raises(expected_exception, match=expected_message):
         poses_to_bboxes(valid_poses_dataset.position, padding=padding)
+
+
+@pytest.mark.parametrize(
+    "angle, expected_rotation_matrix",
+    [
+        (0, [[1, 0], [0, 1]]),
+        (-np.pi / 2, [[0, 1], [-1, 0]]),
+        (np.pi / 4, [[0.70710678, -0.70710678], [0.70710678, 0.70710678]]),
+        (np.pi / 3, [[0.5, -0.8660254], [0.8660254, 0.5]]),
+    ],
+)
+def test_ego_centric_angles_to_rotation_matrix(
+    angle, expected_rotation_matrix
+):
+    """Test that the rotation matrices are computed correctly."""
+    angles_da = xr.DataArray([angle], dims="angles")
+
+    rot_mats = _rotation_matrix_2d_from_angle(angles_da, ["x", "y"])
+
+    xr.testing.assert_allclose(
+        rot_mats.isel(angles=0),
+        xr.DataArray(
+            expected_rotation_matrix,
+            dims=("space_rot", "space"),
+            coords={"space_rot": ["x", "y"], "space": ["x", "y"]},
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "keypoint_to_align, align_to_vector",
+    [
+        ("left", (1, 0)),
+        ("left", (0, -1)),
+        ("right", (0, 1)),
+        ("right", (-1, 0)),
+        ("left", (0.70710678, 0.70710678)),
+        ("right", (-0.70710678, -0.70710678)),
+        ("left", (0.76818644, -0.64022620)),
+        ("right", (-0.54483743, -0.83854169)),
+    ],
+)
+def test_ego_centric_aligner_2d_centering(
+    valid_poses_dataset, keypoint_to_align, align_to_vector
+):
+    """Test that the ego-centric aligner correctly centers and rotates."""
+    ego_aligner = EgocentricAligner2d(
+        keypoint_to_center="centroid",
+        keypoint_to_align=keypoint_to_align,
+        align_to_vector=align_to_vector,
+    )
+
+    position = valid_poses_dataset.position
+
+    if keypoint_to_align == "left":
+        opposite_keypoint = "right"
+        opposite_target_vector = (
+            align_to_vector[1],
+            -align_to_vector[0],
+        )  # perpendicular, to the right (when keypoint_to_align is left)
+    elif keypoint_to_align == "right":
+        opposite_keypoint = "left"
+        opposite_target_vector = (
+            -align_to_vector[1],
+            align_to_vector[0],
+        )  # perpendicular, to the left (when keypoint_to_align is right)
+    else:
+        raise AssertionError(
+            "Invalid keypoint_to_align: "
+            f"{keypoint_to_align}. Must be 'left' or 'right'."
+        )
+
+    ego_aligner.fit(position)
+
+    aligned = ego_aligner.align(position)
+
+    # Test centering
+    centered_at_zero = aligned.sel(keypoint="centroid")
+
+    xr.testing.assert_allclose(
+        centered_at_zero, xr.zeros_like(centered_at_zero)
+    )
+
+    # Test aligmnent of keypoint
+    keypoint_aligned = aligned.sel(keypoint=keypoint_to_align)
+    keypoint_aligned_target = xr.DataArray(
+        np.array(align_to_vector), dims=["space"], coords={"space": ["x", "y"]}
+    )
+
+    diff = keypoint_aligned - keypoint_aligned_target
+    assert np.allclose(diff.values, 0)
+
+    # Test alignment of opposite keypoint
+    opposite_keypoint_aligned = aligned.sel(keypoint=opposite_keypoint)
+    opposite_keypoint_aligned_target = xr.DataArray(
+        np.array(opposite_target_vector),
+        dims=["space"],
+        coords={"space": ["x", "y"]},
+    )
+
+    diff = opposite_keypoint_aligned - opposite_keypoint_aligned_target
+
+    assert np.allclose(diff.values, 0)
+
+
+@pytest.mark.parametrize(
+    "keypoint_to_center, keypoint_to_align, align_to_vector",
+    [
+        ("centroid", "left", (1, 0)),
+        ("centroid", "right", (0, -1)),
+        ("left", "centroid", (0.76818644, -0.64022620)),
+        ("right", "left", (-0.54483743, -0.83854169)),
+    ],
+)
+def test_ego_centric_aligner_2d_inverse(
+    valid_poses_dataset,
+    keypoint_to_center,
+    keypoint_to_align,
+    align_to_vector,
+):
+    """Test that the ego-centric aligner correctly aligns inversly."""
+    ego_aligner = EgocentricAligner2d(
+        keypoint_to_center=keypoint_to_center,
+        keypoint_to_align=keypoint_to_align,
+        align_to_vector=align_to_vector,
+    )
+
+    position = valid_poses_dataset.position
+
+    ego_aligner.fit(position)
+
+    aligned = ego_aligner.align(position)
+
+    xr.testing.assert_allclose(ego_aligner.inverse_align(aligned), position)
+
+
+def test_ego_centric_aligner_3d_inverse(valid_poses_dataset):
+    position = valid_poses_dataset.position
+
+    pad_zeros = (
+        xr.zeros_like(position.sel(space="y"))
+        .expand_dims("space")
+        .assign_coords(space=["z"])
+    )
+    position_3d = xr.concat([position, pad_zeros], dim="space")
+
+    ego_aligner = EgocentricAligner3d(
+        keypoint_to_center="centroid",
+        keypoints_to_align=["left", "right"],
+        align_to_vectors=[[-1, 1, 0], [1, 1, 0]],
+    )
+
+    ego_aligner.fit(position_3d)
+
+    aligned = ego_aligner.align(position_3d)
+
+    xr.testing.assert_allclose(ego_aligner.inverse_align(aligned), position_3d)


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Egocentric alignment is a common pre-processing step for
- Gait/stride analysis
- Clustering or classification of single-animal poses or behavior segmentation
- Computing social receptive fields (SRF)

**What does this PR do?**
This (early) PR implements a 2D and 3D class for egocentric alignment, borrowing from scikit-learn's transformer convention `fit()`/`align()`/`inverse_align()` to save the 'fitted' transformation for later use. A typical workflow for egocentrically aligning poses would collapse to `fit(positions).align(positions)`. 

A stateful aligner instance, however, can be useful for later transforming other 2D points from the *world* coordinate system into the egocentric view of an animal, without having to recompute the transform.

In addition, saving the transformation in the aligner instance provides the ability to use `inverse_align()`, which is useful, e.g., to compute oblique bounding boxes. In the future, image warping to visualize egocentric image content might also be supported by stateful aligner instances.

The `EgocentricAligner2d` implements alignment as proposed in [issue #239], relying on xarray. In short, it centers by either a given keypoint or by the centroid of the pose. Then, it finds the signed angle between a given `keypoint_to_align` and a given `align_to_vector`, and computes the rotation matrix to match both.

The `EgocentricAligner3d` implements a more general alignment strategy and works with 3D poses. 2D pose datasets can also be used, by first zero-padding the 'z' dimension. Alignment is done by aligning two sets of vectors:
1. `keypoints_to_align`: an ordered list of (x, y, z) vectors, derived from keypoints (after centering)
2. `align_to_vectors`: an ordered list of (x, y, z) coordinates, to which the poses should be aligned

Then, `scipy.spatial.transform.Rotation.align_vectors` is used to find the *optimal* 3D rotation to align (1) onto (2). Beforehand, both sets of vectors are normalized to unit length to avoid implicit weighting in the optimization (see [scipy Rotation docs](https://docs.scipy.org/doc/scipy-1.18.0/reference/generated/scipy.spatial.transform.Rotation.align_vectors.html)).

An optional weight vector can be supplied as `alignment_weights` to favor certain keypoints in the alignment.

**Shortcomings**
- This PR separates 2D and 3D processing. A generic alignment strategy would be preferable.
- The `EgocentricAligner3d` only accepts 3D `movement poses`.
- 3D alignment speed might be too slow / hard to vectorize.
- No 2D image warping.
- 
This PR is also meant as a basis for further discussion, and I hope it will help figure out the best way to add egocentric alignment to `movement`! :-)

## References
Many discussions with @niksirbi and @sfmig at the awesome [OSSS-2026](https://neuroinformatics.zulipchat.com/#narrow/channel/406001-Movement/topic/Egocentric.20alignment/with/621415282), and the feature request in [issue #239](https://github.com/neuroinformatics-unit/movement/issues/239).

## How has this PR been tested?
This PR adds 17 new tests. For the 3D class, more tests are needed, and perhaps also a new fixture for 3D `movement poses`.

## Is this a breaking change?
I don't think so.

## Does this PR require an update to the documentation?
Yes, but since this is an early PR, I expect many changes ahead...

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
