### PR TITLE
Define governance and contributor roles

### DIFF
--- a/docs/source/community/governance.md
+++ b/docs/source/community/governance.md
@@ -1,7 +1,7 @@
 (target-governance)=
 # Governance
 
-`movement` is led by the [Neuroinformatics Unit](https://neuroinformatics.dev/) (NIU)
+`movement` is currently led by the [Neuroinformatics Unit](https://neuroinformatics.dev/) (NIU)
 at the [Sainsbury Wellcome Centre](https://www.sainsburywellcome.org/web/),
 but it's very much a community effort, and we're grateful to everyone who helps move
 it forward. The roles below describe the different ways people take part and the
@@ -66,7 +66,7 @@ They hold *Maintain* access on GitHub, which is why you'll sometimes see them ca
 Beyond everything a **trusted contributor** can do, **core developers** perform the following tasks:
 
 - manage the repository itself, including merging pull requests and making releases;
-- manage the community by moderating conversations on GitHub and Zulip, organising community calls, and posting on social media;
+- foster the community by moderating conversations on GitHub and Zulip, organising community calls, and posting on social media;
 - make decisions about the project's scope and roadmap, and prioritise features and bug fixes;
 - publicly represent the project in talks, workshops, and other events.
 

--- a/docs/source/community/governance.md
+++ b/docs/source/community/governance.md
@@ -13,7 +13,7 @@ the [People](target-people) page.
 ### Contributors
 
 If you've opened a pull request, filed an issue, or joined a discussion,
-you're a contributor; No special access required, and every bit of help counts.
+you're a contributor. No special access is required, and every bit of help counts.
 Our [contributing guide](target-contributing) is the place to start.
 
 Everyone who pitches in—whether through code, documentation, sample data, or discussions
@@ -29,12 +29,12 @@ Beyond technical improvements, contributions help us build trust, foster shared 
 make the project more sustainable, and strengthen the wider ecosystem of
 open-source tools for behavioural analysis.
 
-### Trusted Contributors
+### Trusted contributors
 
-Trusted Contributors are community members who have shown a consistent involvement
+**Trusted contributors** are community members who have shown consistent involvement
 in the project and have demonstrated that they can help maintain `movement` with care.
 
-Trusted Contributors are welcome to help with a range of tasks, including:
+**Trusted contributors** are welcome to help with a range of tasks, including:
 
 - keeping the issue tracker and pull requests tidy and welcoming;
 - participating in discussions on [Zulip](movement-zulip:) and attending community calls;
@@ -42,62 +42,81 @@ Trusted Contributors are welcome to help with a range of tasks, including:
 
 On GitHub, this role comes with *Write* access. We trust members to use that judiciously:
 merging straightforward changes, particularly in areas they know well,
-while seeking input from Core Developers for larger or more contentious decisions.
+while seeking input from **core developers** for larger or more contentious decisions.
 
 There's no expected time commitment and no quota to meet.
 Some people take on this role for a fixed period—for instance while doing an internship with us,
 or while working on `movement` as part of a collaboration.
 
-For some contributors, this role is a stepping stone towards becoming a Core Developer.
+For some contributors, this role is a stepping stone towards becoming a **core developer**.
 For others, it is simply a rewarding place to make a lasting contribution.
 Both are entirely fine—the role is a valued destination in its own right,
 and there is no expectation that you continue beyond it.
 
-::: {callout-note}
+:::{note}
 This role is inspired by [napari's Triage team](napari:developers/coredev/triage.html),
 whose thoughtful approach to community maintenance we've adapted to fit `movement`.
 :::
 
-### Core Developers
+### Core developers
 
-Core Developers are the stewards of `movement`, responsible for the long-term health of the project.
+**Core developers** are the stewards of `movement`, responsible for the long-term health of the project.
 They hold *Maintain* access on GitHub, which is why you'll sometimes see them called maintainers.
 
-Beyond everything a Trusted Contributor can do, Core Developers help with the following tasks:
+Beyond everything a **trusted contributor** can do, **core developers** perform the following tasks:
 
-- They manage the repository itself, including merging pull requests and making releases.
-- They manage the community by moderating conversations on GitHub and Zulip, and organizing community calls.
-- They make decisions about the project's scope and technical direction, and prioritise features and bug fixes.
-  This
+- manage the repository itself, including merging pull requests and making releases;
+- manage the community by moderating conversations on GitHub and Zulip, organising community calls, and posting on social media;
+- make decisions about the project's scope and roadmap, and prioritise features and bug fixes;
+- publicly represent the project in talks, workshops, and other events.
 
+Administrative access to the GitHub repository, the `movement` package on PyPI,
+and our [Zulip chat](movement-zulip:) is reserved for **core developers** only.
+Typically, administrative rights will be held by the head of the NIU
+and at least one other **core developer**, to ensure continuity in case of absence.
 
-they manage the repository itself, prepare releases, and help steer the project's scope and technical direction. The NIU leads this team and holds final responsibility for the project.
- community members who've committed to the ongoing care of
-`movement`, and who hold *Maintain* access on GitHub—which is why you'll sometimes
-see them called maintainers. Beyond everything a Trusted Contributor can do, they
-manage the repository itself, prepare releases, and help steer the project's scope and
-technical direction. The NIU leads this team and holds final responsibility for the
-project.
+## Decision-making
 
+Most day-to-day decisions are made by
+lazy consensus[^consensus] among the **core developers**.
+Approval from one **core developer** is enough to merge most pull requests.
+We only escalate to the full team for matters that affect the project's
+core architecture, scope, roadmap, or governance.
+
+For these more consequential decisions, we discuss publicly on GitHub, Zulip
+or in community calls, and consult **trusted contributors** and the wider community for input.
+We aim to reach a consensus[^consensus] among **core developers**. In the rare cases we can't,
+the head of the NIU has the final say and responsibility to decide for the project.
 
 ## Joining and stepping down
-Growing the team is something we take joy in. New Trusted Contributors and Core Developers are
-nominated by an existing Core Developer, usually after a stretch of thoughtful,
-reliable contributions. A nomination is approved by
-[lazy consensus](https://en.wikipedia.org/wiki/Lazy_consensus) among the Core
-Developers over one week—after which we add you to the relevant GitHub team and pair
-you with a Core Developer who'll help you find your feet. A Trusted Contributor who takes on
-more review and release work over time is a wonderful candidate to join the Core
-Developers, through the very same process.
+
+Growing the team is something we take joy in.
+New **trusted contributors** are nominated by an existing **core developer**,
+usually after a stretch of thoughtful, reliable contributions.
+A nomination is approved by consensus[^consensus] among the **core developers**,
+who are thereby committing to mentor and shepherd new **trusted contributors**
+as they grow into the role.
+
+A **trusted contributor** who takes on more work over time is a wonderful candidate
+to join the **core developers**, through the very same process.
+There is also an alternative path to becoming a **core developer**:
+being a member of the NIU who is assigned to develop and maintain `movement`
+as part of their job.
 
 Life changes, and so does the time we can give to a project—so you're welcome to step
 back at any point by simply letting us know. These roles reflect active involvement,
-never a lasting obligation, and stepping away carries no stigma. The door stays open
-if you'd like to return.
+not a lasting obligation, and stepping away carries no consequences.
+The door stays open if you'd like to return.
+
+In the unlikely case that a **core developer** or **trusted contributor** has ceased
+to participate in the project for more than three months without notice,
+the other **core developers** will reach out to check in. If they don't respond,
+the team may decide to revoke or downgrade their access rights.
 
 ## Governance model changes
 
 Governance model changes occur through a GitHub pull request that updates
-this document. The pull request is marked for review by all core developers
-and is merged as soon as they all approve,
-or latest after one week if no objections are raised.
+this document. The pull request is marked for review by all **core developers**
+and is merged as soon as they all approve, or after two weeks if no objections are raised.
+
+[^consensus]: We use the terms consensus and lazy consensus as defined by the [Apache Software Foundation](https://community.apache.org/committers/decisionMaking.html#lazy-consensus).

--- a/docs/source/community/governance.md
+++ b/docs/source/community/governance.md
@@ -12,40 +12,67 @@ the [People](target-people) page.
 
 ### Contributors
 
-If you've opened a pull request, filed an issue, or joined a discussion, you're a
-contributor; No special access required, and every bit of help counts. Our
-[contributing guide](target-contributing) is the place to start.
+If you've opened a pull request, filed an issue, or joined a discussion,
+you're a contributor; No special access required, and every bit of help counts.
+Our [contributing guide](target-contributing) is the place to start.
 
-Everyone who pitches in—whether through code, documentation, sample data, or
-discussions that help shape the project's direction—is credited on the
-[People](target-people) page. Once your first pull request is merged, a regular job
-adds you there automatically, and you'll also get a mention in the
-[release notes](movement-github:releases) for that version of `movement`.
+Everyone who pitches in—whether through code, documentation, sample data, or discussions
+that help shape the project's direction—is credited on the [People](target-people) page.
+Once your first pull request is merged, a regular job adds you to that page,
+and you'll also get a mention in the [release notes](movement-github:releases)
+for that version of `movement`.
+
+We strongly believe that volunteer contributions directly help us achieve our [mission](target-mission).
+The more people get involved, the more robust and versatile `movement` becomes.
+Contributors bring fresh perspectives, ensuring that the software serves a broader and more diverse community of users.
+Beyond technical improvements, contributions help us build trust, foster shared ownership,
+make the project more sustainable, and strengthen the wider ecosystem of
+open-source tools for behavioural analysis.
 
 ### Trusted Contributors
-Trusted Contributors are community members who help keep our issues and
-pull requests tidy and welcoming. They apply labels, tidy up titles and descriptions,
-sort issues into milestones, close and reopen issues and PRs, spot duplicates and
-regressions, and flag good first issues so newcomers know where to jump in. They're
-also very welcome to review pull requests—especially in parts of the codebase they
-know well, where their feedback is invaluable. On GitHub this comes with *Write*
-access, so the team can merge pull requests too. We trust members to use that
-judiciously: merging straightforward changes, particularly in areas they know well,
-while leaving larger or more contentious decisions to the Core Developers.
 
-There's no expected time commitment and no quota to meet—you help as much as suits
-you, and stepping back later is completely fine. Some people take on this role for a
-fixed period—for instance while doing an internship with us, or while working on
-`movement` as part of a collaboration between their research or engineering team and
-ours—and that's just as welcome. Being a Trusted Contributor is a valued role in its
-own right, and for those who'd like to, it can also be a natural stepping stone
-towards joining the Core Developers.
+Trusted Contributors are community members who have shown a consistent involvement
+in the project and have demonstrated that they can help maintain `movement` with care.
 
+Trusted Contributors are welcome to help with a range of tasks, including:
+
+- keeping the issue tracker and pull requests tidy and welcoming;
+- participating in discussions on [Zulip](movement-zulip:) and attending community calls;
+- reviewing pull requests—especially in parts of the codebase they are familiar with.
+
+On GitHub, this role comes with *Write* access. We trust members to use that judiciously:
+merging straightforward changes, particularly in areas they know well,
+while seeking input from Core Developers for larger or more contentious decisions.
+
+There's no expected time commitment and no quota to meet.
+Some people take on this role for a fixed period—for instance while doing an internship with us,
+or while working on `movement` as part of a collaboration.
+
+For some contributors, this role is a stepping stone towards becoming a Core Developer.
+For others, it is simply a rewarding place to make a lasting contribution.
+Both are entirely fine—the role is a valued destination in its own right,
+and there is no expectation that you continue beyond it.
+
+::: {callout-note}
 This role is inspired by [napari's Triage team](napari:developers/coredev/triage.html),
 whose thoughtful approach to community maintenance we've adapted to fit `movement`.
+:::
 
 ### Core Developers
-Core Developers are community members who've committed to the ongoing care of
+
+Core Developers are the stewards of `movement`, responsible for the long-term health of the project.
+They hold *Maintain* access on GitHub, which is why you'll sometimes see them called maintainers.
+
+Beyond everything a Trusted Contributor can do, Core Developers help with the following tasks:
+
+- They manage the repository itself, including merging pull requests and making releases.
+- They manage the community by moderating conversations on GitHub and Zulip, and organizing community calls.
+- They make decisions about the project's scope and technical direction, and prioritise features and bug fixes.
+  This
+
+
+they manage the repository itself, prepare releases, and help steer the project's scope and technical direction. The NIU leads this team and holds final responsibility for the project.
+ community members who've committed to the ongoing care of
 `movement`, and who hold *Maintain* access on GitHub—which is why you'll sometimes
 see them called maintainers. Beyond everything a Trusted Contributor can do, they
 manage the repository itself, prepare releases, and help steer the project's scope and

--- a/docs/source/community/governance.md
+++ b/docs/source/community/governance.md
@@ -11,45 +11,55 @@ the [People](target-people) page.
 ## Roles
 
 ### Contributors
-If you've opened a pull request, filed an issue, or joined a discussion, you're a
-contributor—no special access required, and every bit of help counts. Our
-[contribution guide](target-contributing) is the place to start.
 
-### Triage Team
-Members of the Triage Team are trusted community members who help keep our issues and
+If you've opened a pull request, filed an issue, or joined a discussion, you're a
+contributor; No special access required, and every bit of help counts. Our
+[contributing guide](target-contributing) is the place to start.
+
+Everyone who pitches in—whether through code, documentation, sample data, or
+discussions that help shape the project's direction—is credited on the
+[People](target-people) page. Once your first pull request is merged, a regular job
+adds you there automatically, and you'll also get a mention in the
+[release notes](movement-github:releases) for that version of `movement`.
+
+### Trusted Contributors
+Trusted Contributors are community members who help keep our issues and
 pull requests tidy and welcoming. They apply labels, tidy up titles and descriptions,
 sort issues into milestones, close and reopen issues and PRs, spot duplicates and
-regressions, and flag good first issues so newcomers know where to jump in. This
-matches *Triage* access on GitHub: the team helps curate the project, but doesn't
-push commits or merge pull requests.
+regressions, and flag good first issues so newcomers know where to jump in. They're
+also very welcome to review pull requests—especially in parts of the codebase they
+know well, where their feedback is invaluable. On GitHub this comes with *Write*
+access, so the team can merge pull requests too. We trust members to use that
+judiciously: merging straightforward changes, particularly in areas they know well,
+while leaving larger or more contentious decisions to the Core Developers.
 
 There's no expected time commitment and no quota to meet—you help as much as suits
-you, and stepping back later is completely fine. Joining the Triage Team is a valued
-role in its own right, and for those who'd like to, it can also be a natural stepping
-stone towards joining the Core Developers.
+you, and stepping back later is completely fine. Some people take on this role for a
+fixed period—for instance while doing an internship with us, or while working on
+`movement` as part of a collaboration between their research or engineering team and
+ours—and that's just as welcome. Being a Trusted Contributor is a valued role in its
+own right, and for those who'd like to, it can also be a natural stepping stone
+towards joining the Core Developers.
+
+This role is inspired by [napari's Triage team](napari:developers/coredev/triage.html),
+whose thoughtful approach to community maintenance we've adapted to fit `movement`.
 
 ### Core Developers
 Core Developers are community members who've committed to the ongoing care of
-`movement`, and who hold *Write* access on GitHub. They review and merge pull
-requests, prepare releases, and help steer the project's scope and technical
-direction. The NIU leads this team and holds final responsibility for the project.
+`movement`, and who hold *Maintain* access on GitHub—which is why you'll sometimes
+see them called maintainers. Beyond everything a Trusted Contributor can do, they
+manage the repository itself, prepare releases, and help steer the project's scope and
+technical direction. The NIU leads this team and holds final responsibility for the
+project.
 
-### Collaborators
-Some of the most valuable contributions come from whole teams rather than
-individuals. Collaborators are research labs and research software engineering groups
-who dedicate development time or resources to `movement`—for example by building
-features together, sharing sample data, or supporting the project in kind. We're
-always keen to explore new collaborations; if that sounds like your team, do
-[get in touch](target-connect-with-us). You'll find our current and past
-collaborators on the [People](target-people) page.
 
 ## Joining and stepping down
-Growing the team is something we take joy in. New Triagers and Core Developers are
+Growing the team is something we take joy in. New Trusted Contributors and Core Developers are
 nominated by an existing Core Developer, usually after a stretch of thoughtful,
 reliable contributions. A nomination is approved by
 [lazy consensus](https://en.wikipedia.org/wiki/Lazy_consensus) among the Core
 Developers over one week—after which we add you to the relevant GitHub team and pair
-you with a Core Developer who'll help you find your feet. A Triage Team member who takes on
+you with a Core Developer who'll help you find your feet. A Trusted Contributor who takes on
 more review and release work over time is a wonderful candidate to join the Core
 Developers, through the very same process.
 
@@ -57,3 +67,10 @@ Life changes, and so does the time we can give to a project—so you're welcome 
 back at any point by simply letting us know. These roles reflect active involvement,
 never a lasting obligation, and stepping away carries no stigma. The door stays open
 if you'd like to return.
+
+## Governance model changes
+
+Governance model changes occur through a GitHub pull request that updates
+this document. The pull request is marked for review by all core developers
+and is merged as soon as they all approve,
+or latest after one week if no objections are raised.

--- a/docs/source/community/governance.md
+++ b/docs/source/community/governance.md
@@ -1,0 +1,59 @@
+(target-governance)=
+# Governance
+
+`movement` is led by the [Neuroinformatics Unit](https://neuroinformatics.dev/) (NIU)
+at the [Sainsbury Wellcome Centre](https://www.sainsburywellcome.org/web/),
+but it's very much a community effort, and we're grateful to everyone who helps move
+it forward. The roles below describe the different ways people take part and the
+repository access that comes with each. To see who currently fills them, head over to
+the [People](target-people) page.
+
+## Roles
+
+### Contributors
+If you've opened a pull request, filed an issue, or joined a discussion, you're a
+contributor—no special access required, and every bit of help counts. Our
+[contribution guide](target-contributing) is the place to start.
+
+### Triage Team
+Members of the Triage Team are trusted community members who help keep our issues and
+pull requests tidy and welcoming. They apply labels, tidy up titles and descriptions,
+sort issues into milestones, close and reopen issues and PRs, spot duplicates and
+regressions, and flag good first issues so newcomers know where to jump in. This
+matches *Triage* access on GitHub: the team helps curate the project, but doesn't
+push commits or merge pull requests.
+
+There's no expected time commitment and no quota to meet—you help as much as suits
+you, and stepping back later is completely fine. Joining the Triage Team is a valued
+role in its own right, and for those who'd like to, it can also be a natural stepping
+stone towards joining the Core Developers.
+
+### Core Developers
+Core Developers are community members who've committed to the ongoing care of
+`movement`, and who hold *Write* access on GitHub. They review and merge pull
+requests, prepare releases, and help steer the project's scope and technical
+direction. The NIU leads this team and holds final responsibility for the project.
+
+### Collaborators
+Some of the most valuable contributions come from whole teams rather than
+individuals. Collaborators are research labs and research software engineering groups
+who dedicate development time or resources to `movement`—for example by building
+features together, sharing sample data, or supporting the project in kind. We're
+always keen to explore new collaborations; if that sounds like your team, do
+[get in touch](target-connect-with-us). You'll find our current and past
+collaborators on the [People](target-people) page.
+
+## Joining and stepping down
+Growing the team is something we take joy in. New Triagers and Core Developers are
+nominated by an existing Core Developer, usually after a stretch of thoughtful,
+reliable contributions. A nomination is approved by
+[lazy consensus](https://en.wikipedia.org/wiki/Lazy_consensus) among the Core
+Developers over one week—after which we add you to the relevant GitHub team and pair
+you with a Core Developer who'll help you find your feet. A Triage Team member who takes on
+more review and release work over time is a wonderful candidate to join the Core
+Developers, through the very same process.
+
+Life changes, and so does the time we can give to a project—so you're welcome to step
+back at any point by simply letting us know. These roles reflect active involvement,
+never a lasting obligation, and stepping away carries no stigma. The door stays open
+if you'd like to return.

--- a/docs/source/community/index.md
+++ b/docs/source/community/index.md
@@ -15,6 +15,7 @@ through our [communication channels](target-connect-with-us) if you have any que
 Meet the team and learn about the project's context, goals, and future plans.
 
 - [People](target-people)
+- [Governance](target-governance)
 - [Mission & Scope](target-mission)
 - [Roadmaps](target-roadmaps)
 - [Related Projects](target-related-projects)
@@ -47,6 +48,7 @@ Learn how to set up your development environment and contribute code or document
 :hidden:
 
 people
+governance
 mission-scope
 roadmaps
 contributing

--- a/docs/source/community/people.md
+++ b/docs/source/community/people.md
@@ -6,7 +6,8 @@
 [Sainsbury Wellcome Centre](https://www.sainsburywellcome.org/web/) by [Niko Sirmpilatze](https://github.com/niksirbi) and
 [Adam Tyson](https://github.com/adamltyson).
 See [Governance](target-governance) for what the roles below mean and how to take them on.
-The current active core development team is composed of:
+
+The current **active core development** team is composed of:
 - [Niko Sirmpilatze](https://github.com/niksirbi)
 - [Chang Huan Lo](https://github.com/lochhh)
 - [Sofía Miñano](https://github.com/sfmig)

--- a/docs/source/community/people.md
+++ b/docs/source/community/people.md
@@ -5,6 +5,7 @@
 `movement` is led by the [Neuroinformatics Unit](https://neuroinformatics.dev/) at the
 [Sainsbury Wellcome Centre](https://www.sainsburywellcome.org/web/) by [Niko Sirmpilatze](https://github.com/niksirbi) and
 [Adam Tyson](https://github.com/adamltyson).
+See [Governance](target-governance) for what the roles below mean and how to take them on.
 The current active core development team is composed of:
 - [Niko Sirmpilatze](https://github.com/niksirbi)
 - [Chang Huan Lo](https://github.com/lochhh)

--- a/docs/source/community/people.md
+++ b/docs/source/community/people.md
@@ -7,7 +7,7 @@
 [Adam Tyson](https://github.com/adamltyson).
 See [Governance](target-governance) for what the roles below mean and how to take them on.
 
-The current **active core development** team is composed of:
+The currently active **core developers** are:
 - [Niko Sirmpilatze](https://github.com/niksirbi)
 - [Chang Huan Lo](https://github.com/lochhh)
 - [Sofía Miñano](https://github.com/sfmig)


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other: docs

**Why is this PR needed?**

Defining governance is part of the whole effort described in #704, and specifically closes #78.
We've been thinking about this for a while, but it has become timely now because:

- We have active non-NIU contributors that we would like to offer increase levels of access and recognition to (for reasons covered in #704).
- I was inspired by `napari`'s recent introduction of the so-called "Triage team": [#general > The (new) Triage Team and the Triage Channel!](https://napari.zulipchat.com/#narrow/channel/212875-general/topic/The.20.28new.29.20Triage.20Team.20and.20the.20Triage.20Channel.21/with/620473699)

**What does this PR do?**

Adds a new `governance.md` under the Community section of the website, and links to it from the community landing page and from `people.md`.

The docs defines:
- Three roles: contributors, trusted contributors, and core developer (each with corresponding tasks and access rights)
- Processes for:
	- decision-making
	- joining and stepping down
	- governance model changes
	
I've tried to keep things minimal, and mostly stick to documenting our existing practices, instead of mandating new ones. I've tried to use language that's not legalese, but hopefully somewhat warm.

The main "new thing" is the formalised **trusted contributor** role.

Given the scope of this PR, I'd like explicit approval from @neuroinformatics-unit/movement-active-devs as well as @adamltyson. Anyone else interested in `movement`, and especially existing contributors, is also welcome to comment.

I would especially like feedback on:

- Are **core developer** and **trusted contributor** suitable names, or do we prefer other ones?
- Is the demarcation between these 2 roles appropriately defined?
- We have some past, no longer active contributors who match my description of **trusted contributor** (e.g. the ARC engineers working with us temporarily). Should we list them as **past trusted contributors** on the "People" page?
- Is my description of "Decision making" and "Joining and stepping down" at the appropriate level of detail? Do we want these processes to be more strictly/fuzzily defined?

I'm also tagging @alessandrofelder and @IgorTatarnikov to provide comments if they wish. I've briefly discussed this with them, and they may want to adopt something similar for BrainGlobe. I'm also open to later generalising this to an NIU-level document, but I'd rather start 'small' in `movement` and generalise later (following discussion with all NIU members).

## References

- Part of #704
- Closes #78
- Relevant [slides](https://neuroinformatics.dev/slides-movement-governance/#/title-slide) I've presented almost a year ago

## How has this PR been tested?

Local docs build. 

## Is this a breaking change?

N/A

## Does this PR require an update to the documentation?

It is an update of docs.

## Checklist:

- [x] The code has been tested locally
- ~[ ] Tests have been added to cover all new functionality~
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
